### PR TITLE
Forward any body of the request to the mock route handler

### DIFF
--- a/mockServiceWorker.js
+++ b/mockServiceWorker.js
@@ -64,6 +64,13 @@ self.addEventListener('fetch', async (event) => {
         reqHeaders[name] = value
       })
 
+      /**
+       * If the body cannot be resolved (either as JSON or to text/string),
+       * the default value will be undefined.
+       */
+      const json = await req.json().catch(() => void 0)
+      const text = await req.text().catch(() => void 0)
+
       const clientResponse = await messageClient(client, {
         url: req.url,
         method: req.method,
@@ -74,6 +81,7 @@ self.addEventListener('fetch', async (event) => {
         redirect: req.redirect,
         referrer: req.referrer,
         referrerPolicy: req.referrerPolicy,
+        body: json || text,
       })
 
       if (clientResponse === 'MOCK_NOT_FOUND') {


### PR DESCRIPTION
Closes https://github.com/kettanaito/msw/issues/13

The Fetch API for `Body` has several methods to resolve the body contents: https://developer.mozilla.org/en-US/docs/Web/API/Body

Only `Body.text()` and `Body.json()` are useful since they can be serialized into JSON. 

If the contents of the body cannot be resolved either as text (e.g. it's empty), or as JSON (e.g. parsing error), then their respective values will be `undefined` (or `void 0`).

--------

@kettanaito This PR was something similar I had to augment for the `mockServiceWorker.js` file I used. 