### PR TITLE
fix: exmaple mock api req params not found

### DIFF
--- a/example/src/mocks/index.js
+++ b/example/src/mocks/index.js
@@ -4,7 +4,7 @@ import userMocks from './user'
 const { start } = composeMocks(
   ...userMocks,
   rest.get('https://api.github.com/users/:username', (req, res, { json }) => {
-    const { username } = req.params
+    const { username } = req.params.params
 
     return res(
       json({


### PR DESCRIPTION
request params has matches, isExact, params
![image](https://user-images.githubusercontent.com/12692552/75618686-d4bed480-5bac-11ea-9828-e4ae744c6576.png)
