### PR TITLE
Adds dependabot configuration file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: 'javascript'
+    directory: './'
+    update_schedule: 'weekly'


### PR DESCRIPTION
Configures dependabot to ignore `examples/create-react-app` dependencies. 

- Sets the `directory` in the config to explicitly point to the root