### PR TITLE
graphql: Accepts the operation name as a plain string/RegExp

### DIFF
--- a/src/handlers/graphql.ts
+++ b/src/handlers/graphql.ts
@@ -7,9 +7,7 @@ import { delay } from '../context/delay'
 import { data, DataContext } from '../context/data'
 import { errors } from '../context/errors'
 
-interface GraphQLRequestHandlerSelector {
-  operation: RegExp | string
-}
+type GraphQLRequestHandlerSelector = RegExp | string
 
 type GraphQLMockedRequest<
   VariablesType = Record<string, any>
@@ -65,7 +63,7 @@ const parseQuery = (
 
 const createGraphQLHandler = (operationType: OperationTypeNode) => {
   return <QueryType, VariablesType = Record<string, any>>(
-    selector: GraphQLRequestHandlerSelector,
+    expectedOperation: GraphQLRequestHandlerSelector,
     resolver: GraphQLResponseResolver<QueryType, VariablesType>,
   ): RequestHandler<GraphQLMockedContext<QueryType>> => {
     return {
@@ -77,7 +75,6 @@ const createGraphQLHandler = (operationType: OperationTypeNode) => {
           return false
         }
 
-        const { operation: expectedOperation } = selector
         const { query, variables } = req.body as GraphQLRequestPayload<
           VariablesType
         >

--- a/test/graphql-api/errors.mocks.ts
+++ b/test/graphql-api/errors.mocks.ts
@@ -1,7 +1,7 @@
 import { composeMocks, graphql } from 'msw'
 
 const { start } = composeMocks(
-  graphql.query({ operation: 'Login' }, (req, res, ctx) => {
+  graphql.query('Login', (req, res, ctx) => {
     return res(
       ctx.errors([
         {

--- a/test/graphql-api/mutation.mocks.ts
+++ b/test/graphql-api/mutation.mocks.ts
@@ -1,7 +1,7 @@
 import { composeMocks, graphql } from 'msw'
 
 const { start } = composeMocks(
-  graphql.mutation({ operation: 'Logout' }, (req, res, ctx) => {
+  graphql.mutation('Logout', (req, res, ctx) => {
     return res(
       ctx.data({
         logout: {

--- a/test/graphql-api/query.mocks.ts
+++ b/test/graphql-api/query.mocks.ts
@@ -1,7 +1,7 @@
 import { composeMocks, graphql } from 'msw'
 
 const { start } = composeMocks(
-  graphql.query({ operation: 'GetUserDetail' }, (req, res, ctx) => {
+  graphql.query('GetUserDetail', (req, res, ctx) => {
     return res(
       ctx.data({
         user: {

--- a/test/graphql-api/variables.mocks.ts
+++ b/test/graphql-api/variables.mocks.ts
@@ -1,7 +1,7 @@
 import { composeMocks, graphql } from 'msw'
 
 const { start } = composeMocks(
-  graphql.query({ operation: 'GetGithubUser' }, (req, res, ctx) => {
+  graphql.query('GetGithubUser', (req, res, ctx) => {
     const { username } = req.variables
 
     return res(
@@ -14,7 +14,7 @@ const { start } = composeMocks(
     )
   }),
 
-  graphql.mutation({ operation: 'DeletePost' }, (req, res, ctx) => {
+  graphql.mutation('DeletePost', (req, res, ctx) => {
     const { postId } = req.variables
 
     return res(
@@ -26,7 +26,7 @@ const { start } = composeMocks(
     )
   }),
 
-  graphql.query({ operation: 'GetActiveUser' }, (req, res, ctx) => {
+  graphql.query('GetActiveUser', (req, res, ctx) => {
     // Intentionally unused variable
     const { foo } = req.variables
 


### PR DESCRIPTION
> This change introduced a **BREAKING CHANGE**. However, since the API of the library is not final, any version update should be considered carefully, as it may contain backward-incompatible changes.

- Shortens the declaration of `graphql.query()` and `graphql.mutation()` request handlers by accepting a string/RegExp directly (without the `{ operation }` wrapper).