### PR TITLE
Ignores trailing slashes during URI matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "graphql": "^14.6.0",
-    "node-match-path": "^0.2.2",
+    "node-match-path": "^0.3.0",
     "ramda": "^0.27.0",
     "yargs": "^15.1.0"
   },

--- a/test/rest-api/request-matching/uri.test.ts
+++ b/test/rest-api/request-matching/uri.test.ts
@@ -13,24 +13,48 @@ describe('REST: Request matching (URI)', () => {
   })
 
   describe('given exact string for request URI', () => {
-    it('should match a request with the exact URI', async () => {
-      const REQUEST_URL = 'https://api.github.com/made-up'
-      api.page.evaluate((url) => fetch(url), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
-      const body = await res.json()
+    describe('given the actual URI with trailing slash', () => {
+      it('should match a request with the exact URI', async () => {
+        const REQUEST_URL = 'https://api.github.com/made-up/'
+        api.page.evaluate((url) => fetch(url), REQUEST_URL)
+        const res = await api.page.waitForResponse(REQUEST_URL)
+        const body = await res.json()
 
-      expect(res.status()).toBe(200)
-      expect(body).toEqual({
-        mocked: true,
+        expect(res.status()).toBe(200)
+        expect(body).toEqual({
+          mocked: true,
+        })
+      })
+
+      it('should not match a request with different URI', async () => {
+        const res = await api.page.evaluate(() =>
+          fetch('https://api.github.com/other/'),
+        )
+
+        expect(res.status).not.toBe(200)
       })
     })
 
-    it('should not match a request with different URI', async () => {
-      const res = await api.page.evaluate(() =>
-        fetch('https://api.github.com/other'),
-      )
+    describe('given the actual URL without a trailing slash', () => {
+      it('should match a request with the exact URI', async () => {
+        const REQUEST_URL = 'https://api.github.com/made-up'
+        api.page.evaluate((url) => fetch(url), REQUEST_URL)
+        const res = await api.page.waitForResponse(REQUEST_URL)
+        const body = await res.json()
 
-      expect(res.status).not.toBe(200)
+        expect(res.status()).toBe(200)
+        expect(body).toEqual({
+          mocked: true,
+        })
+      })
+
+      it('should not match a request with different URI', async () => {
+        const res = await api.page.evaluate(() =>
+          fetch('https://api.github.com/other'),
+        )
+
+        expect(res.status).not.toBe(200)
+      })
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5092,10 +5092,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-match-path@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.2.3.tgz#d237b87fdc8c925c21986634c0776dbd8c8a551a"
-  integrity sha512-V9oxXIngpP9Su5kfTDp7CbeWs7Pt1PPTWenZSTUR1+5pyk6WzYjI9YQBAfKR0CVEJylNX5YGhWKz1MAXcqilLg==
+node-match-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.3.0.tgz#aa191cc1195b6f343f6e3b0faba1724c6f59edb1"
+  integrity sha512-pB29+sa+Nk5sHSLZ/dMXmH5sWCCrBCdwajF8Bz4SyYsBSBwpppJCWkvb64wqQm9tfNTYsCjiHo+rWYIqRTzzMA==
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Fixes #57 

Updates to `node-match-path@0.3.0` which ignores trailing slashes when matching URI. Adds respective integration tests to MSW.