### PR TITLE
Returns Promise from "start" and "stop" calls

### DIFF
--- a/test/msw-api/compose-mocks/start.mocks.ts
+++ b/test/msw-api/compose-mocks/start.mocks.ts
@@ -1,0 +1,12 @@
+import { composeMocks, rest } from 'msw'
+
+const { start } = composeMocks(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.status(200))
+  }),
+)
+
+// @ts-ignore
+window.__MSW_REGISTRATION__ = start().then((reg) => {
+  return reg.constructor.name
+})

--- a/test/msw-api/compose-mocks/start.test.ts
+++ b/test/msw-api/compose-mocks/start.test.ts
@@ -1,0 +1,30 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
+import { resolvePtr } from 'dns'
+
+describe('API: composeMocks / start', () => {
+  let api: TestAPI
+
+  beforeAll(async () => {
+    api = await runBrowserWith(path.resolve(__dirname, 'start.mocks.ts'))
+  })
+
+  afterAll(() => {
+    return api.cleanup()
+  })
+
+  describe('given a custom Promise chain handler to start()', () => {
+    let resolvedPayload
+
+    beforeAll(async () => {
+      resolvedPayload = await api.page.evaluate(() => {
+        // @ts-ignore
+        return window.__MSW_REGISTRATION__
+      })
+    })
+
+    it('should return instance of ServiceWorkerRegistration', () => {
+      expect(resolvedPayload).toBe('ServiceWorkerRegistration')
+    })
+  })
+})

--- a/test/support/runBrowserWith.ts
+++ b/test/support/runBrowserWith.ts
@@ -4,6 +4,7 @@ import WebpackDevServer from 'webpack-dev-server'
 
 export interface TestAPI {
   server: WebpackDevServer
+  origin: string
   browser: puppeteer.Browser
   page: puppeteer.Page
   cleanup: () => Promise<unknown>
@@ -35,6 +36,7 @@ export const runBrowserWith = async (
 
   return {
     server,
+    origin,
     browser,
     page,
     cleanup,


### PR DESCRIPTION
- Calling `start()` and `stop()` now returns a Promise so it's possible to react to Service Worker registration (as much as it's possible per Service Worker lifecycle)

> Note that `start().then()` does not guarantee that the Service Worker is active. It only guarantees it has been registered and may now be in one of the valid lifecycle states:
> 
> - installing
> - installed
> - activating
> - activated
> - redundant

## GitHub

- Closes #58