### PR TITLE
Supports response patching

### DIFF
--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -1,0 +1,42 @@
+import { MockedRequest } from '../handlers/requestHandler'
+
+const gracefully = <ResponseType>(
+  promise: Promise<Response>,
+): Promise<ResponseType> => {
+  return promise.then((res) => res.json().catch(() => res.text()))
+}
+
+const augmentRequestInit = (requestInit: RequestInit): RequestInit => {
+  return {
+    ...requestInit,
+    headers: {
+      ...requestInit.headers,
+      'x-msw-bypass': 'true',
+    },
+  }
+}
+
+/**
+ * Wrapper around the native `window.fetch()` function that performs
+ * a request bypassing MSW. Requests performed using
+ * this function will never be mocked.
+ */
+export const fetch = <ResponseType = any>(
+  input: string | MockedRequest,
+  requestInit: RequestInit = {},
+) => {
+  // Keep the default `window.fetch()` call signature
+  if (typeof input === 'string') {
+    return gracefully<ResponseType>(
+      window.fetch(input, augmentRequestInit(requestInit)),
+    )
+  }
+
+  const { body } = input
+  const compliantReq: RequestInit = augmentRequestInit({
+    ...input,
+    body: typeof body === 'object' ? JSON.stringify(body) : body,
+  })
+
+  return gracefully<ResponseType>(window.fetch(input.url, compliantReq))
+}

--- a/src/handlers/requestHandler.ts
+++ b/src/handlers/requestHandler.ts
@@ -6,11 +6,16 @@ export interface MockedRequest {
   method: Request['method']
   headers: Request['headers']
   mode: Request['mode']
+  keepalive: Request['keepalive']
+  cache: Request['cache']
+  destination: Request['destination']
+  integrity: Request['integrity']
   credentials: Request['credentials']
   redirect: Request['redirect']
   referrer: Request['referrer']
   referrerPolicy: Request['referrerPolicy']
   body: Record<string, any> | string
+  bodyUsed: Request['bodyUsed']
   params: RequestParams
 }
 
@@ -22,7 +27,7 @@ export type ResponseResolver<ContextType = any> = (
   req: MockedRequest,
   res: ResponseComposition,
   context: ContextType,
-) => MockedResponse
+) => Promise<MockedResponse> | MockedResponse
 
 export interface RequestHandler<ContextType = any> {
   mask?: Mask
@@ -30,8 +35,8 @@ export interface RequestHandler<ContextType = any> {
    * Predicate function that decides whether a Request should be mocked.
    */
   predicate: (req: MockedRequest) => boolean
-  defineContext: (req: MockedRequest) => ContextType
   resolver: ResponseResolver<ContextType>
+  defineContext: (req: MockedRequest) => ContextType
 }
 
 export default null

--- a/src/handlers/rest.ts
+++ b/src/handlers/rest.ts
@@ -8,6 +8,8 @@ import { text } from '../context/text'
 import { json } from '../context/json'
 import { xml } from '../context/xml'
 import { delay } from '../context/delay'
+import { fetch } from '../context/fetch'
+import { resolveRequestMask } from '../utils/resolveRequestMask'
 
 export enum RESTMethods {
   GET = 'GET',
@@ -26,6 +28,7 @@ interface RestHandlerContext {
   json: typeof json
   xml: typeof xml
   delay: typeof delay
+  fetch: typeof fetch
 }
 
 const createRESTHandler = (method: RESTMethods) => {
@@ -42,12 +45,7 @@ const createRESTHandler = (method: RESTMethods) => {
         // with the slash ("/"). This way such routes will match
         // the respective hostname's routes, while bypassing
         // the routes from different hosts.
-        const resolvedMask =
-          typeof mask === 'string' && mask.startsWith('/')
-            ? `${location.origin}${mask}`
-            : mask
-
-        const urlMatch = match(resolvedMask, req.url)
+        const urlMatch = match(resolveRequestMask(mask), req.url)
 
         return hasSameMethod && urlMatch.matches
       },
@@ -60,6 +58,7 @@ const createRESTHandler = (method: RESTMethods) => {
           json,
           xml,
           delay,
+          fetch,
         }
       },
       resolver,

--- a/src/utils/resolveRequestMask.ts
+++ b/src/utils/resolveRequestMask.ts
@@ -1,0 +1,11 @@
+import { Mask } from '../composeMocks'
+
+/**
+ * Resolves a relative URL to the absolute URL with the same hostname.
+ * Ignores regular expressions.
+ */
+export const resolveRequestMask = (mask: Mask) => {
+  return typeof mask === 'string' && mask.startsWith('/')
+    ? `${location.origin}${mask}`
+    : mask
+}

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -1,0 +1,33 @@
+import { composeMocks, rest } from 'msw'
+
+const { start } = composeMocks(
+  rest.get('https://test.msw.io/user', async (req, res, ctx) => {
+    const originalResponse = await ctx.fetch(
+      'https://api.github.com/users/octocat',
+    )
+
+    return res(
+      ctx.json({
+        name: originalResponse.name,
+        location: originalResponse.location,
+        mocked: true,
+      }),
+    )
+  }),
+
+  rest.get(
+    'https://api.github.com/repos/:owner/:repoName',
+    async (req, res, ctx) => {
+      const originalResponse = await ctx.fetch(req)
+
+      return res(
+        ctx.json({
+          name: originalResponse.name,
+          stargazers_count: 9999,
+        }),
+      )
+    },
+  ),
+)
+
+start()

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -1,0 +1,54 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+
+describe('REST: Response patching', () => {
+  let api: TestAPI
+
+  beforeAll(async () => {
+    api = await runBrowserWith(
+      path.resolve(__dirname, 'response-patching.mocks.ts'),
+    )
+  })
+
+  afterAll(() => {
+    return api.cleanup()
+  })
+
+  describe('given mocked and original requests differ', () => {
+    it('should return a combination of mocked and original responses', async () => {
+      const REQUEST_URL = 'https://test.msw.io/user'
+      api.page.evaluate((url) => fetch(url), REQUEST_URL)
+      const res = await api.page.waitForResponse(REQUEST_URL)
+      const body = await res.json()
+
+      expect(res.status()).toBe(200)
+      expect(body).toEqual({
+        name: 'The Octocat',
+        location: 'San Francisco',
+        mocked: true,
+      })
+    })
+  })
+
+  describe('given mocked and original requests are the same', () => {
+    it('should bypass the original request', async () => {
+      const REQUEST_URL =
+        'https://api.github.com/repos/open-draft/msw?mocked=true'
+      api.page.evaluate((url) => fetch(url), REQUEST_URL)
+      const res = await api.page.waitForResponse((res) => {
+        return (
+          // Await for the response from MSW, so that original response
+          // from the same URL would not interfere.
+          res.url() === REQUEST_URL && res.headers()['x-powered-by'] === 'msw'
+        )
+      })
+      const body = await res.json()
+
+      expect(res.status()).toBe(200)
+      expect(body).toEqual({
+        name: 'msw',
+        stargazers_count: 9999,
+      })
+    })
+  })
+})


### PR DESCRIPTION
## GitHub

- Fixes #66 

## Changes

- Adds new `ctx.fetch()` utility to perform a bypassed request
- Supports bypassing of requests that have `x-msw-bypass` header set
- Sets the following new properties on the mocked `req` object:
  - `bodyUsed`
  - `integrity`
  - `destination`
  - `keepalive`