### PR TITLE
Sets "statusText" based on the given status code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msw",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Deviation-less client-side runtime API mocking using Service Workers.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "graphql": "^14.6.0",
     "node-match-path": "^0.3.0",
     "ramda": "^0.27.0",
+    "statuses": "^1.5.0",
     "yargs": "^15.1.0"
   },
   "devDependencies": {

--- a/src/context/status.test.ts
+++ b/src/context/status.test.ts
@@ -13,8 +13,8 @@ describe('status', () => {
       expect(result).toHaveProperty('status', 403)
     })
 
-    it('should have the default status text (OK)', () => {
-      expect(result).toHaveProperty('statusText', 'OK')
+    it('should have the status text associated with the status code', () => {
+      expect(result).toHaveProperty('statusText', 'Forbidden')
     })
   })
 

--- a/src/context/status.ts
+++ b/src/context/status.ts
@@ -1,4 +1,4 @@
-import * as R from 'ramda'
+import statuses from 'statuses/codes.json'
 import { ResponseTransformer } from '../response'
 
 export const status = (
@@ -7,10 +7,7 @@ export const status = (
 ): ResponseTransformer => {
   return (res) => {
     res.status = statusCode
-
-    if (statusText) {
-      res.statusText = statusText
-    }
+    res.statusText = statusText || statuses[statusCode]
 
     return res
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6448,7 +6448,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
+"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0, statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=


### PR DESCRIPTION
- Fixes #70 

## Changes

- Uses the [`statuses`](https://github.com/jshttp/statuses) package used by Express, that contains the map of status codes to status texts
- Sets the status text associated with the given status code, if no custom status text is provided