### PR TITLE
Adds Service Worker to compilation, but ignores in output

### DIFF
--- a/config/IntegrityWebpackPlugin/index.js
+++ b/config/IntegrityWebpackPlugin/index.js
@@ -13,9 +13,9 @@ class IntegrityWebpackPlugin {
   apply(compiler) {
     const { src, output } = this.options
 
-    console.log('Signing the Service Worker at:\n%s', chalk.cyan(src))
-
     compiler.hooks.beforeCompile.tapPromise(PLUGIN_NAME, async () => {
+      console.log('Signing the Service Worker at:\n%s', chalk.cyan(src))
+
       // Generate the checksum based on the Service Worker file
       const checksum = getChecksum(src)
 
@@ -23,9 +23,6 @@ class IntegrityWebpackPlugin {
       // Inject its checksum into a private variable.
       await copyServiceWorker(src, output, checksum)
 
-      /**
-       * @todo Provide the checksum as a global variable to the client-side code.
-       */
       return new webpack.DefinePlugin({
         SERVICE_WORKER_CHECKSUM: JSON.stringify(checksum),
       }).apply(compiler)

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-plugin-ramda": "2.0.0",
     "cross-env": "^7.0.0",
     "html-webpack-plugin": "^3.2.0",
+    "ignore-loader": "^0.1.2",
     "jest": "^25.1.0",
     "node-fetch": "^2.6.0",
     "prettier": "^1.19.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,11 @@ const { IntegrityWebpackPlugin } = require('./config/IntegrityWebpackPlugin')
 
 module.exports = {
   mode: process.env.NODE_ENV,
-  entry: ['regenerator-runtime/runtime', path.resolve(__dirname, 'src/index')],
+  entry: [
+    'regenerator-runtime/runtime',
+    SERVICE_WORKER_SOURCE_PATH,
+    path.resolve(__dirname, 'src/index'),
+  ],
   output: {
     filename: 'index.js',
     path: path.resolve(__dirname, 'lib'),
@@ -28,6 +32,10 @@ module.exports = {
             loader: 'awesome-typescript-loader',
           },
         ],
+      },
+      {
+        test: SERVICE_WORKER_SOURCE_PATH,
+        use: 'ignore-loader',
       },
       {
         test: /\.mjs$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3934,6 +3934,11 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+ignore-loader@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
+  integrity sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=
+
 import-local@2.0.0, import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"


### PR DESCRIPTION
- Relates to #81 

Necessary to trigger the library's compilation and integrity signing of the Service Worker when its module updates in `src`.