### PR TITLE
Awaits until Service Worker confirms successful mocking activation

### DIFF
--- a/src/handleRequest.ts
+++ b/src/handleRequest.ts
@@ -6,16 +6,12 @@ import {
   defaultContext,
 } from './handlers/requestHandler'
 import { resolveRelativeUrl } from './utils/resolveRelativeUrl'
-import { createBroadcastChannel } from './utils/createBroadcastChannel'
+import {
+  ServiceWorkerMessage,
+  createBroadcastChannel,
+} from './utils/createBroadcastChannel'
 
-interface ServiceWorkerMessage<T> {
-  type: string
-  payload: T
-}
-
-export const createIncomingRequestHandler = (
-  requestHandlers: RequestHandler[],
-) => {
+export const handleRequestWith = (requestHandlers: RequestHandler[]) => {
   return async (event: MessageEvent) => {
     const channel = createBroadcastChannel(event)
     const message: ServiceWorkerMessage<MockedRequest> = JSON.parse(

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -20,11 +20,11 @@ self.addEventListener('activate', function() {
 })
 
 self.addEventListener('message', async function(event) {
+  const clientId = event.source.id
+  const client = await event.currentTarget.clients.get(clientId)
+
   switch (event.data) {
     case 'INTEGRITY_CHECK_REQUEST': {
-      const clientId = event.source.id
-      const client = await event.currentTarget.clients.get(clientId)
-
       messageClient(client, {
         type: 'INTEGRITY_CHECK_RESPONSE',
         payload: INTEGRITY_CHECKSUM,
@@ -34,6 +34,11 @@ self.addEventListener('message', async function(event) {
 
     case 'MOCK_ACTIVATE': {
       self.__isMswEnabled = true
+      messageClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+
       console.groupCollapsed('%c[MSW] Mocking enabled.', bannerStyle)
       console.log(
         '%cDocumentation: %chttps://redd.gitbook.io/msw',

--- a/src/requestIntegrityCheck.ts
+++ b/src/requestIntegrityCheck.ts
@@ -1,23 +1,25 @@
+import { addMessageListener } from './utils/createBroadcastChannel'
+
+addMessageListener
+
 export const requestIntegrityCheck = (
   serviceWorker: ServiceWorker,
 ): Promise<ServiceWorker> => {
   return new Promise((resolve, reject) => {
-    navigator.serviceWorker.addEventListener('message', (event) => {
-      const { type, payload: actualChecksum } = JSON.parse(event.data)
+    addMessageListener('INTEGRITY_CHECK_RESPONSE', (message) => {
+      const { payload: actualChecksum } = message
 
-      if (type === 'INTEGRITY_CHECK_RESPONSE') {
-        // Compare the response from the Service Worker and the
-        // global variable set by webpack upon build.
-        if (actualChecksum !== SERVICE_WORKER_CHECKSUM) {
-          return reject(
-            new Error(
-              `Currently active Service Worker (${actualChecksum}) is behind the latest published one (${SERVICE_WORKER_CHECKSUM}).`,
-            ),
-          )
-        }
-
-        resolve(serviceWorker)
+      // Compare the response from the Service Worker and the
+      // global variable set by webpack upon build.
+      if (actualChecksum !== SERVICE_WORKER_CHECKSUM) {
+        return reject(
+          new Error(
+            `Currently active Service Worker (${actualChecksum}) is behind the latest published one (${SERVICE_WORKER_CHECKSUM}).`,
+          ),
+        )
       }
+
+      resolve(serviceWorker)
     })
 
     navigator.serviceWorker.addEventListener('messageerror', reject)

--- a/src/utils/createBroadcastChannel.ts
+++ b/src/utils/createBroadcastChannel.ts
@@ -1,3 +1,8 @@
+export interface ServiceWorkerMessage<T> {
+  type: string
+  payload: T
+}
+
 /**
  * Creates a communication channel between the client
  * and the Service Worker associated with the given event.
@@ -15,4 +20,38 @@ export const createBroadcastChannel = (event: MessageEvent) => {
       }
     },
   }
+}
+
+export type ServiceWorkerMessageHandler<T> = (
+  message: ServiceWorkerMessage<T>,
+  event: MessageEvent,
+) => void
+
+export const addMessageListener = <T>(
+  type: string,
+  handler: ServiceWorkerMessageHandler<T>,
+  errorHandler?: () => void,
+) => {
+  const handleMessage = (event: MessageEvent) => {
+    const message = JSON.parse(event.data)
+
+    if (message.type === type) {
+      handler(message, event)
+    }
+  }
+
+  navigator.serviceWorker.addEventListener('message', handleMessage)
+
+  if (errorHandler) {
+    navigator.serviceWorker.addEventListener('messageerror', errorHandler)
+  }
+
+  // Clean up the listener when page unloads
+  window.addEventListener('beforeunload', () => {
+    navigator.serviceWorker.removeEventListener('message', handleMessage)
+
+    if (errorHandler) {
+      navigator.serviceWorker.removeEventListener('messageerror', errorHandler)
+    }
+  })
 }

--- a/test/msw-api/compose-mocks/start.mocks.ts
+++ b/test/msw-api/compose-mocks/start.mocks.ts
@@ -8,5 +8,6 @@ const { start } = composeMocks(
 
 // @ts-ignore
 window.__MSW_REGISTRATION__ = start().then((reg) => {
+  console.log('Registration Promise resolved')
   return reg.constructor.name
 })

--- a/test/msw-api/compose-mocks/start.test.ts
+++ b/test/msw-api/compose-mocks/start.test.ts
@@ -1,6 +1,5 @@
 import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
-import { resolvePtr } from 'dns'
 
 describe('API: composeMocks / start', () => {
   let api: TestAPI
@@ -25,6 +24,30 @@ describe('API: composeMocks / start', () => {
 
     it('should return instance of ServiceWorkerRegistration', () => {
       expect(resolvedPayload).toBe('ServiceWorkerRegistration')
+    })
+
+    it('should resolve after the mocking has been activated', async () => {
+      const logs: string[] = []
+
+      api.page.on('console', function(message) {
+        if (message.type() === 'log') {
+          logs.push(message.text())
+        }
+      })
+
+      await api.page.goto(api.origin, {
+        waitUntil: 'networkidle0',
+      })
+
+      const activationMessageIndex = logs.findIndex((text) => {
+        return text.startsWith('[MSW] Mocking enabled')
+      })
+
+      const customMessageIndex = logs.findIndex((text) => {
+        return text.startsWith('Registration Promise resolved')
+      })
+
+      expect(customMessageIndex).toBeGreaterThan(activationMessageIndex)
     })
   })
 })


### PR DESCRIPTION
## GitHib

- Fixes #73

## Changes

- Adds a new signal from the Service Worker to the client called `MOCKING_ENABLED` when the internal mocking enabling variable has been updated in the Service Worker
- Resolves the `start()` Promise only when received the mocking enabled confirmation from the Service Worker
- Provides a few internal improvements to easily establishing handlers for Service Worker messages and renames functions here and there