### PR TITLE
Handles internal exception as a 500 response

### DIFF
--- a/src/handleRequest.ts
+++ b/src/handleRequest.ts
@@ -48,7 +48,7 @@ export const handleRequestWith = (requestHandlers: RequestHandler[]) => {
       })
 
       if (relevantRequestHandler == null) {
-        return channel.send('MOCK_NOT_FOUND')
+        return channel.send({ type: 'MOCK_NOT_FOUND' })
       }
 
       const { mask, defineContext, resolver } = relevantRequestHandler
@@ -78,7 +78,7 @@ export const handleRequestWith = (requestHandlers: RequestHandler[]) => {
           mockedResponse,
         )
 
-        return channel.send('MOCK_NOT_FOUND')
+        return channel.send({ type: 'MOCK_NOT_FOUND' })
       }
 
       // Transform Headers into a list to be stringified preserving multiple
@@ -89,21 +89,22 @@ export const handleRequestWith = (requestHandlers: RequestHandler[]) => {
         headers: Array.from(mockedResponse.headers.entries()),
       }
 
-      channel.send(JSON.stringify(responseWithHeaders))
+      channel.send({
+        type: 'MOCK_SUCCESS',
+        payload: responseWithHeaders,
+      })
     } catch (error) {
-      channel.send(
-        JSON.stringify({
-          type: 'INTERNAL_ERROR',
-          payload: {
-            status: 500,
-            body: JSON.stringify({
-              errorType: error.constructor.name,
-              message: error.message,
-              location: error.stack,
-            }),
-          },
-        }),
-      )
+      channel.send({
+        type: 'INTERNAL_ERROR',
+        payload: {
+          status: 500,
+          body: JSON.stringify({
+            errorType: error.constructor.name,
+            message: error.message,
+            location: error.stack,
+          }),
+        },
+      })
     }
   }
 }

--- a/src/utils/createBroadcastChannel.ts
+++ b/src/utils/createBroadcastChannel.ts
@@ -3,6 +3,11 @@ export interface ServiceWorkerMessage<T> {
   payload: T
 }
 
+export type ClientMessageTypes =
+  | 'MOCK_NOT_FOUND'
+  | 'MOCK_SUCCESS'
+  | 'INTERNAL_ERROR'
+
 /**
  * Creates a communication channel between the client
  * and the Service Worker associated with the given event.
@@ -14,9 +19,12 @@ export const createBroadcastChannel = (event: MessageEvent) => {
     /**
      * Sends a text message to the connected Service Worker.
      */
-    send(message: string) {
+    send(message: {
+      type: ClientMessageTypes
+      payload?: Record<string, any> | string
+    }) {
       if (port) {
-        port.postMessage(message)
+        port.postMessage(JSON.stringify(message))
       }
     },
   }

--- a/test/msw-api/exception-handling.mocks.ts
+++ b/test/msw-api/exception-handling.mocks.ts
@@ -1,0 +1,11 @@
+import { composeMocks, rest } from 'msw'
+
+const { start } = composeMocks(
+  rest.get('https://api.github.com/users/:username', () => {
+    // @ts-ignore
+    nonExisting()
+    return null
+  }),
+)
+
+start()

--- a/test/msw-api/exception-handling.test.ts
+++ b/test/msw-api/exception-handling.test.ts
@@ -1,0 +1,46 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+
+describe('Exception handling', () => {
+  describe('given exception in a request handler', () => {
+    let api: TestAPI
+
+    beforeAll(async () => {
+      api = await runBrowserWith(
+        path.resolve(__dirname, 'exception-handling.mocks.ts'),
+      )
+    })
+
+    afterAll(() => {
+      return api.cleanup()
+    })
+
+    it('should activate without errors', async () => {
+      const errorMessages: string[] = []
+
+      api.page.on('console', function(message) {
+        if (message.type() === 'error') {
+          errorMessages.push(message.text())
+        }
+      })
+
+      await api.page.goto(api.origin, {
+        waitUntil: 'networkidle0',
+      })
+
+      expect(errorMessages).toHaveLength(0)
+    })
+
+    it('should transform exception into 500 response', async () => {
+      const REQUEST_URL = 'https://api.github.com/users/octocat'
+      api.page.evaluate((url) => fetch(url), REQUEST_URL)
+      const res = await api.page.waitForResponse(REQUEST_URL)
+      const body = await res.json()
+
+      expect(res.status()).toEqual(500)
+      expect(res.headers()).not.toHaveProperty('x-powered-by', 'msw')
+      expect(body).toHaveProperty('errorType', 'ReferenceError')
+      expect(body).toHaveProperty('message', 'nonExisting is not defined')
+    })
+  })
+})


### PR DESCRIPTION
> This change bumps the integrity checksum of the Service Worker. Users would have to update the Service Worker, following the instructions in the integrity failure error message.

## GitHub

- Fixes #80 

## Changes

- `handleRequestWith` now executes in a `try`/`catch` block
- Any exceptions originating from a request handler are signaled to the Service Worker and it responds with a 500 response, including a suggestion error message to handle the exception, and the detailed original exception in the response's body

## TODO

- [x] Rewrite the successful mock signal from `channel.send(body)` to `channel.send({ type: '...', payload: body })` to be aligned with all the other signals