### PR TITLE
Handles unregistering of the Service Worker

### DIFF
--- a/src/composeMocks.ts
+++ b/src/composeMocks.ts
@@ -122,11 +122,6 @@ const createStart = (context: InternalContext): PublicAPI['start'] => {
         // it would expect the MSW to resolve a mock for assets,
         // which would result into an infinite promise.
         worker.postMessage('MOCK_DEACTIVATE')
-
-        // Unregister the Service Worker.
-        // This way it doesn't persist between page sessions, as well as
-        // doesn't affect other apps running on the same address.
-        registration.unregister()
       }
     })
 
@@ -163,24 +158,7 @@ const createStop = (context: InternalContext): PublicAPI['stop'] => {
    * Stop the active running instance of the Service Worker.
    */
   return async () => {
-    const { registration } = context
-
-    if (!registration) {
-      console.warn('[MSW] No active instance of Service Worker is running.')
-      return null
-    }
-
-    const [error] = await until(() => registration.unregister())
-
-    if (error) {
-      console.error('[MSW] Failed to unregister Service Worker. %o', error)
-      return
-    }
-
     context.worker.postMessage('MOCK_DEACTIVATE')
-
-    context.worker = null
-    context.registration = null
   }
 }
 

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testRegex: '(.+)\\.test\\.ts$',
   // Increase the test timeout to allow webpack build
   // and Puppeteer bootstrapping to take place.
-  testTimeout: 999999,
+  testTimeout: 60000,
   moduleNameMapper: {
     '^msw$': '<rootDir>/../lib/index.js',
   },

--- a/test/msw-api/compose-mocks/start.test.ts
+++ b/test/msw-api/compose-mocks/start.test.ts
@@ -2,21 +2,21 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
 
 describe('API: composeMocks / start', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'start.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'start.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   describe('given a custom Promise chain handler to start()', () => {
     let resolvedPayload
 
     beforeAll(async () => {
-      resolvedPayload = await api.page.evaluate(() => {
+      resolvedPayload = await test.page.evaluate(() => {
         // @ts-ignore
         return window.__MSW_REGISTRATION__
       })
@@ -29,22 +29,22 @@ describe('API: composeMocks / start', () => {
     it('should resolve after the mocking has been activated', async () => {
       const logs: string[] = []
 
-      api.page.on('console', function(message) {
+      test.page.on('console', function (message) {
         if (message.type() === 'log') {
           logs.push(message.text())
         }
       })
 
-      await api.page.goto(api.origin, {
+      await test.page.goto(test.origin, {
         waitUntil: 'networkidle0',
       })
 
-      const activationMessageIndex = logs.findIndex((text) => {
-        return text.startsWith('[MSW] Mocking enabled')
+      const activationMessageIndex = logs.findIndex((log) => {
+        return log.startsWith('[MSW] Mocking enabled')
       })
 
-      const customMessageIndex = logs.findIndex((text) => {
-        return text.startsWith('Registration Promise resolved')
+      const customMessageIndex = logs.findIndex((log) => {
+        return log.startsWith('Registration Promise resolved')
       })
 
       expect(customMessageIndex).toBeGreaterThan(activationMessageIndex)

--- a/test/msw-api/compose-mocks/stop.mocks.ts
+++ b/test/msw-api/compose-mocks/stop.mocks.ts
@@ -1,0 +1,12 @@
+import { composeMocks, rest } from 'msw'
+
+const { start, stop } = composeMocks(
+  rest.get('https://api.github.com', (req, res, ctx) => {
+    return res(ctx.json({ mocked: true }))
+  }),
+)
+
+start()
+
+// @ts-ignore
+window.__mswStop = stop

--- a/test/msw-api/compose-mocks/stop.test.ts
+++ b/test/msw-api/compose-mocks/stop.test.ts
@@ -1,5 +1,21 @@
 import * as path from 'path'
-import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
+import { Page } from 'puppeteer'
+import {
+  TestAPI,
+  runBrowserWith,
+  createRequestHelper,
+} from '../../support/runBrowserWith'
+
+const stopWorkerOn = async (page: Page) => {
+  await page.evaluate(() => {
+    // @ts-ignore
+    return window.__mswStop()
+  })
+
+  return new Promise((resolve) => {
+    setTimeout(resolve, 1000)
+  })
+}
 
 describe('API: composeMocks / stop', () => {
   let test: TestAPI
@@ -12,16 +28,13 @@ describe('API: composeMocks / stop', () => {
     return test.cleanup()
   })
 
-  describe('given a manually stop the service worker', () => {
-    beforeAll((done) => {
-      const onceUnregistered = test.page.evaluate(() => {
-        // @ts-ignore
-        return window.__mswStop()
-      })
+  describe('given I manually stop the service worker', () => {
+    beforeAll(async () => {
+      await stopWorkerOn(test.page)
+    })
 
-      onceUnregistered.then(() => {
-        setTimeout(done, 1000)
-      })
+    afterAll(async () => {
+      await test.page.close()
     })
 
     it('should have the mocking disabled', async () => {
@@ -34,6 +47,50 @@ describe('API: composeMocks / stop', () => {
       expect(headers).not.toHaveProperty('x-powered-by', 'msw')
       expect(body).not.toEqual({
         mocked: true,
+      })
+    })
+  })
+
+  describe('given multiple clients of the same project', () => {
+    let firstPage: Page
+    let secondPage: Page
+
+    beforeAll(async () => {
+      firstPage = await test.browser.newPage()
+      await firstPage.goto(test.origin, {
+        waitUntil: 'networkidle0',
+      })
+
+      secondPage = await test.browser.newPage()
+      await secondPage.goto(test.origin, {
+        waitUntil: 'networkidle0',
+      })
+    })
+
+    describe('when I stop the service worker on one page', () => {
+      beforeAll(async () => {
+        await stopWorkerOn(firstPage)
+      })
+
+      describe('and switch to another page', () => {
+        beforeAll(async () => {
+          await secondPage.bringToFront()
+        })
+
+        it('should still have mocking enabled', async () => {
+          // Creating a request handler for the new page
+          const request = createRequestHelper(secondPage)
+          const res = await request({
+            url: 'https://api.github.com',
+          })
+          const headers = res.headers()
+          const body = await res.json()
+
+          expect(headers).toHaveProperty('x-powered-by', 'msw')
+          expect(body).toEqual({
+            mocked: true,
+          })
+        })
       })
     })
   })

--- a/test/msw-api/compose-mocks/stop.test.ts
+++ b/test/msw-api/compose-mocks/stop.test.ts
@@ -1,0 +1,40 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
+
+describe('API: composeMocks / stop', () => {
+  let test: TestAPI
+
+  beforeAll(async () => {
+    test = await runBrowserWith(path.resolve(__dirname, 'stop.mocks.ts'))
+  })
+
+  afterAll(() => {
+    return test.cleanup()
+  })
+
+  describe('given a manually stop the service worker', () => {
+    beforeAll((done) => {
+      const onceUnregistered = test.page.evaluate(() => {
+        // @ts-ignore
+        return window.__mswStop()
+      })
+
+      onceUnregistered.then(() => {
+        setTimeout(done, 1000)
+      })
+    })
+
+    it('should have the mocking disabled', async () => {
+      const res = await test.request({
+        url: 'https://api.github.com',
+      })
+      const headers = res.headers()
+      const body = res.json()
+
+      expect(headers).not.toHaveProperty('x-powered-by', 'msw')
+      expect(body).not.toEqual({
+        mocked: true,
+      })
+    })
+  })
+})

--- a/test/msw-api/exception-handling.test.ts
+++ b/test/msw-api/exception-handling.test.ts
@@ -35,10 +35,12 @@ describe('Exception handling', () => {
       const res = await test.request({
         url: 'https://api.github.com/users/octocat',
       })
+      const status = res.status()
+      const headers = res.headers()
       const body = await res.json()
 
-      expect(res.status()).toEqual(500)
-      expect(res.headers()).not.toHaveProperty('x-powered-by', 'msw')
+      expect(status).toEqual(500)
+      expect(headers).not.toHaveProperty('x-powered-by', 'msw')
       expect(body).toHaveProperty('errorType', 'ReferenceError')
       expect(body).toHaveProperty('message', 'nonExisting is not defined')
     })

--- a/test/msw-api/exception-handling.test.ts
+++ b/test/msw-api/exception-handling.test.ts
@@ -3,28 +3,28 @@ import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('Exception handling', () => {
   describe('given exception in a request handler', () => {
-    let api: TestAPI
+    let test: TestAPI
 
     beforeAll(async () => {
-      api = await runBrowserWith(
+      test = await runBrowserWith(
         path.resolve(__dirname, 'exception-handling.mocks.ts'),
       )
     })
 
     afterAll(() => {
-      return api.cleanup()
+      return test.cleanup()
     })
 
     it('should activate without errors', async () => {
       const errorMessages: string[] = []
 
-      api.page.on('console', function(message) {
+      test.page.on('console', function (message) {
         if (message.type() === 'error') {
           errorMessages.push(message.text())
         }
       })
 
-      await api.page.goto(api.origin, {
+      await test.page.goto(test.origin, {
         waitUntil: 'networkidle0',
       })
 
@@ -32,9 +32,9 @@ describe('Exception handling', () => {
     })
 
     it('should transform exception into 500 response', async () => {
-      const REQUEST_URL = 'https://api.github.com/users/octocat'
-      api.page.evaluate((url) => fetch(url), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.request({
+        url: 'https://api.github.com/users/octocat',
+      })
       const body = await res.json()
 
       expect(res.status()).toEqual(500)

--- a/test/msw-api/hard-reload.mocks.ts
+++ b/test/msw-api/hard-reload.mocks.ts
@@ -1,0 +1,13 @@
+import { composeMocks, rest } from 'msw'
+
+const { start } = composeMocks(
+  rest.get('https://api.github.com', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        mocked: true,
+      }),
+    )
+  }),
+)
+
+start()

--- a/test/msw-api/hard-reload.test.ts
+++ b/test/msw-api/hard-reload.test.ts
@@ -1,0 +1,53 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+
+describe('Hard reload', () => {
+  let test: TestAPI
+
+  beforeAll(async () => {
+    test = await runBrowserWith(path.resolve(__dirname, 'hard-reload.mocks.ts'))
+  })
+
+  afterAll(() => {
+    return test.cleanup()
+  })
+
+  describe('given I load the page that activates the Service Worker', () => {
+    it('should have the mocking enabled', async () => {
+      const res = await test.request({
+        url: 'https://api.github.com',
+      })
+      const headers = res.headers()
+      const body = await res.json()
+
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(body).toEqual({
+        mocked: true,
+      })
+    })
+
+    describe('when I hard reload the page', () => {
+      beforeAll(async () => {
+        // Passing `true` to `location.reload()` forces a hard reload
+        test.page.evaluate(() => location.reload(true))
+
+        await test.page.waitForNavigation({
+          waitUntil: 'networkidle0',
+        })
+      })
+
+      it('should still have the mocking enabled', async () => {
+        const res = await test.request({
+          url: 'https://api.github.com',
+        })
+        const headers = res.headers()
+        const body = await res.json()
+
+        expect(headers).toHaveProperty('x-powered-by', 'msw')
+        expect(body).toEqual({
+          mocked: true,
+        })
+      })
+    })
+  })
+})

--- a/test/msw-api/integrity-check.test.ts
+++ b/test/msw-api/integrity-check.test.ts
@@ -39,8 +39,10 @@ describe('Integrity check', () => {
       const res = await test.request({
         url: 'https://api.github.com/users/octocat',
       })
+      const headers = res.headers()
       const body = await res.json()
 
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         mocked: true,
       })
@@ -98,8 +100,10 @@ describe('Integrity check', () => {
       const res = await test.request({
         url: 'https://api.github.com/users/octocat',
       })
+      const headers = res.headers()
       const body = await res.json()
 
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         mocked: true,
       })

--- a/test/msw-api/unregister.mocks.ts
+++ b/test/msw-api/unregister.mocks.ts
@@ -1,0 +1,14 @@
+import { composeMocks, rest } from 'msw'
+
+const { start } = composeMocks(
+  rest.get('https://api.github.com', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        mocked: true,
+      }),
+    )
+  }),
+)
+
+// @ts-ignore
+window.__mswStart = start

--- a/test/msw-api/unregister.test.ts
+++ b/test/msw-api/unregister.test.ts
@@ -1,0 +1,62 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+
+describe('Unregister', () => {
+  let test: TestAPI
+
+  beforeAll(async () => {
+    test = await runBrowserWith(path.resolve(__dirname, 'unregister.mocks.ts'))
+  })
+
+  afterAll(() => {
+    return test.cleanup()
+  })
+
+  describe('given the service worker is manually started', () => {
+    beforeAll((done) => {
+      const onceRegistered = test.page.evaluate(() => {
+        // @ts-ignore
+        return window.__mswStart()
+      })
+
+      onceRegistered.then(() => {
+        /**
+         * @fixme Stop relying on side-effects in tests.
+         * For no apparent reason, awaiting the registration promise is not enough.
+         */
+        setTimeout(done, 1000)
+      })
+    })
+
+    it('should have the mocking enabled', async () => {
+      const res = await test.request({
+        url: 'https://api.github.com',
+      })
+      const headers = res.headers()
+      const body = await res.json()
+
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(body).toEqual({
+        mocked: true,
+      })
+    })
+
+    describe('and I reload the page without starting the service worker', () => {
+      beforeAll(async () => {
+        await test.page.reload()
+      })
+
+      it('should have the service worker unregistered', async () => {
+        const res = await test.request({
+          url: 'https://api.github.com',
+        })
+        const body = await res.json()
+
+        expect(res.fromServiceWorker()).toBe(false)
+        expect(body).not.toEqual({
+          mocked: true,
+        })
+      })
+    })
+  })
+})

--- a/test/rest-api/basic.test.ts
+++ b/test/rest-api/basic.test.ts
@@ -2,22 +2,23 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('REST: Basic example', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'basic.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'basic.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   it('should receive mocked response', async () => {
-    const REQUEST_URL = 'https://api.github.com/users/octocat'
-    api.page.evaluate((url) => fetch(url), REQUEST_URL)
-    const res = await api.page.waitForResponse(REQUEST_URL)
+    const res = await test.request({
+      url: 'https://api.github.com/users/octocat',
+    })
     const body = await res.json()
 
+    expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
     expect(res.status()).toBe(200)
     expect(body).toEqual({
       name: 'John Maverick',

--- a/test/rest-api/context.test.ts
+++ b/test/rest-api/context.test.ts
@@ -2,25 +2,26 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('REST: Context utilities', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'context.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'context.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   it('should receive mocked response', async () => {
-    const REQUEST_URL = 'https://test.msw.io/'
-    api.page.evaluate((url) => fetch(url), REQUEST_URL)
-    const res = await api.page.waitForResponse(REQUEST_URL)
+    const res = await test.request({
+      url: 'https://test.msw.io/',
+    })
     const headers = res.headers()
     const body = await res.json()
 
     expect(res.status()).toEqual(305)
     expect(res.statusText()).toEqual('Yahoo!')
+    expect(headers).toHaveProperty('x-powered-by', 'msw')
     expect(headers).toHaveProperty('content-type', 'application/json')
     expect(headers).toHaveProperty('accept', 'foo/bar')
     expect(headers).toHaveProperty('custom-header', 'arbitrary-value')

--- a/test/rest-api/custom-request-handler.test.ts
+++ b/test/rest-api/custom-request-handler.test.ts
@@ -2,34 +2,33 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('REST: Custom request handler', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(
+    test = await runBrowserWith(
       path.resolve(__dirname, 'custom-request-handler.mocks.ts'),
     )
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   describe('given a request handler with default context', () => {
     it('should intercept request by a custom handler', async () => {
-      const REQUEST_URL = 'https://test.msw.io/url/matters/not'
-      api.page.evaluate(
-        (url) =>
-          fetch(url, {
-            headers: {
-              'x-custom-header': 'true',
-            },
-          }),
-        REQUEST_URL,
-      )
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.request({
+        url: 'https://test.msw.io/url/matters/not',
+        fetchOptions: {
+          headers: {
+            'x-custom-header': 'true',
+          },
+        },
+      })
       const body = await res.json()
+      const headers = res.headers()
 
       expect(res.status()).toBe(401)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         error: 'Hey, this is a mocked error',
       })
@@ -38,16 +37,13 @@ describe('REST: Custom request handler', () => {
 
   describe('given a request handler with custom context', () => {
     it('should mock the response according to custom context', async () => {
-      const REQUEST_URL = 'https://test.url/'
-      api.page.evaluate((url) => fetch(url), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.request({ url: 'https://test.url/' })
       const body = await res.json()
+      const headers = res.headers()
 
       expect(res.status()).toBe(200)
-      expect(res.headers()).toHaveProperty(
-        'content-type',
-        'application/hal+json',
-      )
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(headers).toHaveProperty('content-type', 'application/hal+json')
       expect(body).toEqual({
         firstName: 'John',
         age: 42,

--- a/test/rest-api/params.test.ts
+++ b/test/rest-api/params.test.ts
@@ -2,23 +2,26 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('REST: URI parameters', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'params.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'params.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   it('should retrieve parameters from the URI', async () => {
-    const REQUEST_URL = 'https://api.github.com/users/octocat/messages/abc-123'
-    api.page.evaluate((url) => fetch(url), REQUEST_URL)
-    const res = await api.page.waitForResponse(REQUEST_URL)
+    const res = await test.request({
+      url: 'https://api.github.com/users/octocat/messages/abc-123',
+    })
+    const status = res.status()
+    const headers = res.headers()
     const body = await res.json()
 
-    expect(res.status()).toBe(200)
+    expect(status).toBe(200)
+    expect(headers).toHaveProperty('x-powered-by', 'msw')
     expect(body).toEqual({
       username: 'octocat',
       messageId: 'abc-123',

--- a/test/rest-api/query.test.ts
+++ b/test/rest-api/query.test.ts
@@ -2,24 +2,27 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('REST: Query parameters', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'query.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'query.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   describe('given a single query parameter', () => {
     it('should retrieve parameters from the URI', async () => {
-      const REQUEST_URL = 'https://test.msw.io/api/books?id=abc-123'
-      api.page.evaluate((url) => fetch(url), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.request({
+        url: 'https://test.msw.io/api/books?id=abc-123',
+      })
+      const status = res.status()
+      const headers = res.headers()
       const body = await res.json()
 
-      expect(res.status()).toBe(200)
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         bookId: 'abc-123',
       })
@@ -28,12 +31,18 @@ describe('REST: Query parameters', () => {
 
   describe('given multiple query parameters', () => {
     it('should return the list of values by parameter name', async () => {
-      const REQUEST_URL = 'https://test.msw.io/products?id=1&id=2&id=3'
-      api.page.evaluate((url) => fetch(url, { method: 'POST' }), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.request({
+        url: 'https://test.msw.io/products?id=1&id=2&id=3',
+        fetchOptions: {
+          method: 'POST',
+        },
+      })
+      const status = res.status()
+      const headers = res.headers()
       const body = await res.json()
 
-      expect(res.status()).toBe(200)
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         productIds: ['1', '2', '3'],
       })

--- a/test/rest-api/request-matching/method.test.ts
+++ b/test/rest-api/request-matching/method.test.ts
@@ -2,36 +2,45 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
 
 describe('REST: Request matching (method)', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'method.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'method.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   describe('given mocked a POST request to "https://api.github.com/users/:username"', () => {
     it('should mock a POST request to the matched URL', async () => {
-      const REQUEST_URL = 'https://api.github.com/users/octocat'
-      api.page.evaluate((url) => fetch(url, { method: 'POST' }), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.request({
+        url: 'https://api.github.com/users/octocat',
+        fetchOptions: {
+          method: 'POST',
+        },
+      })
+      const status = res.status()
+      const headers = res.headers()
       const body = await res.json()
 
-      expect(res.status()).toBe(200)
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         mocked: true,
       })
     })
 
     it('should not mock a GET request to the matched URL', async () => {
-      const REQUEST_URL = 'https://api.github.com/users/octocat'
-      api.page.evaluate((url) => fetch(url), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.request({
+        url: 'https://api.github.com/users/octocat',
+      })
+      const status = res.status()
+      const headers = res.headers()
       const body = await res.json()
 
-      expect(res.status()).toBe(200)
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).not.toHaveProperty('mocked', true)
     })
   })

--- a/test/rest-api/request-matching/method.test.ts
+++ b/test/rest-api/request-matching/method.test.ts
@@ -12,7 +12,7 @@ describe('REST: Request matching (method)', () => {
     return test.cleanup()
   })
 
-  describe('given mocked a POST request to "https://api.github.com/users/:username"', () => {
+  describe('given mocked a POST request', () => {
     it('should mock a POST request to the matched URL', async () => {
       const res = await test.request({
         url: 'https://api.github.com/users/octocat',
@@ -40,7 +40,7 @@ describe('REST: Request matching (method)', () => {
       const body = await res.json()
 
       expect(status).toBe(200)
-      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(headers).not.toHaveProperty('x-powered-by', 'msw')
       expect(body).not.toHaveProperty('mocked', true)
     })
   })

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -29,19 +29,16 @@ const { start } = composeMocks(
     },
   ),
 
-  rest.post(
-    'https://jsonplaceholder.typicode.com/posts',
-    async (req, res, ctx) => {
-      const originalResponse = await ctx.fetch(req)
+  rest.post('/posts', async (req, res, ctx) => {
+    const originalResponse = await ctx.fetch(req)
 
-      return res(
-        ctx.json({
-          ...originalResponse,
-          mocked: true,
-        }),
-      )
-    },
-  ),
+    return res(
+      ctx.json({
+        ...originalResponse,
+        mocked: true,
+      }),
+    )
+  }),
 )
 
 start()

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -2,26 +2,29 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('REST: Response patching', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(
+    test = await runBrowserWith(
       path.resolve(__dirname, 'response-patching.mocks.ts'),
     )
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   describe('given mocked and original requests differ', () => {
     it('should return a combination of mocked and original responses', async () => {
-      const REQUEST_URL = 'https://test.msw.io/user'
-      api.page.evaluate((url) => fetch(url), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.request({
+        url: 'https://test.msw.io/user',
+      })
+      const status = res.status()
+      const headers = res.headers()
       const body = await res.json()
 
-      expect(res.status()).toBe(200)
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         name: 'The Octocat',
         location: 'San Francisco',
@@ -32,19 +35,22 @@ describe('REST: Response patching', () => {
 
   describe('given mocked and original requests are the same', () => {
     it('should bypass the original request', async () => {
-      const REQUEST_URL =
-        'https://api.github.com/repos/open-draft/msw?mocked=true'
-      api.page.evaluate((url) => fetch(url), REQUEST_URL)
-      const res = await api.page.waitForResponse((res) => {
-        return (
-          // Await for the response from MSW, so that original response
-          // from the same URL would not interfere.
-          res.url() === REQUEST_URL && res.headers()['x-powered-by'] === 'msw'
-        )
+      const res = await test.request({
+        url: 'https://api.github.com/repos/open-draft/msw?mocked=true',
+        responsePredicate(res, url) {
+          return (
+            // Await for the response from MSW, so that original response
+            // from the same URL would not interfere.
+            res.url() === url && res.headers()['x-powered-by'] === 'msw'
+          )
+        },
       })
+      const status = res.status()
+      const headers = res.headers()
       const body = await res.json()
 
-      expect(res.status()).toBe(200)
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         name: 'msw',
         stargazers_count: 9999,
@@ -54,29 +60,29 @@ describe('REST: Response patching', () => {
 
   describe('given a post request to be patched', () => {
     it('should be able to properly request and patch a post', async () => {
-      const REQUEST_URL = 'https://jsonplaceholder.typicode.com/posts'
-
-      const data = {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const res = await test.request({
+        url: 'https://jsonplaceholder.typicode.com/posts',
+        fetchOptions: {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            title: 'foo',
+            body: 'bar',
+            userId: 1,
+          }),
         },
-        body: JSON.stringify({
-          title: 'foo',
-          body: 'bar',
-          userId: 1,
-        }),
-      }
-
-      api.page.evaluate((url, init) => fetch(url, init), REQUEST_URL, data)
-      const res = await api.page.waitForResponse((res) => {
-        return (
-          res.url() === REQUEST_URL && res.headers()['x-powered-by'] === 'msw'
-        )
+        responsePredicate(res, url) {
+          return res.url() === url && res.headers()['x-powered-by'] === 'msw'
+        },
       })
+      const status = res.status()
+      const headers = res.headers()
       const body = await res.json()
 
-      expect(res.status()).toBe(200)
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({
         id: 101,
         mocked: true,

--- a/test/rest-api/xhr.test.ts
+++ b/test/rest-api/xhr.test.ts
@@ -2,24 +2,24 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('XHR', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'xhr.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'xhr.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   it('should return the mocked response', async () => {
     const REQUEST_URL = 'https://api.github.com/users/octocat'
-    api.page.evaluate((url) => {
+    test.page.evaluate((url) => {
       const req = new XMLHttpRequest()
       req.open('GET', url)
       req.send()
     }, REQUEST_URL)
-    const res = await api.page.waitForResponse(REQUEST_URL)
+    const res = await test.page.waitForResponse(REQUEST_URL)
     const body = await res.json()
 
     expect(res.status()).toBe(200)

--- a/test/support/runBrowserWith.ts
+++ b/test/support/runBrowserWith.ts
@@ -12,7 +12,7 @@ type RequestHelper = (options: {
   responsePredicate?: (res: puppeteer.Response, url: string) => boolean
 }) => Promise<puppeteer.Response>
 
-const createRequestHelper = (page: puppeteer.Page): RequestHelper => {
+export const createRequestHelper = (page: puppeteer.Page): RequestHelper => {
   return async ({
     url,
     fetchOptions,

--- a/test/support/runBrowserWith.ts
+++ b/test/support/runBrowserWith.ts
@@ -47,7 +47,8 @@ export const runBrowserWith = async (
   const { server, origin } = await spawnServer(mockDefinitionPath)
 
   const browser = await puppeteer.launch({
-    headless: true,
+    headless: !process.env.DEBUG,
+    devtools: !!process.env.DEBUG,
     args: ['--no-sandbox'],
   })
   const page = await browser.newPage()

--- a/test/support/runBrowserWith.ts
+++ b/test/support/runBrowserWith.ts
@@ -1,6 +1,6 @@
 import * as puppeteer from 'puppeteer'
 import { match } from 'node-match-path'
-import { spawnServer } from './spawnServer'
+import { SpawnServerOptions, spawnServer } from './spawnServer'
 import WebpackDevServer from 'webpack-dev-server'
 
 /**
@@ -43,8 +43,12 @@ export interface TestAPI {
 
 export const runBrowserWith = async (
   mockDefinitionPath: string,
+  serverOptions?: SpawnServerOptions,
 ): Promise<TestAPI> => {
-  const { server, origin } = await spawnServer(mockDefinitionPath)
+  const { server, origin } = await spawnServer(
+    mockDefinitionPath,
+    serverOptions,
+  )
 
   const browser = await puppeteer.launch({
     headless: !process.env.DEBUG,

--- a/test/support/spawnServer.ts
+++ b/test/support/spawnServer.ts
@@ -52,7 +52,7 @@ Resolved "msw" module to:
     },
     plugins: [
       new HtmlWebpackPlugin({
-        template: 'test/support/index.html',
+        template: 'test/support/template/index.html',
         templateParameters: () => ({
           mockDefs: `// ${mockDefs}\n${mockDefsContent}`,
         }),
@@ -71,7 +71,7 @@ Resolved "msw" module to:
     contentBase: path.resolve(__dirname, '../..'),
     publicPath: '/',
     noInfo: true,
-    openPage: '/test/support/index.html',
+    openPage: '/test/support/template/index.html',
     headers: {
       // Allow for the test-only Service Workers from "/tmp" directory
       // to be registered at the website's root.

--- a/test/support/spawnServer.ts
+++ b/test/support/spawnServer.ts
@@ -12,7 +12,14 @@ interface Payload {
   origin: string
 }
 
-export const spawnServer = (mockDefs: string): Promise<Payload> => {
+export interface SpawnServerOptions {
+  withRoutes?: WebpackDevServer.Configuration['after']
+}
+
+export const spawnServer = (
+  mockDefs: string,
+  options?: SpawnServerOptions,
+): Promise<Payload> => {
   const absoluteMockPath = path.resolve(process.cwd(), mockDefs)
   const mswModulePath = path.resolve(__dirname, '../..', packageJson.main)
 
@@ -77,10 +84,14 @@ Resolved "msw" module to:
       // to be registered at the website's root.
       'Service-Worker-Allowed': '/',
     },
-    after(app) {
+    after(app, server, compiler) {
       app.get('/mockServiceWorker.js', (req, res) => {
         res.sendFile(path.resolve(__dirname, '../../lib/mockServiceWorker.js'))
       })
+
+      if (options?.withRoutes) {
+        options.withRoutes(app, server, compiler)
+      }
     },
   })
 

--- a/test/support/template/components/prism-clike.min.js
+++ b/test/support/template/components/prism-clike.min.js
@@ -1,0 +1,21 @@
+Prism.languages.clike = {
+  comment: [
+    { pattern: /(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/, lookbehind: !0 },
+    { pattern: /(^|[^\\:])\/\/.*/, lookbehind: !0, greedy: !0 },
+  ],
+  string: {
+    pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+    greedy: !0,
+  },
+  'class-name': {
+    pattern: /(\b(?:class|interface|extends|implements|trait|instanceof|new)\s+|\bcatch\s+\()[\w.\\]+/i,
+    lookbehind: !0,
+    inside: { punctuation: /[.\\]/ },
+  },
+  keyword: /\b(?:if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/,
+  boolean: /\b(?:true|false)\b/,
+  function: /\w+(?=\()/,
+  number: /\b0x[\da-f]+\b|(?:\b\d+\.?\d*|\B\.\d+)(?:e[+-]?\d+)?/i,
+  operator: /[<>]=?|[!=]=?=?|--?|\+\+?|&&?|\|\|?|[?*/~^%]/,
+  punctuation: /[{}[\];(),.:]/,
+}

--- a/test/support/template/components/prism-javascript.min.js
+++ b/test/support/template/components/prism-javascript.min.js
@@ -1,0 +1,79 @@
+;(Prism.languages.javascript = Prism.languages.extend('clike', {
+  'class-name': [
+    Prism.languages.clike['class-name'],
+    {
+      pattern: /(^|[^$\w\xA0-\uFFFF])[_$A-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\.(?:prototype|constructor))/,
+      lookbehind: !0,
+    },
+  ],
+  keyword: [
+    { pattern: /((?:^|})\s*)(?:catch|finally)\b/, lookbehind: !0 },
+    {
+      pattern: /(^|[^.]|\.\.\.\s*)\b(?:as|async(?=\s*(?:function\b|\(|[$\w\xA0-\uFFFF]|$))|await|break|case|class|const|continue|debugger|default|delete|do|else|enum|export|extends|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)\b/,
+      lookbehind: !0,
+    },
+  ],
+  number: /\b(?:(?:0[xX](?:[\dA-Fa-f](?:_[\dA-Fa-f])?)+|0[bB](?:[01](?:_[01])?)+|0[oO](?:[0-7](?:_[0-7])?)+)n?|(?:\d(?:_\d)?)+n|NaN|Infinity)\b|(?:\b(?:\d(?:_\d)?)+\.?(?:\d(?:_\d)?)*|\B\.(?:\d(?:_\d)?)+)(?:[Ee][+-]?(?:\d(?:_\d)?)+)?/,
+  function: /#?[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*(?:\.\s*(?:apply|bind|call)\s*)?\()/,
+  operator: /--|\+\+|\*\*=?|=>|&&|\|\||[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?[.?]?|[~:]/,
+})),
+  (Prism.languages.javascript[
+    'class-name'
+  ][0].pattern = /(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w.\\]+/),
+  Prism.languages.insertBefore('javascript', 'keyword', {
+    regex: {
+      pattern: /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*[\s\S]*?\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
+      lookbehind: !0,
+      greedy: !0,
+    },
+    'function-variable': {
+      pattern: /#?[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*[=:]\s*(?:async\s*)?(?:\bfunction\b|(?:\((?:[^()]|\([^()]*\))*\)|[_$a-zA-Z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)\s*=>))/,
+      alias: 'function',
+    },
+    parameter: [
+      {
+        pattern: /(function(?:\s+[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)?\s*\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\))/,
+        lookbehind: !0,
+        inside: Prism.languages.javascript,
+      },
+      {
+        pattern: /[_$a-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*(?=\s*=>)/i,
+        inside: Prism.languages.javascript,
+      },
+      {
+        pattern: /(\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\)\s*=>)/,
+        lookbehind: !0,
+        inside: Prism.languages.javascript,
+      },
+      {
+        pattern: /((?:\b|\s|^)(?!(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)(?![$\w\xA0-\uFFFF]))(?:[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*\s*)\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\)\s*\{)/,
+        lookbehind: !0,
+        inside: Prism.languages.javascript,
+      },
+    ],
+    constant: /\b[A-Z](?:[A-Z_]|\dx?)*\b/,
+  }),
+  Prism.languages.insertBefore('javascript', 'string', {
+    'template-string': {
+      pattern: /`(?:\\[\s\S]|\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})+}|(?!\${)[^\\`])*`/,
+      greedy: !0,
+      inside: {
+        'template-punctuation': { pattern: /^`|`$/, alias: 'string' },
+        interpolation: {
+          pattern: /((?:^|[^\\])(?:\\{2})*)\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})+}/,
+          lookbehind: !0,
+          inside: {
+            'interpolation-punctuation': {
+              pattern: /^\${|}$/,
+              alias: 'punctuation',
+            },
+            rest: Prism.languages.javascript,
+          },
+        },
+        string: /[\s\S]+/,
+      },
+    },
+  }),
+  Prism.languages.markup &&
+    Prism.languages.markup.tag.addInlined('script', 'javascript'),
+  (Prism.languages.js = Prism.languages.javascript)

--- a/test/support/template/index.html
+++ b/test/support/template/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <link
-      href="https://cdn.jsdelivr.net/npm/prism-themes@1.3.0/themes/prism-material-oceanic.css"
+      href="test/support/template/prism-material-oceanic.css"
       rel="stylesheet"
     />
     <style>
@@ -21,7 +21,7 @@
     <p>This test suite is created with the following mock definitions:</p>
     <pre><code class="language-js"><%= mockDefs %></code></pre>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.19.0/components/prism-core.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.19.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="test/support/template/prism-core.min.js"></script>
+    <script src="test/support/template/prism-autoloader.min.js"></script>
   </body>
 </html>

--- a/test/support/template/index.html
+++ b/test/support/template/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <link
       href="test/support/template/prism-material-oceanic.css"
       rel="stylesheet"

--- a/test/support/template/prism-autoloader.min.js
+++ b/test/support/template/prism-autoloader.min.js
@@ -1,0 +1,246 @@
+!(function () {
+  if (
+    'undefined' != typeof self &&
+    self.Prism &&
+    self.document &&
+    document.createElement
+  ) {
+    var c = {
+        javascript: 'clike',
+        actionscript: 'javascript',
+        arduino: 'cpp',
+        aspnet: ['markup', 'csharp'],
+        bison: 'c',
+        c: 'clike',
+        csharp: 'clike',
+        cpp: 'c',
+        coffeescript: 'javascript',
+        crystal: 'ruby',
+        'css-extras': 'css',
+        d: 'clike',
+        dart: 'clike',
+        django: 'markup-templating',
+        ejs: ['javascript', 'markup-templating'],
+        etlua: ['lua', 'markup-templating'],
+        erb: ['ruby', 'markup-templating'],
+        fsharp: 'clike',
+        'firestore-security-rules': 'clike',
+        flow: 'javascript',
+        ftl: 'markup-templating',
+        glsl: 'clike',
+        gml: 'clike',
+        go: 'clike',
+        groovy: 'clike',
+        haml: 'ruby',
+        handlebars: 'markup-templating',
+        haxe: 'clike',
+        java: 'clike',
+        javadoc: ['markup', 'java', 'javadoclike'],
+        jolie: 'clike',
+        jsdoc: ['javascript', 'javadoclike'],
+        'js-extras': 'javascript',
+        'js-templates': 'javascript',
+        jsonp: 'json',
+        json5: 'json',
+        kotlin: 'clike',
+        latte: ['clike', 'markup-templating', 'php'],
+        less: 'css',
+        lilypond: 'scheme',
+        markdown: 'markup',
+        'markup-templating': 'markup',
+        n4js: 'javascript',
+        nginx: 'clike',
+        objectivec: 'c',
+        opencl: 'cpp',
+        parser: 'markup',
+        php: ['clike', 'markup-templating'],
+        phpdoc: ['php', 'javadoclike'],
+        'php-extras': 'php',
+        plsql: 'sql',
+        processing: 'clike',
+        protobuf: 'clike',
+        pug: ['markup', 'javascript'],
+        qml: 'javascript',
+        qore: 'clike',
+        jsx: ['markup', 'javascript'],
+        tsx: ['jsx', 'typescript'],
+        reason: 'clike',
+        ruby: 'clike',
+        sass: 'css',
+        scss: 'css',
+        scala: 'java',
+        'shell-session': 'bash',
+        smarty: 'markup-templating',
+        solidity: 'clike',
+        soy: 'markup-templating',
+        sparql: 'turtle',
+        sqf: 'clike',
+        swift: 'clike',
+        tap: 'yaml',
+        textile: 'markup',
+        tt2: ['clike', 'markup-templating'],
+        twig: 'markup',
+        typescript: 'javascript',
+        't4-cs': ['t4-templating', 'csharp'],
+        't4-vb': ['t4-templating', 'visual-basic'],
+        vala: 'clike',
+        vbnet: 'basic',
+        velocity: 'markup',
+        wiki: 'markup',
+        xeora: 'markup',
+        xquery: 'markup',
+      },
+      l = {
+        html: 'markup',
+        xml: 'markup',
+        svg: 'markup',
+        mathml: 'markup',
+        js: 'javascript',
+        g4: 'antlr4',
+        adoc: 'asciidoc',
+        shell: 'bash',
+        rbnf: 'bnf',
+        cs: 'csharp',
+        dotnet: 'csharp',
+        coffee: 'coffeescript',
+        jinja2: 'django',
+        'dns-zone': 'dns-zone-file',
+        dockerfile: 'docker',
+        gamemakerlanguage: 'gml',
+        hs: 'haskell',
+        tex: 'latex',
+        context: 'latex',
+        ly: 'lilypond',
+        emacs: 'lisp',
+        elisp: 'lisp',
+        'emacs-lisp': 'lisp',
+        md: 'markdown',
+        moon: 'moonscript',
+        n4jsd: 'n4js',
+        objectpascal: 'pascal',
+        px: 'pcaxis',
+        py: 'python',
+        robot: 'robotframework',
+        rb: 'ruby',
+        rq: 'sparql',
+        trig: 'turtle',
+        ts: 'typescript',
+        t4: 't4-cs',
+        vb: 'visual-basic',
+        xeoracube: 'xeora',
+        yml: 'yaml',
+      },
+      n = {},
+      a = 'components/',
+      e = Prism.util.currentScript()
+    if (e) {
+      var t = /\bplugins\/autoloader\/prism-autoloader\.(?:min\.)js$/i,
+        s = /[\w-]+\.(?:min\.)js$/i
+      if (e.hasAttribute('data-autoloader-path'))
+        a = e.getAttribute('data-autoloader-path').trim().replace(/\/?$/, '/')
+      else {
+        var i = e.src
+        t.test(i)
+          ? (a = i.replace(t, 'components/'))
+          : s.test(i) && (a = i.replace(s, 'components/'))
+      }
+    }
+    var p = (Prism.plugins.autoloader = {
+      languages_path: a,
+      use_minified: !0,
+      loadLanguages: o,
+    })
+    Prism.hooks.add('complete', function (a) {
+      a.element &&
+        a.language &&
+        !a.grammar &&
+        'none' !== a.language &&
+        (function (a, e) {
+          a in l && (a = l[a])
+          var t = e.getAttribute('data-dependencies'),
+            s = e.parentElement
+          !t &&
+            s &&
+            'pre' === s.tagName.toLowerCase() &&
+            (t = s.getAttribute('data-dependencies')),
+            o((t = t ? t.split(/\s*,\s*/g) : []), function () {
+              m(a, function () {
+                Prism.highlightElement(e)
+              })
+            })
+        })(a.language, a.element)
+    })
+  }
+  function o(a, e, t) {
+    'string' == typeof a && (a = [a])
+    var s = a.length,
+      i = 0,
+      r = !1
+    function c() {
+      r || (++i === s && e && e(a))
+    }
+    0 !== s
+      ? a.forEach(function (a) {
+          m(a, c, function () {
+            r || ((r = !0), t && t(a))
+          })
+        })
+      : e && setTimeout(e, 0)
+  }
+  function m(e, t, s) {
+    var i = 0 <= e.indexOf('!')
+    ;(e = e.replace('!', '')), (e = l[e] || e)
+    var a = function () {
+        var a = n[e]
+        if (
+          (a || (a = n[e] = { callbacks: [] }),
+          a.callbacks.push({ success: t, error: s }),
+          !i && Prism.languages[e])
+        )
+          u(e, 'success')
+        else if (!i && a.error) u(e, 'error')
+        else if (i || !a.loading) {
+          ;(a.loading = !0),
+            (function (a, e, t) {
+              var s = document.createElement('script')
+              ;(s.src = a),
+                (s.async = !0),
+                (s.onload = function () {
+                  document.body.removeChild(s), e && e()
+                }),
+                (s.onerror = function () {
+                  document.body.removeChild(s), t && t()
+                }),
+                document.body.appendChild(s)
+            })(
+              (function (a) {
+                return (
+                  p.languages_path +
+                  'prism-' +
+                  a +
+                  (p.use_minified ? '.min' : '') +
+                  '.js'
+                )
+              })(e),
+              function () {
+                ;(a.loading = !1), u(e, 'success')
+              },
+              function () {
+                ;(a.loading = !1), (a.error = !0), u(e, 'error')
+              },
+            )
+        }
+      },
+      r = c[e]
+    r && r.length ? o(r, a, s) : a()
+  }
+  function u(a, e) {
+    if (n[a]) {
+      for (var t = n[a].callbacks, s = 0, i = t.length; s < i; s++) {
+        var r = t[s][e]
+        r && setTimeout(r, 0)
+      }
+      t.length = 0
+    }
+  }
+})()

--- a/test/support/template/prism-core.min.js
+++ b/test/support/template/prism-core.min.js
@@ -1,0 +1,361 @@
+var _self =
+    'undefined' != typeof window
+      ? window
+      : 'undefined' != typeof WorkerGlobalScope &&
+        self instanceof WorkerGlobalScope
+      ? self
+      : {},
+  Prism = (function (u) {
+    var c = /\blang(?:uage)?-([\w-]+)\b/i,
+      n = 0,
+      C = {
+        manual: u.Prism && u.Prism.manual,
+        disableWorkerMessageHandler:
+          u.Prism && u.Prism.disableWorkerMessageHandler,
+        util: {
+          encode: function (e) {
+            return e instanceof _
+              ? new _(e.type, C.util.encode(e.content), e.alias)
+              : Array.isArray(e)
+              ? e.map(C.util.encode)
+              : e
+                  .replace(/&/g, '&amp;')
+                  .replace(/</g, '&lt;')
+                  .replace(/\u00a0/g, ' ')
+          },
+          type: function (e) {
+            return Object.prototype.toString.call(e).slice(8, -1)
+          },
+          objId: function (e) {
+            return (
+              e.__id || Object.defineProperty(e, '__id', { value: ++n }), e.__id
+            )
+          },
+          clone: function r(e, t) {
+            var a,
+              n,
+              i = C.util.type(e)
+            switch (((t = t || {}), i)) {
+              case 'Object':
+                if (((n = C.util.objId(e)), t[n])) return t[n]
+                for (var o in ((a = {}), (t[n] = a), e))
+                  e.hasOwnProperty(o) && (a[o] = r(e[o], t))
+                return a
+              case 'Array':
+                return (
+                  (n = C.util.objId(e)),
+                  t[n]
+                    ? t[n]
+                    : ((a = []),
+                      (t[n] = a),
+                      e.forEach(function (e, n) {
+                        a[n] = r(e, t)
+                      }),
+                      a)
+                )
+              default:
+                return e
+            }
+          },
+          getLanguage: function (e) {
+            for (; e && !c.test(e.className); ) e = e.parentElement
+            return e
+              ? (e.className.match(c) || [, 'none'])[1].toLowerCase()
+              : 'none'
+          },
+          currentScript: function () {
+            if ('undefined' == typeof document) return null
+            if ('currentScript' in document) return document.currentScript
+            try {
+              throw new Error()
+            } catch (e) {
+              var n = (/at [^(\r\n]*\((.*):.+:.+\)$/i.exec(e.stack) || [])[1]
+              if (n) {
+                var r = document.getElementsByTagName('script')
+                for (var t in r) if (r[t].src == n) return r[t]
+              }
+              return null
+            }
+          },
+        },
+        languages: {
+          extend: function (e, n) {
+            var r = C.util.clone(C.languages[e])
+            for (var t in n) r[t] = n[t]
+            return r
+          },
+          insertBefore: function (r, e, n, t) {
+            var a = (t = t || C.languages)[r],
+              i = {}
+            for (var o in a)
+              if (a.hasOwnProperty(o)) {
+                if (o == e)
+                  for (var l in n) n.hasOwnProperty(l) && (i[l] = n[l])
+                n.hasOwnProperty(o) || (i[o] = a[o])
+              }
+            var s = t[r]
+            return (
+              (t[r] = i),
+              C.languages.DFS(C.languages, function (e, n) {
+                n === s && e != r && (this[e] = i)
+              }),
+              i
+            )
+          },
+          DFS: function e(n, r, t, a) {
+            a = a || {}
+            var i = C.util.objId
+            for (var o in n)
+              if (n.hasOwnProperty(o)) {
+                r.call(n, o, n[o], t || o)
+                var l = n[o],
+                  s = C.util.type(l)
+                'Object' !== s || a[i(l)]
+                  ? 'Array' !== s || a[i(l)] || ((a[i(l)] = !0), e(l, r, o, a))
+                  : ((a[i(l)] = !0), e(l, r, null, a))
+              }
+          },
+        },
+        plugins: {},
+        highlightAll: function (e, n) {
+          C.highlightAllUnder(document, e, n)
+        },
+        highlightAllUnder: function (e, n, r) {
+          var t = {
+            callback: r,
+            container: e,
+            selector:
+              'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code',
+          }
+          C.hooks.run('before-highlightall', t),
+            (t.elements = Array.prototype.slice.apply(
+              t.container.querySelectorAll(t.selector),
+            )),
+            C.hooks.run('before-all-elements-highlight', t)
+          for (var a, i = 0; (a = t.elements[i++]); )
+            C.highlightElement(a, !0 === n, t.callback)
+        },
+        highlightElement: function (e, n, r) {
+          var t = C.util.getLanguage(e),
+            a = C.languages[t]
+          e.className =
+            e.className.replace(c, '').replace(/\s+/g, ' ') + ' language-' + t
+          var i = e.parentNode
+          i &&
+            'pre' === i.nodeName.toLowerCase() &&
+            (i.className =
+              i.className.replace(c, '').replace(/\s+/g, ' ') +
+              ' language-' +
+              t)
+          var o = { element: e, language: t, grammar: a, code: e.textContent }
+          function l(e) {
+            ;(o.highlightedCode = e),
+              C.hooks.run('before-insert', o),
+              (o.element.innerHTML = o.highlightedCode),
+              C.hooks.run('after-highlight', o),
+              C.hooks.run('complete', o),
+              r && r.call(o.element)
+          }
+          if ((C.hooks.run('before-sanity-check', o), !o.code))
+            return C.hooks.run('complete', o), void (r && r.call(o.element))
+          if ((C.hooks.run('before-highlight', o), o.grammar))
+            if (n && u.Worker) {
+              var s = new Worker(C.filename)
+              ;(s.onmessage = function (e) {
+                l(e.data)
+              }),
+                s.postMessage(
+                  JSON.stringify({
+                    language: o.language,
+                    code: o.code,
+                    immediateClose: !0,
+                  }),
+                )
+            } else l(C.highlight(o.code, o.grammar, o.language))
+          else l(C.util.encode(o.code))
+        },
+        highlight: function (e, n, r) {
+          var t = { code: e, grammar: n, language: r }
+          return (
+            C.hooks.run('before-tokenize', t),
+            (t.tokens = C.tokenize(t.code, t.grammar)),
+            C.hooks.run('after-tokenize', t),
+            _.stringify(C.util.encode(t.tokens), t.language)
+          )
+        },
+        matchGrammar: function (e, n, r, t, a, i, o) {
+          for (var l in r)
+            if (r.hasOwnProperty(l) && r[l]) {
+              var s = r[l]
+              s = Array.isArray(s) ? s : [s]
+              for (var u = 0; u < s.length; ++u) {
+                if (o && o == l + ',' + u) return
+                var c = s[u],
+                  g = c.inside,
+                  f = !!c.lookbehind,
+                  h = !!c.greedy,
+                  d = 0,
+                  m = c.alias
+                if (h && !c.pattern.global) {
+                  var p = c.pattern.toString().match(/[imsuy]*$/)[0]
+                  c.pattern = RegExp(c.pattern.source, p + 'g')
+                }
+                c = c.pattern || c
+                for (var y = t, v = a; y < n.length; v += n[y].length, ++y) {
+                  var k = n[y]
+                  if (n.length > e.length) return
+                  if (!(k instanceof _)) {
+                    if (h && y != n.length - 1) {
+                      if (((c.lastIndex = v), !(O = c.exec(e)))) break
+                      for (
+                        var b = O.index + (f && O[1] ? O[1].length : 0),
+                          w = O.index + O[0].length,
+                          A = y,
+                          P = v,
+                          x = n.length;
+                        A < x && (P < w || (!n[A].type && !n[A - 1].greedy));
+                        ++A
+                      )
+                        (P += n[A].length) <= b && (++y, (v = P))
+                      if (n[y] instanceof _) continue
+                      ;(S = A - y), (k = e.slice(v, P)), (O.index -= v)
+                    } else {
+                      c.lastIndex = 0
+                      var O = c.exec(k),
+                        S = 1
+                    }
+                    if (O) {
+                      f && (d = O[1] ? O[1].length : 0)
+                      w = (b = O.index + d) + (O = O[0].slice(d)).length
+                      var j = k.slice(0, b),
+                        N = k.slice(w),
+                        E = [y, S]
+                      j && (++y, (v += j.length), E.push(j))
+                      var L = new _(l, g ? C.tokenize(O, g) : O, m, O, h)
+                      if (
+                        (E.push(L),
+                        N && E.push(N),
+                        Array.prototype.splice.apply(n, E),
+                        1 != S &&
+                          C.matchGrammar(e, n, r, y, v, !0, l + ',' + u),
+                        i)
+                      )
+                        break
+                    } else if (i) break
+                  }
+                }
+              }
+            }
+        },
+        tokenize: function (e, n) {
+          var r = [e],
+            t = n.rest
+          if (t) {
+            for (var a in t) n[a] = t[a]
+            delete n.rest
+          }
+          return C.matchGrammar(e, r, n, 0, 0, !1), r
+        },
+        hooks: {
+          all: {},
+          add: function (e, n) {
+            var r = C.hooks.all
+            ;(r[e] = r[e] || []), r[e].push(n)
+          },
+          run: function (e, n) {
+            var r = C.hooks.all[e]
+            if (r && r.length) for (var t, a = 0; (t = r[a++]); ) t(n)
+          },
+        },
+        Token: _,
+      }
+    function _(e, n, r, t, a) {
+      ;(this.type = e),
+        (this.content = n),
+        (this.alias = r),
+        (this.length = 0 | (t || '').length),
+        (this.greedy = !!a)
+    }
+    if (
+      ((u.Prism = C),
+      (_.stringify = function (e, n) {
+        if ('string' == typeof e) return e
+        if (Array.isArray(e))
+          return e
+            .map(function (e) {
+              return _.stringify(e, n)
+            })
+            .join('')
+        var r = {
+          type: e.type,
+          content: _.stringify(e.content, n),
+          tag: 'span',
+          classes: ['token', e.type],
+          attributes: {},
+          language: n,
+        }
+        if (e.alias) {
+          var t = Array.isArray(e.alias) ? e.alias : [e.alias]
+          Array.prototype.push.apply(r.classes, t)
+        }
+        C.hooks.run('wrap', r)
+        var a = Object.keys(r.attributes)
+          .map(function (e) {
+            return (
+              e + '="' + (r.attributes[e] || '').replace(/"/g, '&quot;') + '"'
+            )
+          })
+          .join(' ')
+        return (
+          '<' +
+          r.tag +
+          ' class="' +
+          r.classes.join(' ') +
+          '"' +
+          (a ? ' ' + a : '') +
+          '>' +
+          r.content +
+          '</' +
+          r.tag +
+          '>'
+        )
+      }),
+      !u.document)
+    )
+      return (
+        u.addEventListener &&
+          (C.disableWorkerMessageHandler ||
+            u.addEventListener(
+              'message',
+              function (e) {
+                var n = JSON.parse(e.data),
+                  r = n.language,
+                  t = n.code,
+                  a = n.immediateClose
+                u.postMessage(C.highlight(t, C.languages[r], r)), a && u.close()
+              },
+              !1,
+            )),
+        C
+      )
+    var e = C.util.currentScript()
+    if (
+      (e &&
+        ((C.filename = e.src),
+        e.hasAttribute('data-manual') && (C.manual = !0)),
+      !C.manual)
+    ) {
+      function r() {
+        C.manual || C.highlightAll()
+      }
+      var t = document.readyState
+      'loading' === t || ('interactive' === t && e && e.defer)
+        ? document.addEventListener('DOMContentLoaded', r)
+        : window.requestAnimationFrame
+        ? window.requestAnimationFrame(r)
+        : window.setTimeout(r, 16)
+    }
+    return C
+  })(_self)
+'undefined' != typeof module && module.exports && (module.exports = Prism),
+  'undefined' != typeof global && (global.Prism = Prism)

--- a/test/support/template/prism-material-oceanic.css
+++ b/test/support/template/prism-material-oceanic.css
@@ -1,0 +1,210 @@
+code[class*='language-'],
+pre[class*='language-'] {
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  color: #c3cee3;
+  background: #263238;
+  font-family: Roboto Mono, monospace;
+  font-size: 1em;
+  line-height: 1.5em;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+code[class*='language-']::-moz-selection,
+pre[class*='language-']::-moz-selection,
+code[class*='language-'] ::-moz-selection,
+pre[class*='language-'] ::-moz-selection {
+  background: #363636;
+}
+
+code[class*='language-']::selection,
+pre[class*='language-']::selection,
+code[class*='language-'] ::selection,
+pre[class*='language-'] ::selection {
+  background: #363636;
+}
+
+:not(pre) > code[class*='language-'] {
+  white-space: normal;
+  border-radius: 0.2em;
+  padding: 0.1em;
+}
+
+pre[class*='language-'] {
+  overflow: auto;
+  position: relative;
+  margin: 0.5em 0;
+  padding: 1.25em 1em;
+}
+
+.language-css > code,
+.language-sass > code,
+.language-scss > code {
+  color: #fd9170;
+}
+
+[class*='language-'] .namespace {
+  opacity: 0.7;
+}
+
+.token.atrule {
+  color: #c792ea;
+}
+
+.token.attr-name {
+  color: #ffcb6b;
+}
+
+.token.attr-value {
+  color: #c3e88d;
+}
+
+.token.attribute {
+  color: #c3e88d;
+}
+
+.token.boolean {
+  color: #c792ea;
+}
+
+.token.builtin {
+  color: #ffcb6b;
+}
+
+.token.cdata {
+  color: #80cbc4;
+}
+
+.token.char {
+  color: #80cbc4;
+}
+
+.token.class {
+  color: #ffcb6b;
+}
+
+.token.class-name {
+  color: #f2ff00;
+}
+
+.token.color {
+  color: #f2ff00;
+}
+
+.token.comment {
+  color: #546e7a;
+}
+
+.token.constant {
+  color: #c792ea;
+}
+
+.token.deleted {
+  color: #f07178;
+}
+
+.token.doctype {
+  color: #546e7a;
+}
+
+.token.entity {
+  color: #f07178;
+}
+
+.token.function {
+  color: #c792ea;
+}
+
+.token.hexcode {
+  color: #f2ff00;
+}
+
+.token.id {
+  color: #c792ea;
+  font-weight: bold;
+}
+
+.token.important {
+  color: #c792ea;
+  font-weight: bold;
+}
+
+.token.inserted {
+  color: #80cbc4;
+}
+
+.token.keyword {
+  color: #c792ea;
+  font-style: italic;
+}
+
+.token.number {
+  color: #fd9170;
+}
+
+.token.operator {
+  color: #89ddff;
+}
+
+.token.prolog {
+  color: #546e7a;
+}
+
+.token.property {
+  color: #80cbc4;
+}
+
+.token.pseudo-class {
+  color: #c3e88d;
+}
+
+.token.pseudo-element {
+  color: #c3e88d;
+}
+
+.token.punctuation {
+  color: #89ddff;
+}
+
+.token.regex {
+  color: #f2ff00;
+}
+
+.token.selector {
+  color: #f07178;
+}
+
+.token.string {
+  color: #c3e88d;
+}
+
+.token.symbol {
+  color: #c792ea;
+}
+
+.token.tag {
+  color: #f07178;
+}
+
+.token.unit {
+  color: #f07178;
+}
+
+.token.url {
+  color: #fd9170;
+}
+
+.token.variable {
+  color: #f07178;
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2015",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Change log

### Service Worker instance handling

- Worker instance now keeps an internal `clients` map that holds all controlled clients.
- Worker instance provisions conditional mocking based on the `MOCK_ACTIVATE` event dispatched by a client. All clients have mocking disabled by default.
- Worker now bypasses requests with `mode: "navigate"` to prevent loading initial page load assets
- Client **no longer deactivates mocking** on `beforeunload` event. Instead, it dispatches the `CLIENT_CLOSED` event to notify the worker that the client has closed.
- Client now reloads the worker whenever a new worker instance has been installed.
- Calling `start()` now looks up for already running instances of the worker and updates them, instead of creating a new instance.
- Calling `stop()` now disables the mocking state for the client that called it. This allows different clients (tabs) to have different mocking state.

### Internal changes

- Adds `test.request()` utility that encapsulates a `fetch()` call in a page's context, and awaits for that request to finish, before resolving the promise.
- Adds a way to customize WDS routes by `withRoutes(app)`. This way WDS can be used as a local server for testing more complex server interactions scenarios (#79)

```ts
runBrowserWith(path.resolve('path/to/example.mocks.ts', {
  withRoutes(app) {
    app.post('/users', (req, res) => {
      res.status(200).json({ real: 'data' })
    })
  }
})
```

## GitHub

- Closes #79
- Closes #96 
- Potentially closes #98 

## Roadmap

- [x] Add a test suite on how Service Worker unregistration behaves with multiple clients (tabs) opened
- [x] Can there be a `mode: "navigate"` request that users may want to mock?
- [x] Declare the `clients` map on the worker instance (`self`) upon activation