### PR TITLE
Logs matched requests into browser console

### DIFF
--- a/src/handleRequest.ts
+++ b/src/handleRequest.ts
@@ -10,6 +10,7 @@ import {
   ServiceWorkerMessage,
   createBroadcastChannel,
 } from './utils/createBroadcastChannel'
+import { log } from './logger'
 
 export const handleRequestWith = (requestHandlers: RequestHandler[]) => {
   return async (event: MessageEvent) => {
@@ -83,11 +84,13 @@ export const handleRequestWith = (requestHandlers: RequestHandler[]) => {
 
       // Transform Headers into a list to be stringified preserving multiple
       // header keys. Stringified list is then parsed inside the ServiceWorker.
-      const responseWithHeaders = {
+      const responseWithHeaders: MockedResponse = {
         ...mockedResponse,
         // @ts-ignore
         headers: Array.from(mockedResponse.headers.entries()),
       }
+
+      log(req, responseWithHeaders, relevantRequestHandler)
 
       channel.send({
         type: 'MOCK_SUCCESS',

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,38 @@
+import url from 'url'
+import { MockedRequest, RequestHandler } from './handlers/requestHandler'
+import { MockedResponse } from './response'
+import { getTimestamp } from './utils/getTimestamp'
+import { styleStatusCode } from './utils/styleStatusCode'
+
+export const log = (
+  req: MockedRequest,
+  res: MockedResponse,
+  handler: RequestHandler<any>,
+) => {
+  const isLocal = req.url.startsWith(req.referrer)
+  const parsedUrl = url.parse(req.url)
+  const publicUrl = isLocal
+    ? parsedUrl.pathname
+    : url.format({
+        protocol: parsedUrl.protocol,
+        host: parsedUrl.host,
+        pathname: parsedUrl.pathname,
+      })
+
+  console.groupCollapsed(
+    '[MSW] %s %s %s (%c%s%c)',
+    getTimestamp(),
+    req.method,
+    publicUrl,
+    styleStatusCode(res.status),
+    res.status,
+    'color:inherit',
+  )
+  console.log('Request', req)
+  console.log('Handler:', {
+    mask: handler.mask,
+    resolver: handler.resolver,
+  })
+  console.log('Response', res)
+  console.groupEnd()
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -19,20 +19,22 @@ export const log = (
         pathname: parsedUrl.pathname,
       })
 
-  console.groupCollapsed(
-    '[MSW] %s %s %s (%c%s%c)',
-    getTimestamp(),
-    req.method,
-    publicUrl,
-    styleStatusCode(res.status),
-    res.status,
-    'color:inherit',
-  )
-  console.log('Request', req)
-  console.log('Handler:', {
-    mask: handler.mask,
-    resolver: handler.resolver,
-  })
-  console.log('Response', res)
-  console.groupEnd()
+  setTimeout(() => {
+    console.groupCollapsed(
+      '[MSW] %s %s %s (%c%s%c)',
+      getTimestamp(),
+      req.method,
+      publicUrl,
+      styleStatusCode(res.status),
+      res.status,
+      'color:inherit',
+    )
+    console.log('Request', req)
+    console.log('Handler:', {
+      mask: handler.mask,
+      resolver: handler.resolver,
+    })
+    console.log('Response', res)
+    console.groupEnd()
+  }, res.delay)
 }

--- a/src/utils/getTimestamp.ts
+++ b/src/utils/getTimestamp.ts
@@ -1,0 +1,8 @@
+export const getTimestamp = () => {
+  const now = new Date()
+  return [now.getHours(), now.getMinutes(), now.getSeconds()]
+    .map(String)
+    .map((chunk) => chunk.slice(0, 2))
+    .map((chunk) => chunk.padStart(2, '0'))
+    .join(':')
+}

--- a/src/utils/styleStatusCode.ts
+++ b/src/utils/styleStatusCode.ts
@@ -1,0 +1,11 @@
+export const styleStatusCode = (status: number) => {
+  if (status < 300) {
+    return 'color:#69AB32;'
+  }
+
+  if (status < 400) {
+    return 'color:#F0BB4B;'
+  }
+
+  return 'color:#E95F5D;'
+}


### PR DESCRIPTION
## Changes

- Logs matched requests into browser console
- Each log entry contains a timestamp that indicates when the mocking has happened
- Strips the hostname of the local requests
- Always strips query parameters from the logged request URL
- Status code is colored depending on the value (green, yellow, or red)

## Preview

<img width="1811" alt="Screen Shot 2020-04-17 at 20 19 41" src="https://user-images.githubusercontent.com/14984911/79601246-d1de5b80-80e8-11ea-9724-1b3059746c94.png">

## GitHub

- Closes #55

## Roadmap

- [x] Consider delayed responses