### PR TITLE
Updates to "node-match-path@0.4.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chalk": "^4.0.0",
     "cookie": "^0.4.0",
     "graphql": "^15.0.0",
-    "node-match-path": "^0.3.1",
+    "node-match-path": "^0.4.2",
     "statuses": "^2.0.0",
     "yargs": "^15.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5515,10 +5515,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-match-path@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.3.1.tgz#5fad8475e7763840960ad436fa4e3ed01275e22f"
-  integrity sha512-1XC05rKixOzElozv6MngsCiS9aaNcBTA4eg2Uw8z36qXetUNfk3Le3VBEH4s5Dg/wWhAz6yHsbQct3na67rEJg==
+node-match-path@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.4.2.tgz#30cc39510fa493bff03c3d0d2fff711c868ec457"
+  integrity sha512-wfde4FOC5A8RTSUVZ7pTpBV+dJsr2vVxT6374VrNam6wnnhx6EvwAwL/E/r3AW/YU6XkeZggF5xfBlu4a/ULBg==
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
No associated issues, maintenance task.

- See [`node-match-path@0.4.1`](https://github.com/open-draft/node-match-path/releases/tag/v0.4.1) release notes