### PR TITLE
Fixes "only-if-cached" console error when opening DevTools

### DIFF
--- a/config/plugins/rollup-integrity-check-plugin/index.js
+++ b/config/plugins/rollup-integrity-check-plugin/index.js
@@ -22,6 +22,8 @@ module.exports = function integrityCheck(options) {
       return replace(injectChecksum(this.checksum)).transform(...args)
     },
     buildStart() {
+      this.addWatchFile(input)
+
       if (!fs.existsSync(input)) {
         this.error(`Failed to locate the Service Worker file at: ${input}`)
       }

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -70,6 +70,12 @@ self.addEventListener('fetch', async function (event) {
   const requestClone = request.clone()
   const getOriginalResponse = () => fetch(requestClone)
 
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  // if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+  //   return
+  // }
+
   event.respondWith(
     new Promise(async (resolve) => {
       const client = await event.target.clients.get(clientId)

--- a/test/graphql-api/errors.test.ts
+++ b/test/graphql-api/errors.test.ts
@@ -4,14 +4,14 @@ import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 import { executeOperation } from './utils/executeOperation'
 
 describe('GraphQL: Errors', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'errors.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'errors.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   describe('given mocked query errors', () => {
@@ -19,7 +19,7 @@ describe('GraphQL: Errors', () => {
     let body: Record<string, any>
 
     beforeAll(async () => {
-      res = await executeOperation(api.page, {
+      res = await executeOperation(test.page, {
         query: `
           query Login {
             user {

--- a/test/graphql-api/mutation.test.ts
+++ b/test/graphql-api/mutation.test.ts
@@ -3,18 +3,18 @@ import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 import { executeOperation } from './utils/executeOperation'
 
 describe('GraphQL: Mutation', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'mutation.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'mutation.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   it('should mock the mutation response', async () => {
-    const res = await executeOperation(api.page, {
+    const res = await executeOperation(test.page, {
       query: `
         mutation Logout {
           logout {

--- a/test/graphql-api/query.test.ts
+++ b/test/graphql-api/query.test.ts
@@ -3,18 +3,18 @@ import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 import { executeOperation } from './utils/executeOperation'
 
 describe('GraphQL: Query', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'query.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'query.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   it('should mock the query response', async () => {
-    const res = await executeOperation(api.page, {
+    const res = await executeOperation(test.page, {
       query: `
         query GetUserDetail {
           user {

--- a/test/graphql-api/variables.test.ts
+++ b/test/graphql-api/variables.test.ts
@@ -4,14 +4,14 @@ import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 import { executeOperation } from './utils/executeOperation'
 
 describe('GraphQL: Variables', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(path.resolve(__dirname, 'variables.mocks.ts'))
+    test = await runBrowserWith(path.resolve(__dirname, 'variables.mocks.ts'))
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   describe('given a query with variables', () => {
@@ -19,7 +19,7 @@ describe('GraphQL: Variables', () => {
     let body: Record<string, any>
 
     beforeAll(async () => {
-      res = await executeOperation(api.page, {
+      res = await executeOperation(test.page, {
         query: `
           query GetGithubUser($username: String!) {
             user(login: $username) {
@@ -56,7 +56,7 @@ describe('GraphQL: Variables', () => {
     let body: Record<string, any>
 
     beforeAll(async () => {
-      res = await executeOperation(api.page, {
+      res = await executeOperation(test.page, {
         query: `
           mutation DeletePost($postId: String!) {
             deletePost(id: $postId) {
@@ -91,7 +91,7 @@ describe('GraphQL: Variables', () => {
     let body: Record<string, any>
 
     beforeAll(async () => {
-      res = await executeOperation(api.page, {
+      res = await executeOperation(test.page, {
         query: `
             query GetActiveUser {
               user {

--- a/test/msw-api/compose-mocks/start/quiet.test.ts
+++ b/test/msw-api/compose-mocks/start/quiet.test.ts
@@ -27,9 +27,7 @@ describe('API: composeMocks / start / quiet', () => {
         return window.__MSW_REGISTRATION__
       })
 
-      await test.page.goto(test.origin, {
-        waitUntil: 'networkidle0',
-      })
+      await test.reload()
     })
 
     it('should still print activation message into console', () => {

--- a/test/msw-api/compose-mocks/start/start.test.ts
+++ b/test/msw-api/compose-mocks/start/start.test.ts
@@ -35,9 +35,7 @@ describe('API: composeMocks / start', () => {
         }
       })
 
-      await test.page.goto(test.origin, {
-        waitUntil: 'networkidle0',
-      })
+      await test.reload()
 
       const activationMessageIndex = logs.findIndex((message) => {
         return message.includes('[MSW] Mocking enabled')

--- a/test/msw-api/exception-handling.test.ts
+++ b/test/msw-api/exception-handling.test.ts
@@ -24,9 +24,7 @@ describe('Exception handling', () => {
         }
       })
 
-      await test.page.goto(test.origin, {
-        waitUntil: 'networkidle0',
-      })
+      await test.reload()
 
       expect(errorMessages).toHaveLength(0)
     })

--- a/test/msw-api/integrity-check.test.ts
+++ b/test/msw-api/integrity-check.test.ts
@@ -27,9 +27,7 @@ describe('Integrity check', () => {
         }
       })
 
-      await test.page.goto(test.origin, {
-        waitUntil: 'networkidle0',
-      })
+      await test.reload()
 
       expect(errorMessages).toHaveLength(0)
     })
@@ -84,9 +82,7 @@ describe('Integrity check', () => {
       })
 
       // Open the page anew to trigger the console listener
-      await test.page.goto(test.origin, {
-        waitUntil: 'networkidle0',
-      })
+      await test.reload()
 
       const integrityError = errors.find((message) => {
         return message.includes('[MSW] Detected outdated Service Worker')

--- a/test/rest-api/headers-multiple.test.ts
+++ b/test/rest-api/headers-multiple.test.ts
@@ -2,22 +2,22 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
 
 describe('REST: Multiple headers with the same name', () => {
-  let api: TestAPI
+  let test: TestAPI
 
   beforeAll(async () => {
-    api = await runBrowserWith(
+    test = await runBrowserWith(
       path.resolve(__dirname, 'headers-multiple.mocks.ts'),
     )
   })
 
   afterAll(() => {
-    return api.cleanup()
+    return test.cleanup()
   })
 
   describe('given handling a request header with multiple values', () => {
     it('should receive all the headers', async () => {
       const REQUEST_URL = 'https://test.msw.io/'
-      api.page.evaluate((url) => {
+      test.page.evaluate((url) => {
         const headers = new Headers()
         headers.append('accept', 'application/json')
         headers.append('accept', 'image/png')
@@ -27,7 +27,7 @@ describe('REST: Multiple headers with the same name', () => {
           headers,
         })
       }, REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      const res = await test.page.waitForResponse(REQUEST_URL)
       const body = await res.json()
 
       expect(res.status()).toEqual(200)
@@ -40,8 +40,8 @@ describe('REST: Multiple headers with the same name', () => {
   describe('given mocking a header with multiple values', () => {
     it('should receive all the headers', async () => {
       const REQUEST_URL = 'https://test.msw.io/'
-      api.page.evaluate((url) => fetch(url), REQUEST_URL)
-      const res = await api.page.waitForResponse(REQUEST_URL)
+      test.page.evaluate((url) => fetch(url), REQUEST_URL)
+      const res = await test.page.waitForResponse(REQUEST_URL)
       const headers = res.headers()
       const body = await res.json()
 


### PR DESCRIPTION
> These changes bump the integrity of the Service Worker.

## Changes

- Service Worker now bypasses `mode: 'only-if-cached'` requests made otherwhere than `same-origin`
- `runBrowserWith` now exposes a `reload()` function to reload the page at the same origin and await the network to resolve

## GitHub

- Fixes #107 