### PR TITLE
Uses explicit exports instead of "export * as"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,17 @@
+import * as context from './context'
+
 export { composeMocks } from './composeMocks/composeMocks'
 export { MockedResponse, ResponseTransformer, response } from './response'
-export * as context from './context'
+export { context }
 
 /* Request handlers */
-export * from './handlers/requestHandler'
+export {
+  MockedRequest,
+  RequestHandler,
+  RequestParams,
+  RequestQuery,
+  ResponseResolver,
+  defaultContext,
+} from './handlers/requestHandler'
 export { default as rest, restContext, RESTMethods } from './handlers/rest'
 export { default as graphql, graphqlContext } from './handlers/graphql'


### PR DESCRIPTION
## Changes

- Replaces the `export * as abc` syntax with explicit exports to grant TypeScript < 3.8 compatibility. There are still a lot of tooling operating on TypeScript 3.7. Using `msw` with that version has proven to be incompatible due to `export * as` syntax introduced in 3.8.

## GitHub

- Fixes #114 
