### PR TITLE
Silences activation message when started with "quiet: true"

### DIFF
--- a/src/composeMocks/start/createStart.ts
+++ b/src/composeMocks/start/createStart.ts
@@ -90,7 +90,9 @@ If this message still persists after updating, please report an issue: https://g
     }
 
     // Signal the Service Worker to enable requests interception
-    const [activationError] = await until(() => activateMocking(worker))
+    const [activationError] = await until(() =>
+      activateMocking(worker, options),
+    )
 
     if (activationError) {
       console.error('Failed to enable mocking', activationError)

--- a/src/composeMocks/start/utils/activateMocking.ts
+++ b/src/composeMocks/start/utils/activateMocking.ts
@@ -1,6 +1,10 @@
 import { addMessageListener } from '../../../utils/createBroadcastChannel'
+import { StartOptions } from '../../glossary'
 
-export const activateMocking = (worker: ServiceWorker) => {
+export const activateMocking = (
+  worker: ServiceWorker,
+  options?: StartOptions,
+) => {
   worker.postMessage('MOCK_ACTIVATE')
 
   return new Promise((resolve, reject) => {
@@ -8,17 +12,21 @@ export const activateMocking = (worker: ServiceWorker) => {
     addMessageListener(
       'MOCKING_ENABLED',
       () => {
-        console.groupCollapsed(
-          '%c[MSW] Mocking enabled.',
-          'color:orangered;font-weight:bold;',
-        )
-        console.log(
-          '%cDocumentation: %chttps://redd.gitbook.io/msw',
-          'font-weight:bold',
-          'font-weight:normal',
-        )
-        console.log('Found an issue? https://github.com/open-draft/msw/issues')
-        console.groupEnd()
+        if (!options?.quiet) {
+          console.groupCollapsed(
+            '%c[MSW] Mocking enabled.',
+            'color:orangered;font-weight:bold;',
+          )
+          console.log(
+            '%cDocumentation: %chttps://redd.gitbook.io/msw',
+            'font-weight:bold',
+            'font-weight:normal',
+          )
+          console.log(
+            'Found an issue? https://github.com/open-draft/msw/issues',
+          )
+          console.groupEnd()
+        }
 
         return resolve()
       },

--- a/test/msw-api/compose-mocks/start/quiet.test.ts
+++ b/test/msw-api/compose-mocks/start/quiet.test.ts
@@ -30,11 +30,11 @@ describe('API: composeMocks / start / quiet', () => {
       await test.reload()
     })
 
-    it('should still print activation message into console', () => {
+    it('should not print any activation message into console', () => {
       const activationMessage = logs.find((message) => {
         return message.includes('[MSW] Mocking enabled.')
       })
-      expect(activationMessage).toBeTruthy()
+      expect(activationMessage).toBeFalsy()
     })
 
     describe('and I perform a request that should be mocked', () => {


### PR DESCRIPTION
## Changes

- The mock activation messages is now also suppressed when run `start({ quiet: true })`

## GitHub

- Relates to #111 
- Successor to #113 