### PR TITLE
Points "msw" jest alias to the module root

### DIFF
--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   // and Puppeteer bootstrapping to take place.
   testTimeout: 60000,
   moduleNameMapper: {
-    '^msw$': '<rootDir>/../lib/index.js',
+    '^msw$': '<rootDir>/..',
   },
   moduleFileExtensions: ['ts', 'js', 'json'],
   transform: {


### PR DESCRIPTION
Running tests using `jest` (without webpack) results into `msw` alias being broken, as it points to no longer existing `lib/index.js` module.

Pointing `msw` alias to the library's root resolves the module to `packageJson.main`.