### PR TITLE
Reloads the page with registrations but without controller

### DIFF
--- a/src/composeMocks/start/utils/getWorkerInstance.ts
+++ b/src/composeMocks/start/utils/getWorkerInstance.ts
@@ -10,6 +10,31 @@ export const getWorkerInstance = async (
   url: string,
   options?: RegistrationOptions,
 ): Promise<ServiceWorkerInstanceTuple | null> => {
+  // Resolve the absolute Service Worker URL
+  const absoluteWorkerUrl = (location.origin + url).replace(
+    /(\.\/|\/{2,})/g,
+    '/',
+  )
+
+  const [, mockRegistrations] = await until(async () => {
+    const registrations = await navigator.serviceWorker.getRegistrations()
+    return registrations.filter((registration) => {
+      const worker = getWorkerByRegistration(registration)
+      // Filter out other workers that can be associated with this page
+      return worker?.scriptURL === absoluteWorkerUrl
+    })
+  })
+
+  if (!navigator.serviceWorker.controller && mockRegistrations.length > 0) {
+    // Reload the page when it has associated workers, but no active controller.
+    // The absence of a controller can mean either:
+    // - page has no Service Worker associated with it
+    // - page has been hard-reloaded and its workers won't be used until the next reload.
+    // Since we've checked that there are registrations associated with this page,
+    // at this point we are sure it's hard reload that falls into this clause.
+    location.reload()
+  }
+
   const [, existingRegistration] = await until(() => {
     return navigator.serviceWorker.getRegistration(url)
   })


### PR DESCRIPTION
## Changes

During the retrieving of an active worker instance (or creation of a new worker) the library checks if there are worker registrations associated with the client and no `navigatior.serviceWorker.controller` present. In that case it determines that a hard reload has happened, and triggers a regular reload following it.

## GitHub

- Relates to #98 
- Fixes #122 