### PR TITLE
rollup-integrity-check-plugin: Sets up watcher on "transform" hook

### DIFF
--- a/config/plugins/rollup-integrity-check-plugin/index.js
+++ b/config/plugins/rollup-integrity-check-plugin/index.js
@@ -15,15 +15,11 @@ module.exports = function integrityCheck(options) {
 
   return {
     name: 'integrity-check',
-    renderChunk(...args) {
-      return replace(injectChecksum(this.checksum)).renderChunk(...args)
-    },
     transform(...args) {
+      this.addWatchFile(input)
       return replace(injectChecksum(this.checksum)).transform(...args)
     },
     buildStart() {
-      this.addWatchFile(input)
-
       if (!fs.existsSync(input)) {
         this.error(`Failed to locate the Service Worker file at: ${input}`)
       }
@@ -31,6 +27,7 @@ module.exports = function integrityCheck(options) {
       console.log('Signing the Service Worker at:\n%s', chalk.cyan(input))
 
       this.checksum = getChecksum(input)
+
       const workerContent = fs.readFileSync(input, 'utf8')
       const publicWorkerContent = workerContent.replace(
         checksumPlaceholder,


### PR DESCRIPTION
> Completely internal changes, no release intended.

## Changes

- Moves the watcher (`this.addWatchFile`) call to the `transform` hook of rollup. 
- Removes providing of a value in `renderChunk` hook, as it doesn't seem to have access to a plugin-wide variable `this.checksum` anyway.

## GitHub

- Closes #86 