### PR TITLE
Removes forceful reload on found update

### DIFF
--- a/src/composeMocks/start/createStart.ts
+++ b/src/composeMocks/start/createStart.ts
@@ -49,20 +49,6 @@ export const createStart = (context: ComposeMocksInternalContext) => {
     context.worker = worker
     context.registration = registration
 
-    // Reload the page when new Service Worker has been installed
-    registration.addEventListener('updatefound', () => {
-      const nextWorker = registration.installing
-
-      nextWorker?.addEventListener('statechange', () => {
-        if (
-          nextWorker.state === 'installed' &&
-          navigator.serviceWorker.controller
-        ) {
-          location.reload()
-        }
-      })
-    })
-
     window.addEventListener('beforeunload', () => {
       if (worker.state !== 'redundant') {
         // Notify the Service Worker that this client has closed.


### PR DESCRIPTION
## Changes

- Removes forceful page reload when a new worker update is found. This reload caused an issue when "Update on reload" flag is enabled in a browser. Since reload triggers update, it created an infinite loading in: `reload -> update -> update found -> reload -> ...`.

## GitHub

- Fixes #119 