### PR TITLE
Fixes broken worker file copying on "msw init"

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -24,8 +24,9 @@ module.exports = function init(args) {
 
   const swFilename = path.basename(SERVICE_WORKER_BUILD_PATH)
   const swDestFilepath = path.resolve(resolvedPublicDir, swFilename)
+
   fs.copyFile(SERVICE_WORKER_BUILD_PATH, swDestFilepath, (error) => {
-    invariant(typeof error !== null, 'Failed to copy Service Worker. %s', error)
+    invariant(typeof error === null, 'Failed to copy Service Worker. %s', error)
 
     console.log(`
 ${chalk.green('Service Worker successfully created!')}

--- a/cli/invariant.js
+++ b/cli/invariant.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk')
 
-module.exports = function(predicate, message, ...args) {
+module.exports = function (predicate, message, ...args) {
   if (!predicate) {
     console.error(chalk.red(message), ...args)
     process.exit(1)

--- a/config/constants.js
+++ b/config/constants.js
@@ -2,12 +2,14 @@ const path = require('path')
 const packageJson = require('../package.json')
 
 const SERVICE_WORKER_SOURCE_PATH = path.resolve(
-  process.cwd(),
+  __dirname,
+  '../',
   'src/mockServiceWorker.js',
 )
 
 const SERVICE_WORKER_BUILD_PATH = path.resolve(
-  process.cwd(),
+  __dirname,
+  '../',
   path.dirname(packageJson.main),
   path.basename(SERVICE_WORKER_SOURCE_PATH),
 )


### PR DESCRIPTION
## Changes

- First, there was an invalid predicate condition for the `invariant()` call during the `msw init` command. It concealed any occurring errors from the user, preventing this issue from being discovered at the right time.
- Second, changes the constant file path to the service worker to be relative to the `__dirname`. This way `msw init` always grabs the worker file from the installed directory of the library. 

## GitHub

- Fixes #130