### PR TITLE
Fixes invariant predicate for "init" command

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -26,7 +26,7 @@ module.exports = function init(args) {
   const swDestFilepath = path.resolve(resolvedPublicDir, swFilename)
 
   fs.copyFile(SERVICE_WORKER_BUILD_PATH, swDestFilepath, (error) => {
-    invariant(typeof error === null, 'Failed to copy Service Worker. %s', error)
+    invariant(error == null, 'Failed to copy Service Worker. %s', error)
 
     console.log(`
 ${chalk.green('Service Worker successfully created!')}


### PR DESCRIPTION
## Changes

According to how `invariant()` is generally used, as long as its predicate is truthy, it must not throw. This means that its predicate must describe a _desired_ behavior, not an exceptional one.

## GitHub

- Fixes #132 