### PR TITLE
Adds CLI init command integration tests

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -10,7 +10,7 @@ yargs
       yargs
         .positional('publicDir', {
           type: 'string',
-          description: 'Relative path to server public directory',
+          description: 'Relative path to the public directory',
           required: true,
           normalize: true,
         })

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "lib/esm.js",
   "types": "lib/types",
   "bin": {
-    "msw": "cli/msw.js"
+    "msw": "cli/index.js"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=development rollup -c rollup.config.ts -w",

--- a/test/msw-api/cli/init.test.ts
+++ b/test/msw-api/cli/init.test.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { exec } from 'child_process'
+
+const PROJECT_ROOT = path.resolve(__dirname, '../../..')
+const TMP_DIR_PATH = path.resolve(PROJECT_ROOT, 'tmp')
+const TEST_DIR_PATH = path.resolve(TMP_DIR_PATH, 'cli/init')
+
+describe('init', () => {
+  beforeAll(() => {
+    return fs.promises.mkdir(TEST_DIR_PATH, { recursive: true })
+  })
+
+  afterAll(() => {
+    return fs.promises.rmdir(TEST_DIR_PATH, { recursive: true })
+  })
+
+  describe('given an existing public directory', () => {
+    let capturedError: Error
+    let capturedStdout: string
+
+    beforeAll((done) => {
+      // Create a public directory
+      fs.mkdirSync(path.resolve(TEST_DIR_PATH, 'public'), {
+        recursive: true,
+      })
+
+      // Run the CLI command
+      exec(
+        'cli/index.js init ./tmp/cli/init/public',
+        {
+          cwd: PROJECT_ROOT,
+        },
+        (error, stdout) => {
+          capturedError = error
+          capturedStdout = stdout
+          done()
+        },
+      )
+    })
+
+    it('should execute without errors', () => {
+      expect(capturedError).toBeNull()
+    })
+
+    it('should copy the service worker file to the given directory', () => {
+      expect(
+        fs.existsSync(
+          path.resolve(TEST_DIR_PATH, 'public/mockServiceWorker.js'),
+        ),
+      ).toBe(true)
+    })
+
+    it('should print a success message into stdout', () => {
+      expect(capturedStdout).toContain('Service Worker successfully created')
+    })
+  })
+
+  describe('given a non-existing public directory', () => {
+    let capturedError: Error
+
+    beforeAll((done) => {
+      exec(
+        'cli/index.js init ./tmp/cli/init/missing-public',
+        {
+          cwd: PROJECT_ROOT,
+        },
+        (error, stdout) => {
+          capturedError = error
+          done()
+        },
+      )
+    })
+
+    it('should return an exception', () => {
+      expect(capturedError).not.toBeNull()
+      expect(capturedError.message).toContain(
+        'Provided directory does not exist',
+      )
+    })
+
+    it('should not copy the service worker file', () => {
+      expect(
+        fs.existsSync(
+          path.resolve(TEST_DIR_PATH, 'missing-public/mockServiceWorker.js'),
+        ),
+      ).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Changes

Adds `msw init` command integration tests to catch issues when the worker file is not copied, or the error is thrown unexpectedly.

## GitHub

- Related to #132 