### PR TITLE
Supports path parameters in paths with query

### DIFF
--- a/src/handleRequestWith.ts
+++ b/src/handleRequestWith.ts
@@ -7,6 +7,7 @@ import {
   defaultContext,
 } from './handlers/requestHandler'
 import { resolveRelativeUrl } from './utils/resolveRelativeUrl'
+import { getCleanUrl } from './utils/getCleanUrl'
 import {
   ServiceWorkerMessage,
   createBroadcastChannel,
@@ -60,7 +61,9 @@ export const handleRequestWith = (
 
       // Retrieve request URL parameters based on the provided mask
       const params =
-        (mask && match(resolveRelativeUrl(mask), req.url).params) || {}
+        (mask &&
+          match(resolveRelativeUrl(mask), getCleanUrl(parsedUrl)).params) ||
+        {}
 
       const requestWithParams: MockedRequest = {
         ...req,

--- a/src/handlers/rest.ts
+++ b/src/handlers/rest.ts
@@ -15,6 +15,7 @@ import { xml } from '../context/xml'
 import { delay } from '../context/delay'
 import { fetch } from '../context/fetch'
 import { resolveRelativeUrl } from '../utils/resolveRelativeUrl'
+import { getCleanUrl } from '../utils/getCleanUrl'
 
 export enum RESTMethods {
   GET = 'GET',
@@ -46,7 +47,7 @@ const createRESTHandler = (method: RESTMethods) => {
       mask,
       predicate(req, parsedUrl) {
         // Ignore query parameters and hash when matching requests URI
-        const rawUrl = parsedUrl.origin + parsedUrl.pathname
+        const rawUrl = getCleanUrl(parsedUrl)
         const hasSameMethod = method === req.method
         const urlMatch = match(resolveRelativeUrl(mask), rawUrl)
 

--- a/src/utils/getCleanUrl.test.ts
+++ b/src/utils/getCleanUrl.test.ts
@@ -1,0 +1,31 @@
+import { getCleanUrl } from './getCleanUrl'
+
+describe('getCleanUrl', () => {
+  describe('given a URL without query parameters or hash', () => {
+    it('should return the URL as-is', () => {
+      const url = new URL('https://test.msw.io/')
+      expect(getCleanUrl(url)).toEqual('https://test.msw.io/')
+    })
+  })
+
+  describe('given a URL with a hash', () => {
+    it('should return a URL without hashes', () => {
+      const url = new URL('https://test.msw.io/path#hash')
+      expect(getCleanUrl(url)).toEqual('https://test.msw.io/path')
+    })
+  })
+
+  describe('given a URL with a query parameter', () => {
+    it('should return a URL without query parameters', () => {
+      const url = new URL('https://test.msw.io/path?hello=true')
+      expect(getCleanUrl(url)).toEqual('https://test.msw.io/path')
+    })
+  })
+
+  describe('given a URL with a query parameter and hash', () => {
+    it('should return a URL without query parameters and hashes', () => {
+      const url = new URL('https://test.msw.io/path?hello=true#hash')
+      expect(getCleanUrl(url)).toEqual('https://test.msw.io/path')
+    })
+  })
+})

--- a/src/utils/getCleanUrl.ts
+++ b/src/utils/getCleanUrl.ts
@@ -1,0 +1,6 @@
+/**
+ * Given a URL returns a URL string without query parameters and hashes.
+ */
+export function getCleanUrl(url: URL): string {
+  return url.origin + url.pathname
+}

--- a/test/rest-api/request-matching/uri.mocks.ts
+++ b/test/rest-api/request-matching/uri.mocks.ts
@@ -19,6 +19,16 @@ const worker = setupWorker(
     )
   }),
 
+  rest.get('https://test.msw.io/messages/:messageId/items', (req, res, ctx) => {
+    const { messageId } = req.params
+
+    return res(
+      ctx.json({
+        messageId,
+      }),
+    )
+  }),
+
   rest.get(/(.+?)\.google\.com\/path/, (req, res, ctx) => {
     return res(
       ctx.json({

--- a/test/rest-api/request-matching/uri.test.ts
+++ b/test/rest-api/request-matching/uri.test.ts
@@ -87,6 +87,36 @@ describe('REST: Request matching (URI)', () => {
 
       expect(res).toBeNull()
     })
+
+    it('should match a request with query parameters that matches the mask', async () => {
+      const res = await test.request({
+        url: 'https://test.msw.io/messages/abc-123/items?hello=true',
+      })
+      const status = res.status()
+      const headers = res.headers()
+      const body = await res.json()
+
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(body).toEqual({
+        messageId: 'abc-123',
+      })
+    })
+
+    it('should match a request with a hash that matches the mask', async () => {
+      const res = await test.request({
+        url: 'https://test.msw.io/messages/abc-123/items#hello',
+      })
+      const status = res.status()
+      const headers = res.headers()
+      const body = await res.json()
+
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(body).toEqual({
+        messageId: 'abc-123',
+      })
+    })
   })
 
   describe('given RegExp for request URI', () => {

--- a/test/support/runBrowserWith.ts
+++ b/test/support/runBrowserWith.ts
@@ -1,7 +1,8 @@
 import * as puppeteer from 'puppeteer'
 import { match } from 'node-match-path'
-import { SpawnServerOptions, spawnServer } from './spawnServer'
 import WebpackDevServer from 'webpack-dev-server'
+import { SpawnServerOptions, spawnServer } from './spawnServer'
+import { getCleanUrl } from '../../src/utils/getCleanUrl'
 
 /**
  * Requests a given URL within the test scenario's browser session.
@@ -17,9 +18,13 @@ export const createRequestHelper = (page: puppeteer.Page): RequestHelper => {
     url,
     fetchOptions,
     responsePredicate = (res) => {
+      // Remove query parameters from both URLs
+      const expectedUrl = getCleanUrl(new URL(url))
+      const actualUrl = getCleanUrl(new URL(res.url()))
+
       // Use native matcher to preserve the standard matching behavior
       // (i.e. disregard trailing slashes).
-      return match(url, res.url()).matches
+      return match(expectedUrl, actualUrl).matches
     },
   }) => {
     page.evaluate((a, b) => fetch(a, b), url, fetchOptions)


### PR DESCRIPTION
## Changes

- Removes URL query parameters and hashes before passing it to `node-match-path` to extract path parameters.
- Removes URL query parameters and hashes when comparing expected and actual request in test setup (for Puppeteer response awaiting).

## GitHub

- Fixes #140 