### PR TITLE
Replaces negative lookbehind with URL constructor

### DIFF
--- a/src/composeMocks/start/utils/getWorkerInstance.ts
+++ b/src/composeMocks/start/utils/getWorkerInstance.ts
@@ -1,7 +1,7 @@
 import { getWorkerByRegistration } from './getWorkerByRegistration'
 import { until } from '@open-draft/until'
 import { ServiceWorkerInstanceTuple } from '../../glossary'
-import { getAbsoluteWorkerUrl } from '../../../utils/getAbsoluteWorkerURl'
+import { getAbsoluteWorkerUrl } from '../../../utils/getAbsoluteWorkerUrl'
 
 /**
  * Returns an active Service Worker instance.

--- a/src/composeMocks/start/utils/getWorkerInstance.ts
+++ b/src/composeMocks/start/utils/getWorkerInstance.ts
@@ -1,6 +1,7 @@
 import { getWorkerByRegistration } from './getWorkerByRegistration'
 import { until } from '@open-draft/until'
 import { ServiceWorkerInstanceTuple } from '../../glossary'
+import { getAbsoluteWorkerUrl } from '../../../utils/getAbsoluteWorkerURl'
 
 /**
  * Returns an active Service Worker instance.
@@ -11,10 +12,7 @@ export const getWorkerInstance = async (
   options?: RegistrationOptions,
 ): Promise<ServiceWorkerInstanceTuple | null> => {
   // Resolve the absolute Service Worker URL
-  const absoluteWorkerUrl = (location.origin + url).replace(
-    /(?<!:)(\/*\.\/|\/{2,})/g,
-    '/',
-  )
+  const absoluteWorkerUrl = getAbsoluteWorkerUrl(url)
 
   const [, mockRegistrations] = await until(async () => {
     const registrations = await navigator.serviceWorker.getRegistrations()

--- a/src/utils/getAbsoluteWorkerUrl.test.ts
+++ b/src/utils/getAbsoluteWorkerUrl.test.ts
@@ -1,0 +1,11 @@
+import { getAbsoluteWorkerUrl } from './getAbsoluteWorkerUrl'
+
+describe('getAbsoluteWorkerUrl', () => {
+  describe('given a relative worker URL', () => {
+    it('should return an absolute URL against the current location', () => {
+      expect(getAbsoluteWorkerUrl('./mockServiceWorker.js')).toEqual(
+        'http://localhost/mockServiceWorker.js',
+      )
+    })
+  })
+})

--- a/src/utils/getAbsoluteWorkerUrl.ts
+++ b/src/utils/getAbsoluteWorkerUrl.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns an absolute Service Worker URL based on the given
+ * relative URL (known during the registration).
+ */
+export function getAbsoluteWorkerUrl(relativeUrl: string): string {
+  return (location.origin + relativeUrl).replace(/(?<!:)(\/*\.\/|\/{2,})/g, '/')
+}

--- a/src/utils/getAbsoluteWorkerUrl.ts
+++ b/src/utils/getAbsoluteWorkerUrl.ts
@@ -3,5 +3,5 @@
  * relative URL (known during the registration).
  */
 export function getAbsoluteWorkerUrl(relativeUrl: string): string {
-  return (location.origin + relativeUrl).replace(/(?<!:)(\/*\.\/|\/{2,})/g, '/')
+  return new URL(relativeUrl, location.origin).href
 }


### PR DESCRIPTION
## Changes

- Moves the logic that retrieves an absolute Service Worker URL into a separate module. Unit tests it.
- Replaces the usage of a negative lookbehind token (`?<:`), and the regular expression usage in that function, with a `URL` constructor (see [browser support](https://caniuse.com/#feat=url)).

## GitHub

- Originated from https://github.com/kentcdodds/bookshelf/issues/46
- Fixes #142 