### PR TITLE
Provides a meaningful error message when Service Worker is not supported

### DIFF
--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -24,6 +24,13 @@ export const createStart = (context: ComposeMocksInternalContext) => {
   return async function start(options?: StartOptions) {
     const resolvedOptions = Object.assign({}, DEFAULT_START_OPTIONS, options)
 
+    if (!('serviceWorker' in navigator)) {
+      console.error(
+        `[MSW] Failed to register a Service Worker: this browser does not support Service Workers (see https://caniuse.com/serviceworkers), or your application is running on an insecure host (consider using HTTPS for custom hostnames).`,
+      )
+      return null
+    }
+
     navigator.serviceWorker.addEventListener(
       'message',
       handleRequestWith(context.requestHandlers, resolvedOptions),


### PR DESCRIPTION
## Changes

- Provides an error message with helpful instructions when `navigator.serviceWorker` is not present. This can be caused by:

1. Service Worker is not supported in the current browser.
1. Application is served on an insecure host (i.e. using a custom hostname). 

## GitHub

- Relates to #147 