### PR TITLE
fetch: Gets JSON body only if the respective Content-Type is set

### DIFF
--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -3,7 +3,13 @@ import { MockedRequest } from '../handlers/requestHandler'
 const gracefully = <ResponseType>(
   promise: Promise<Response>,
 ): Promise<ResponseType> => {
-  return promise.then((res) => res.json().catch(() => res.text()))
+  return promise.then((res) => {
+    if (res.headers.get('content-type')?.includes('json')) {
+      return res.json()
+    }
+
+    return res.text()
+  })
 }
 
 export const augmentRequestInit = (requestInit: RequestInit): RequestInit => {


### PR DESCRIPTION
## Changes

- Removes the Promise chain in `graceful` utility function.
- Improves error handling, as exceptions during `res.json()`/`res.text()` will now bubble to the call surface.
- Fixes an issue that resulted into `res.text()` being called when the response stream is locked.

## GitHub

- Fixes #150 