### PR TITLE
Default mockServiceWorker.js URL

### DIFF
--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -11,7 +11,7 @@ import { requestIntegrityCheck } from '../../utils/requestIntegrityCheck'
 
 const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
   serviceWorker: {
-    url: './mockServiceWorker.js',
+    url: '/mockServiceWorker.js',
     options: null as any,
   },
   quiet: false,


### PR DESCRIPTION
- Fixes #152 

Modify the default url the mockServiceWorker.js file is served from to be the domain root rather than relative to the starting url