### PR TITLE
Unregisters itself when clients.matchAll() is empty

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -53,10 +53,12 @@ self.addEventListener('message', async function (event) {
     }
 
     case 'CLIENT_CLOSED': {
-      delete clients[clientId]
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
-      if (Object.keys(clients).length === 0) {
+      if (remainingClients.length === 0) {
         self.registration.unregister()
       }
 


### PR DESCRIPTION
## GitHub

- Closes #105 
- Fixes #139 