### PR TITLE
Fixes a broken "request.body" retrieval in the Service Worker

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -107,10 +107,9 @@ self.addEventListener('fetch', async function (event) {
       }
 
       const reqHeaders = serializeHeaders(request.headers)
-      const body = await request
-        .json()
-        .catch(() => request.text())
-        .catch(() => null)
+      const body = request.headers.get('content-type')?.includes('json')
+        ? await request.json()
+        : await request.text()
 
       const rawClientMessage = await sendToClient(client, {
         type: 'REQUEST',


### PR DESCRIPTION
> These changes bump the integrity of the Service Worker file.

## Changes

- Adopts a similar textual/json request body retrieval logic in the Service Worker file.
- Behaves correctly in accordance to the specification: if you specify a JSON-like request body, it must be a valid JSON. If `request.json()` fails, it's most likely means an invalid JSON in a request's body, or an invalid `Content-Type` request header. This must not be silenced. 

## GitHub

- Fixes #165 
- Related to #150 