### PR TITLE
logger: Compares "req.referrer" to "req.url.origin" to determine if request is relative

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -9,8 +9,8 @@ export const log = (
   res: ResponseWithSerializedHeaders,
   handler: RequestHandler<any>,
 ) => {
-  const isLocal = req.url.origin.startsWith(req.referrer)
-  const publicUrl = isLocal
+  const isRelativeRequest = req.referrer.startsWith(req.url.origin)
+  const publicUrl = isRelativeRequest
     ? req.url.pathname
     : format({
         protocol: req.url.protocol,


### PR DESCRIPTION
## Changes

- Compares `req.referrer` to `req.url.origin`, because referrer contains a trailing slash, while origin does not.

## GitHub

- Fixes #164 