### PR TITLE
Parses a JSON request body of the intercepted request

### DIFF
--- a/src/utils/getJsonBody.test.ts
+++ b/src/utils/getJsonBody.test.ts
@@ -1,0 +1,15 @@
+import { getJsonBody } from './getJsonBody'
+
+describe('getJsonBody', () => {
+  describe('given a valid JSON', () => {
+    it('should return a parsed object', () => {
+      expect(getJsonBody('{"prop":"value"}')).toEqual({ prop: 'value' })
+    })
+  })
+
+  describe('given an invalid JSON', () => {
+    it('should return it as text without changes', () => {
+      expect(getJsonBody('{"prop:"value}')).toEqual('{"prop:"value}')
+    })
+  })
+})

--- a/src/utils/getJsonBody.ts
+++ b/src/utils/getJsonBody.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns a parsed object from a given valid JSON string,
+ * otherwise returns as text without parsing.
+ */
+export function getJsonBody(body: string) {
+  try {
+    return JSON.parse(body)
+  } catch (error) {
+    return body
+  }
+}

--- a/src/utils/getResponse.ts
+++ b/src/utils/getResponse.ts
@@ -55,6 +55,8 @@ export const getResponse = async <
     context,
   )
 
+  // Handle a scenario when a request handler is present,
+  // but returns no mocked response (i.e. misses a `return res()` statement).
   if (!mockedResponse) {
     return {
       response: null,

--- a/test/rest-api/body.mocks.ts
+++ b/test/rest-api/body.mocks.ts
@@ -1,0 +1,15 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.post('/login', (req, res, ctx) => {
+    const { body } = req
+
+    if (typeof body === 'object') {
+      return res(ctx.json(body))
+    }
+
+    return res(ctx.text(body))
+  }),
+)
+
+worker.start()

--- a/test/rest-api/body.test.ts
+++ b/test/rest-api/body.test.ts
@@ -1,0 +1,87 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+
+describe('REST: Request body', () => {
+  let test: TestAPI
+
+  beforeAll(async () => {
+    test = await runBrowserWith(path.resolve(__dirname, 'body.mocks.ts'))
+  })
+
+  afterAll(() => {
+    return test.cleanup()
+  })
+
+  describe('when I reference "req.body" inside a request handler', () => {
+    describe('and I performed a request with a text body', () => {
+      it('should return a text request body as-is', async () => {
+        const res = await test.request({
+          url: `${test.origin}/login`,
+          fetchOptions: {
+            method: 'POST',
+            body: 'text-body',
+          },
+        })
+
+        const body = await res.text()
+
+        expect(body).toEqual('text-body')
+      })
+    })
+
+    describe('and I performed a request with a JSON body without any "Content-Type" header', () => {
+      it('should return a text request body as-is', async () => {
+        const res = await test.request({
+          url: `${test.origin}/login`,
+          fetchOptions: {
+            method: 'POST',
+            body: JSON.stringify({
+              json: 'body',
+            }),
+          },
+        })
+
+        const body = await res.text()
+
+        expect(body).toEqual('{"json":"body"}')
+      })
+    })
+
+    describe('and I performed a request with a JSON body with a "Content-Type" header', () => {
+      it('should return a text request body as-is', async () => {
+        const res = await test.request({
+          url: `${test.origin}/login`,
+          fetchOptions: {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              json: 'body',
+            }),
+          },
+        })
+
+        const body = await res.json()
+
+        expect(body).toEqual({
+          json: 'body',
+        })
+      })
+    })
+  })
+
+  // it('should receive mocked response', async () => {
+  //   const res = await test.request({
+  //     url: 'https://api.github.com/users/octocat',
+  //   })
+  //   const body = await res.json()
+
+  //   expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  //   expect(res.status()).toBe(200)
+  //   expect(body).toEqual({
+  //     name: 'John Maverick',
+  //     originalUsername: 'octocat',
+  //   })
+  // })
+})

--- a/test/rest-api/body.test.ts
+++ b/test/rest-api/body.test.ts
@@ -70,18 +70,4 @@ describe('REST: Request body', () => {
       })
     })
   })
-
-  // it('should receive mocked response', async () => {
-  //   const res = await test.request({
-  //     url: 'https://api.github.com/users/octocat',
-  //   })
-  //   const body = await res.json()
-
-  //   expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
-  //   expect(res.status()).toBe(200)
-  //   expect(body).toEqual({
-  //     name: 'John Maverick',
-  //     originalUsername: 'octocat',
-  //   })
-  // })
 })


### PR DESCRIPTION
## Changes

- Parses a JSON request body of the intercepted request, so now `req.body` is contextually an Object or a string, with no need to explicitly parse it.

## GitHub

- Fixes #159 

## Roadmap

- [x] Parse a response JSON body when viewing the logs