### PR TITLE
setupServer: Parses a request JSON body

### DIFF
--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -5,6 +5,7 @@ import {
 } from 'node-request-interceptor'
 import { RequestHandler, MockedRequest } from '../handlers/requestHandler'
 import { getResponse } from '../utils/getResponse'
+import { parseRequestBody } from '../utils/parseRequestBody'
 
 /**
  * Sets up a server-side requests interception with the given mock definition.
@@ -19,11 +20,16 @@ export const setupServer = (...handlers: RequestHandler<any, any>[]) => {
     listen() {
       interceptor = new RequestInterceptor()
       interceptor.use(async (req) => {
+        const requestHeaders = new Headers(
+          flattenHeadersObject(req.headers || {}),
+        )
+
         const mockedRequest: MockedRequest = {
           url: req.url,
           method: req.method,
-          body: req.body || '',
-          headers: new Headers(flattenHeadersObject(req.headers || {})),
+          // Parse the request's body based on the "Content-Type" header.
+          body: parseRequestBody(req.body, requestHeaders),
+          headers: requestHeaders,
           params: {},
           redirect: 'manual',
           referrer: '',

--- a/src/utils/parseRequestBody.ts
+++ b/src/utils/parseRequestBody.ts
@@ -1,0 +1,17 @@
+import { getJsonBody } from './getJsonBody'
+import { MockedRequest } from '../handlers/requestHandler'
+
+type Request = Partial<Pick<MockedRequest, 'headers' | 'body'>>
+
+export function parseRequestBody(
+  body?: MockedRequest['body'],
+  headers?: MockedRequest['headers'],
+) {
+  if (body) {
+    // If the intercepted request's body has a JSON Content-Type
+    // parse it into an object, otherwise leave as-is.
+    const isJsonBody = headers?.get('content-type')?.includes('json')
+
+    return isJsonBody && typeof body !== 'object' ? getJsonBody(body) : body
+  }
+}

--- a/test/msw-api/setup-server/fetch.test.ts
+++ b/test/msw-api/setup-server/fetch.test.ts
@@ -14,9 +14,16 @@ describe('setupServer / fetch', () => {
         }),
       )
     }),
+    rest.post('https://test.msw.io', (req, res, ctx) => {
+      return res(
+        ctx.status(403),
+        ctx.set('x-header', 'yes'),
+        ctx.json(req.body as Record<string, any>),
+      )
+    }),
   )
 
-  beforeAll(async () => {
+  beforeAll(() => {
     server.listen()
   })
 
@@ -24,7 +31,7 @@ describe('setupServer / fetch', () => {
     server.close()
   })
 
-  describe('given I perform a fetch request', () => {
+  describe('given I perform a GET request using fetch', () => {
     let res: Response
 
     beforeAll(async () => {
@@ -46,6 +53,38 @@ describe('setupServer / fetch', () => {
       expect(body).toEqual({
         firstName: 'John',
         age: 32,
+      })
+    })
+  })
+
+  describe('given I perform a POST request using fetch', () => {
+    let res: Response
+
+    beforeAll(async () => {
+      res = await fetch('https://test.msw.io', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          payload: 'info',
+        }),
+      })
+    })
+
+    it('should return mocked status code', () => {
+      expect(res.status).toEqual(403)
+    })
+
+    it('should return mocked headers', () => {
+      expect(res.headers.get('content-type')).toEqual('application/json')
+      expect(res.headers.get('x-header')).toEqual('yes')
+    })
+
+    it('should return mocked and parsed JSON body', async () => {
+      const body = await res.json()
+      expect(body).toEqual({
+        payload: 'info',
       })
     })
   })


### PR DESCRIPTION
## Changes

- Isolates a request body parsing functionality into `parseRequestBody` function.
- Reuses `parseRequestBody` function for both client-side (`handleRequestWith`), and Node (`setupServer`).
- Adds an integration test that asserts `Content-Type: application/json` request body to be parsed in the `req.body` reference of the request handler.

## GitHub

- Fixes #171 
- Follow up to #159, #168 

