### PR TITLE
Parses empty GET request body as undefined

### DIFF
--- a/src/context/text.ts
+++ b/src/context/text.ts
@@ -1,7 +1,7 @@
 import { ResponseTransformer } from '../response'
 
 /**
- * Sets the given text as the body of the response.
+ * Sets a given text as a "Cotent-Type: text/plain" body of the response.
  * @example
  * res(text('Message'))
  */

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -23,6 +23,7 @@ import { prepareRequest } from './utils/logger/prepareRequest'
 import { prepareResponse } from './utils/logger/prepareResponse'
 import { getTimestamp } from './utils/logger/getTimestamp'
 import { styleStatusCode } from './utils/logger/styleStatusCode'
+import { isStringEqual } from './utils/isStringEqual'
 
 export enum RESTMethods {
   GET = 'GET',
@@ -54,7 +55,7 @@ const createRestHandler = (method: RESTMethods) => {
       predicate(req) {
         // Ignore query parameters and hash when matching requests URI
         const cleanUrl = getCleanUrl(req.url)
-        const hasSameMethod = method.toUpperCase() === req.method.toUpperCase()
+        const hasSameMethod = isStringEqual(method, req.method)
         const urlMatch = match(resolveRelativeUrl(mask), cleanUrl)
 
         return hasSameMethod && urlMatch.matches

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -73,7 +73,7 @@ export const handleRequestWith = (
       }
 
       // Handle a scenario when there is a request handler,
-      // but its response resolver didn't return any response.
+      // but it doesn't return any mocked response.
       if (!response) {
         console.warn(
           '[MSW] Expected a mocking resolver function to return a mocked response Object, but got: %s. Original response is going to be used instead.',

--- a/src/utils/isStringEqual.test.ts
+++ b/src/utils/isStringEqual.test.ts
@@ -1,0 +1,45 @@
+import { isStringEqual } from './isStringEqual'
+
+describe('isStringEqual', () => {
+  describe('given two uppercase strings', () => {
+    describe('and the strings are equal', () => {
+      it('should return true', () => {
+        expect(isStringEqual('GET', 'GET')).toBe(true)
+      })
+    })
+
+    describe('and the strings are not equal', () => {
+      it('should return false', () => {
+        expect(isStringEqual('GET', 'POST')).toBe(false)
+      })
+    })
+  })
+
+  describe('given two lowercase strings', () => {
+    describe('and the strings are equal', () => {
+      it('should return true', () => {
+        expect(isStringEqual('get', 'get')).toBe(true)
+      })
+    })
+
+    describe('and the strings are not equal', () => {
+      it('should return false', () => {
+        expect(isStringEqual('get', 'post')).toBe(false)
+      })
+    })
+  })
+
+  describe('given two strings cased differently', () => {
+    describe('and the strings are equal', () => {
+      it('should return true', () => {
+        expect(isStringEqual('get', 'GET')).toBe(true)
+      })
+    })
+
+    describe('and the strings are not equal', () => {
+      it('should return false', () => {
+        expect(isStringEqual('get', 'POST')).toBe(false)
+      })
+    })
+  })
+})

--- a/src/utils/isStringEqual.ts
+++ b/src/utils/isStringEqual.ts
@@ -1,0 +1,6 @@
+/**
+ * Performs a case-insensitive comparison of two given strings.
+ */
+export function isStringEqual(actual: string, expected: string): boolean {
+  return actual.toLowerCase() === expected.toLowerCase()
+}

--- a/src/utils/parseRequestBody.ts
+++ b/src/utils/parseRequestBody.ts
@@ -1,8 +1,6 @@
 import { getJsonBody } from './getJsonBody'
 import { MockedRequest } from '../handlers/requestHandler'
 
-type Request = Partial<Pick<MockedRequest, 'headers' | 'body'>>
-
 export function parseRequestBody(
   body?: MockedRequest['body'],
   headers?: MockedRequest['headers'],
@@ -14,4 +12,7 @@ export function parseRequestBody(
 
     return isJsonBody && typeof body !== 'object' ? getJsonBody(body) : body
   }
+
+  // Return whatever falsey body value is given.
+  return body
 }

--- a/test/rest-api/body.mocks.ts
+++ b/test/rest-api/body.mocks.ts
@@ -1,15 +1,14 @@
 import { setupWorker, rest } from 'msw'
 
+function handleRequestBody(req, res, ctx) {
+  const { body } = req
+
+  return res(ctx.json({ body }))
+}
+
 const worker = setupWorker(
-  rest.post('/login', (req, res, ctx) => {
-    const { body } = req
-
-    if (typeof body === 'object') {
-      return res(ctx.json(body))
-    }
-
-    return res(ctx.text(body))
-  }),
+  rest.get('/login', handleRequestBody),
+  rest.post('/login', handleRequestBody),
 )
 
 worker.start()

--- a/test/rest-api/body.test.ts
+++ b/test/rest-api/body.test.ts
@@ -13,7 +13,33 @@ describe('REST: Request body', () => {
   })
 
   describe('when I reference "req.body" inside a request handler', () => {
-    describe('and I performed a request with a text body', () => {
+    describe('and I performed a GET request without a body', () => {
+      it('should not return any request body', async () => {
+        const res = await test.request({
+          url: `${test.origin}/login`,
+        })
+        const body = await res.json()
+
+        expect(body).toEqual({ body: undefined })
+      })
+    })
+
+    describe('and I performed a POST request with intentionally empty body', () => {
+      it('should return the request body as-is', async () => {
+        const res = await test.request({
+          url: `${test.origin}/login`,
+          fetchOptions: {
+            method: 'POST',
+            body: '',
+          },
+        })
+        const body = await res.json()
+
+        expect(body).toEqual({ body: '' })
+      })
+    })
+
+    describe('and I performed a POST request with a text body', () => {
       it('should return a text request body as-is', async () => {
         const res = await test.request({
           url: `${test.origin}/login`,
@@ -22,14 +48,13 @@ describe('REST: Request body', () => {
             body: 'text-body',
           },
         })
+        const body = await res.json()
 
-        const body = await res.text()
-
-        expect(body).toEqual('text-body')
+        expect(body).toEqual({ body: 'text-body' })
       })
     })
 
-    describe('and I performed a request with a JSON body without any "Content-Type" header', () => {
+    describe('and I performed a POST request with a JSON body without any "Content-Type" header', () => {
       it('should return a text request body as-is', async () => {
         const res = await test.request({
           url: `${test.origin}/login`,
@@ -40,14 +65,13 @@ describe('REST: Request body', () => {
             }),
           },
         })
-
         const body = await res.text()
 
-        expect(body).toEqual('{"json":"body"}')
+        expect(body).toEqual(`{"body":"{\\"json\\":\\"body\\"}"}`)
       })
     })
 
-    describe('and I performed a request with a JSON body with a "Content-Type" header', () => {
+    describe('and I performed a POST request with a JSON body with a "Content-Type" header', () => {
       it('should return a text request body as-is', async () => {
         const res = await test.request({
           url: `${test.origin}/login`,
@@ -61,11 +85,12 @@ describe('REST: Request body', () => {
             }),
           },
         })
-
         const body = await res.json()
 
         expect(body).toEqual({
-          json: 'body',
+          body: {
+            json: 'body',
+          },
         })
       })
     })

--- a/test/support/spawnServer.ts
+++ b/test/support/spawnServer.ts
@@ -29,9 +29,14 @@ Loaded mock definition:
 %s
 
 Resolved "msw" module to:
-%s`,
+%s
+
+Using Service Worker build:
+%s
+`,
     chalk.magenta(absoluteMockPath),
     chalk.magenta(mswModulePath),
+    chalk.magenta(SERVICE_WORKER_BUILD_PATH),
   )
 
   const mockDefsContent = fs.readFileSync(absoluteMockPath).toString()


### PR DESCRIPTION
## Changes

- Treats _only_ `GET` requests with empty body as `undefined` during the parsing of the message received from the service worker.

> The captured request's `req.body` is an empty string (`""`) even if not set.

- Removes unused type definitions.
- Adds integration tests for `GET` request with no body.

## GitHub

- Fixes #175 