### PR TITLE
Lists "node-request-interceptor" as an external dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "graphql": "^15.0.0",
     "headers-utils": "^1.1.9",
     "node-match-path": "^0.4.2",
-    "node-request-interceptor": "^0.2.2",
+    "node-request-interceptor": "^0.2.4",
     "statuses": "^2.0.0",
     "yargs": "^15.3.1"
   },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -65,7 +65,15 @@ const buildUdm = {
 
 const buildNode = {
   input: 'src/node/index.ts',
-  external: ['http', 'https', 'util', 'events', 'tty', 'os'],
+  external: [
+    'http',
+    'https',
+    'util',
+    'events',
+    'tty',
+    'os',
+    'node-request-interceptor',
+  ],
   output: {
     file: 'node/index.js',
     format: 'cjs',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5588,10 +5588,10 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-node-request-interceptor@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.2.2.tgz#bfaf7887cda70833b1be95bcbedb689b64b5257b"
-  integrity sha512-pljLfJrbY3fLKwPQJ773a0M+SDfQVXYIBa3bkTqDVmqzHYLVxbwjcKefk93Yfzjj7M3x52pvTdNHcJNxTVpPcA==
+node-request-interceptor@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.2.4.tgz#f03a1b874823d0bea311a14280227707be946298"
+  integrity sha512-/htjDLmygBczT5qYPaSxfAEtMkc0LGuH6jqAP1o+TKfQh6yQfFyTtac25cpY8+pb4EawHljCLUN7dCeed9SdPA==
   dependencies:
     debug "^4.1.1"
     headers-utils "^1.1.3"


### PR DESCRIPTION
## Changes

- Specifies `node-request-interceptor` in the `rollup.config.js` of the NodeJS bundle. Without this, the NRI is bundled in `node/index.js`, and does not respect the latest version of NRI installed alongside `msw` installation. This makes MSW>NRI and latest NRI out of sync.

## GitHub

- Fixes #180