### PR TITLE
Uses "req.headers.getAllHeaders()" for response patching

### DIFF
--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -32,7 +32,7 @@ const worker = setupWorker(
   rest.get('https://test.msw.io/headers', async (req, res, ctx) => {
     const originalResponse = await ctx.fetch('/headers-proxy', {
       method: 'POST',
-      headers: req.headers,
+      headers: req.headers.getAllHeaders(),
     })
 
     return res(ctx.json(originalResponse))


### PR DESCRIPTION
## Changes

- Uses `req.headers.getAllHeaders()` when constructing an original request via `ctx.fetch()`. This ensures typing compatibility between `Headers` and `HeadersInit` (expected by fetch options).

## GitHub

- Closes #178 