### PR TITLE
fix: move cookie types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "sideEffects": false,
   "dependencies": {
     "@open-draft/until": "^1.0.0",
+    "@types/cookie": "^0.3.3",
     "chalk": "^4.0.0",
     "cookie": "^0.4.1",
     "graphql": "^15.0.0",
@@ -65,7 +66,6 @@
     "@rollup/plugin-json": "^4.0.3",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.2",
-    "@types/cookie": "^0.3.3",
     "@types/jest": "^25.2.1",
     "@types/node": "^13.7.7",
     "@types/node-fetch": "^2.5.7",


### PR DESCRIPTION
Since we expose the types through our typings we need them to be
installed by using libraries. Therefore they are added to the
dependencies.

Closes #185