### PR TITLE
resolveRelativeUrl: Handles "location" object in Node

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,17 +1,17 @@
 const fetch = require('node-fetch')
 
-/**
- * Provide "Headers" to be accessible in test cases
- * since they are not, by default.
- */
-Object.defineProperty(window, 'Headers', {
-  writable: true,
-  value: fetch.Headers,
-})
+if (typeof window !== 'undefined') {
+  // Provide "Headers" to be accessible in test cases
+  // since they are not, by default.
+  Object.defineProperty(window, 'Headers', {
+    writable: true,
+    value: fetch.Headers,
+  })
 
-Object.defineProperty(navigator, 'serviceWorker', {
-  writable: false,
-  value: {
-    addEventListener: () => null,
-  },
-})
+  Object.defineProperty(navigator || {}, 'serviceWorker', {
+    writable: false,
+    value: {
+      addEventListener: () => null,
+    },
+  })
+}

--- a/src/utils/resolveRelativeUrl.node.test.ts
+++ b/src/utils/resolveRelativeUrl.node.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import { resolveRelativeUrl } from './resolveRelativeUrl'
+
+test('leaves relative URL intact', () => {
+  expect(resolveRelativeUrl('/reviews')).toBe('/reviews')
+})
+
+test('leaves absolute URL intact', () => {
+  expect(resolveRelativeUrl('https://api.mswjs.io/users')).toBe(
+    'https://api.mswjs.io/users',
+  )
+})

--- a/src/utils/resolveRelativeUrl.test.ts
+++ b/src/utils/resolveRelativeUrl.test.ts
@@ -1,0 +1,11 @@
+import { resolveRelativeUrl } from './resolveRelativeUrl'
+
+test('resolves relative URL against current location', () => {
+  expect(resolveRelativeUrl('/reviews')).toBe('http://localhost/reviews')
+})
+
+test('leaves absolute URL intact', () => {
+  expect(resolveRelativeUrl('https://api.mswjs.io/users')).toBe(
+    'https://api.mswjs.io/users',
+  )
+})

--- a/src/utils/resolveRelativeUrl.ts
+++ b/src/utils/resolveRelativeUrl.ts
@@ -5,7 +5,11 @@ import { Mask } from '../setupWorker/glossary'
  * Ignores regular expressions.
  */
 export const resolveRelativeUrl = (mask: Mask) => {
+  // Global `location` object doesn't exist in Node.
+  // Relative request predicate URL cannot become absolute.
+  const hasLocation = typeof location !== 'undefined'
+
   return typeof mask === 'string' && mask.startsWith('/')
-    ? `${location.origin}${mask}`
+    ? `${hasLocation ? location.origin : ''}${mask}`
     : mask
 }

--- a/test/msw-api/setup-server/relative-url.test.ts
+++ b/test/msw-api/setup-server/relative-url.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+
+const server = setupServer(
+  rest.get('/books', (req, res, ctx) => {
+    return res(ctx.json([1, 2, 3]))
+  }),
+  rest.get('https://api.backend.com/path', (req, res, ctx) => {
+    return res(ctx.json({ success: true }))
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+test('tolerates relative request handlers on the server', async () => {
+  const res = await fetch('https://api.backend.com/path')
+  const body = await res.json()
+
+  expect(res.status).toBe(200)
+  expect(body).toEqual({ success: true })
+})

--- a/test/msw-api/setup-server/resetHandlers.test.ts
+++ b/test/msw-api/setup-server/resetHandlers.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import fetch from 'node-fetch'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'

--- a/test/msw-api/setup-server/restoreHandlers.test.ts
+++ b/test/msw-api/setup-server/restoreHandlers.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import fetch from 'node-fetch'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'

--- a/test/msw-api/setup-server/use.test.ts
+++ b/test/msw-api/setup-server/use.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import fetch from 'node-fetch'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'


### PR DESCRIPTION
## Changes

- During the lookup for request handlers, the `rest` handlers predicate relying on `resolveRelativeUrl` does not attempt to access `location.origin` when executed in Node.

## GitHub

- Fixes #193 