### PR TITLE
Uses actual repository URL in the activation message

### DIFF
--- a/src/setupWorker/start/utils/activateMocking.ts
+++ b/src/setupWorker/start/utils/activateMocking.ts
@@ -22,9 +22,7 @@ export const activateMocking = (
             'font-weight:bold',
             'font-weight:normal',
           )
-          console.log(
-            'Found an issue? https://github.com/open-draft/msw/issues',
-          )
+          console.log('Found an issue? https://github.com/mswjs/msw/issues')
           console.groupEnd()
         }
 


### PR DESCRIPTION
The current repository URL points to the old organization. 