### PR TITLE
Defers network requests until Service Worker is ready

### DIFF
--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -29,7 +29,7 @@ export interface StartOptions {
 
   /**
    * Defer any network requests until the Service Worker
-   * instance is ready.
+   * instance is ready. Defaults to `true`.
    */
   waitUntilReady?: boolean
 }

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -20,7 +20,18 @@ export interface StartOptions {
     url?: string
     options?: RegistrationOptions
   }
+
+  /**
+   * Disable the logging of captured requests
+   * into browser's console.
+   */
   quiet?: boolean
+
+  /**
+   * Defer any network requests until the Service Worker
+   * instance is ready.
+   */
+  waitUntilReady?: boolean
 }
 
 export type RequestHandlersList = RequestHandler<any, any>[]

--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -8,6 +8,7 @@ import {
 } from '../glossary'
 import { handleRequestWith } from '../../utils/handleRequestWith'
 import { requestIntegrityCheck } from '../../utils/internal/requestIntegrityCheck'
+import { deferNetworkRequests } from '../../utils/deferNetworkRequests'
 
 const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
   serviceWorker: {
@@ -15,62 +16,64 @@ const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
     options: null as any,
   },
   quiet: false,
+  waitUntilReady: true,
 }
 
 export const createStart = (context: ComposeMocksInternalContext) => {
   /**
    * Registers and activates the mock Service Worker.
    */
-  return async function start(options?: StartOptions) {
+  return function start(options?: StartOptions) {
     const resolvedOptions = Object.assign({}, DEFAULT_START_OPTIONS, options)
 
-    if (!('serviceWorker' in navigator)) {
-      console.error(
-        `[MSW] Failed to register a Service Worker: this browser does not support Service Workers (see https://caniuse.com/serviceworkers), or your application is running on an insecure host (consider using HTTPS for custom hostnames).`,
-      )
-      return null
-    }
-
-    navigator.serviceWorker.addEventListener(
-      'message',
-      handleRequestWith(context, resolvedOptions),
-    )
-
-    const [, instance] = await until<ServiceWorkerInstanceTuple | null>(() =>
-      getWorkerInstance(
-        resolvedOptions.serviceWorker.url,
-        resolvedOptions.serviceWorker.options,
-      ),
-    )
-
-    if (!instance) {
-      return null
-    }
-
-    const [worker, registration] = instance
-
-    if (!worker) {
-      return null
-    }
-
-    context.worker = worker
-    context.registration = registration
-
-    window.addEventListener('beforeunload', () => {
-      if (worker.state !== 'redundant') {
-        // Notify the Service Worker that this client has closed.
-        // Internally, it's similar to disabling the mocking, only
-        // client close event has a handler that self-terminates
-        // the Service Worker when there are no open clients.
-        worker.postMessage('CLIENT_CLOSED')
+    const startWorkerInstance = async () => {
+      if (!('serviceWorker' in navigator)) {
+        console.error(
+          `[MSW] Failed to register a Service Worker: this browser does not support Service Workers (see https://caniuse.com/serviceworkers), or your application is running on an insecure host (consider using HTTPS for custom hostnames).`,
+        )
+        return null
       }
-    })
 
-    // Check if the active Service Worker is the latest published one
-    const [integrityError] = await until(() => requestIntegrityCheck(worker))
+      navigator.serviceWorker.addEventListener(
+        'message',
+        handleRequestWith(context, resolvedOptions),
+      )
 
-    if (integrityError) {
-      console.error(`\
+      const [, instance] = await until<ServiceWorkerInstanceTuple | null>(() =>
+        getWorkerInstance(
+          resolvedOptions.serviceWorker.url,
+          resolvedOptions.serviceWorker.options,
+        ),
+      )
+
+      if (!instance) {
+        return null
+      }
+
+      const [worker, registration] = instance
+
+      if (!worker) {
+        return null
+      }
+
+      context.worker = worker
+      context.registration = registration
+
+      window.addEventListener('beforeunload', () => {
+        if (worker.state !== 'redundant') {
+          // Notify the Service Worker that this client has closed.
+          // Internally, it's similar to disabling the mocking, only
+          // client close event has a handler that self-terminates
+          // the Service Worker when there are no open clients.
+          worker.postMessage('CLIENT_CLOSED')
+        }
+      })
+
+      // Check if the active Service Worker is the latest published one
+      const [integrityError] = await until(() => requestIntegrityCheck(worker))
+
+      if (integrityError) {
+        console.error(`\
 [MSW] Detected outdated Service Worker: ${integrityError.message}
 
 The mocking is still enabled, but it's highly recommended that you update your Service Worker by running:
@@ -80,18 +83,30 @@ $ npx msw init <PUBLIC_DIR>
 This is necessary to ensure that the Service Worker is in sync with the library to guarantee its stability.
 If this message still persists after updating, please report an issue: https://github.com/open-draft/msw/issues\
       `)
+      }
+
+      // Signal the Service Worker to enable requests interception
+      const [activationError] = await until(() =>
+        activateMocking(worker, options),
+      )
+
+      if (activationError) {
+        console.error('Failed to enable mocking', activationError)
+        return null
+      }
+
+      return registration
     }
 
-    // Signal the Service Worker to enable requests interception
-    const [activationError] = await until(() =>
-      activateMocking(worker, options),
-    )
+    const workerRegistration = startWorkerInstance()
 
-    if (activationError) {
-      console.error('Failed to enable mocking', activationError)
-      return null
+    // Defer any network requests until the Service Worker instance is ready.
+    // This prevents a race condition between the Service Worker registration
+    // and application's runtime requests (i.e. requests on mount).
+    if (resolvedOptions.waitUntilReady) {
+      deferNetworkRequests(workerRegistration)
     }
 
-    return registration
+    return workerRegistration
   }
 }

--- a/src/utils/deferNetworkRequests.ts
+++ b/src/utils/deferNetworkRequests.ts
@@ -1,0 +1,38 @@
+/**
+ * Intercepts and defers any requests on the page
+ * until the Service Worker instance is ready.
+ */
+export function deferNetworkRequests(
+  workerReady: Promise<ServiceWorkerRegistration | null>,
+) {
+  // Defer `XMLHttpRequest` until the Service Worker is ready.
+  const originalXhrSend = window.XMLHttpRequest.prototype.send
+  const restoreXhrSend = function (
+    this: XMLHttpRequest,
+    ...args: Parameters<XMLHttpRequest['send']>
+  ) {
+    window.XMLHttpRequest.prototype.send = originalXhrSend
+    this.send(...args)
+  }
+
+  window.XMLHttpRequest.prototype.send = function (
+    ...args: Parameters<XMLHttpRequest['send']>
+  ) {
+    workerReady
+      .then(() => restoreXhrSend.call(this, ...args))
+      .catch(() => restoreXhrSend.call(this, ...args))
+  }
+
+  // Defer `fetch` requests until the Service Worker is ready.
+  const originalFetch = window.fetch
+  const restoreFetch = (...args: Parameters<typeof window.fetch>) => {
+    window.fetch = originalFetch
+    return window.fetch(...args)
+  }
+
+  window.fetch = async (...args) => {
+    return workerReady
+      .then(() => restoreFetch(...args))
+      .catch(() => restoreFetch(...args))
+  }
+}

--- a/test/msw-api/setup-worker/start/wait-until-ready.false.mocks.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.false.mocks.ts
@@ -4,6 +4,9 @@ const worker = setupWorker(
   rest.get('/numbers', (req, res, ctx) => {
     return res(ctx.json([1, 2, 3]))
   }),
+  rest.get('/letters', (req, res, ctx) => {
+    return res(ctx.json(['a', 'b', 'c']))
+  }),
 )
 
 worker.start({
@@ -14,3 +17,7 @@ worker.start({
 // there is a race condition between the worker's registration and
 // any runtime requests that may happen meanwhile.
 fetch('/numbers')
+
+const req = new XMLHttpRequest()
+req.open('GET', '/letters')
+req.send()

--- a/test/msw-api/setup-worker/start/wait-until-ready.false.mocks.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.false.mocks.ts
@@ -1,0 +1,16 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/numbers', (req, res, ctx) => {
+    return res(ctx.json([1, 2, 3]))
+  }),
+)
+
+worker.start({
+  waitUntilReady: false,
+})
+
+// Without deferring the network requests until the worker is ready,
+// there is a race condition between the worker's registration and
+// any runtime requests that may happen meanwhile.
+fetch('/numbers')

--- a/test/msw-api/setup-worker/start/wait-until-ready.mocks.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.mocks.ts
@@ -4,6 +4,9 @@ const worker = setupWorker(
   rest.get('/numbers', (req, res, ctx) => {
     return res(ctx.json([1, 2, 3]))
   }),
+  rest.get('/letters', (req, res, ctx) => {
+    return res(ctx.json(['a', 'b', 'c']))
+  }),
 )
 
 // By default, starting the worker defers the network requests
@@ -14,3 +17,7 @@ worker.start()
 // worker registration, it's being deferred by `worker.start`,
 // so it will happen only when the worker is ready.
 fetch('/numbers')
+
+const req = new XMLHttpRequest()
+req.open('GET', '/letters')
+req.send()

--- a/test/msw-api/setup-worker/start/wait-until-ready.mocks.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.mocks.ts
@@ -1,0 +1,16 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/numbers', (req, res, ctx) => {
+    return res(ctx.json([1, 2, 3]))
+  }),
+)
+
+// By default, starting the worker defers the network requests
+// until the worker is ready to intercept them.
+worker.start()
+
+// Although this request is performed alognside an asynchronous
+// worker registration, it's being deferred by `worker.start`,
+// so it will happen only when the worker is ready.
+fetch('/numbers')

--- a/test/msw-api/setup-worker/start/wait-until-ready.mocks.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.mocks.ts
@@ -10,7 +10,7 @@ const worker = setupWorker(
 // until the worker is ready to intercept them.
 worker.start()
 
-// Although this request is performed alognside an asynchronous
+// Although this request is performed alongside an asynchronous
 // worker registration, it's being deferred by `worker.start`,
 // so it will happen only when the worker is ready.
 fetch('/numbers')

--- a/test/msw-api/setup-worker/start/wait-until-ready.test.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.test.ts
@@ -11,15 +11,24 @@ test('defers network requests until the worker is ready', async () => {
   // the deferred network requests option it's still subjected to race condition.
   await runtime.page.reload()
 
-  const res = await runtime.page.waitForResponse((res) => {
-    return res.url().includes('/numbers')
-  })
+  const [numbersResponse, lettersResponse] = await Promise.all([
+    runtime.page.waitForResponse((res) => {
+      return res.url().includes('/numbers')
+    }),
+    runtime.page.waitForResponse((res) => {
+      return res.url().includes('/letters')
+    }),
+  ])
 
-  const status = res.status()
-  const body = await res.json()
+  const numbersStatus = numbersResponse.status()
+  const numbersBody = await numbersResponse.json()
+  expect(numbersStatus).toBe(200)
+  expect(numbersBody).toEqual([1, 2, 3])
 
-  expect(status).toBe(200)
-  expect(body).toEqual([1, 2, 3])
+  const lettersStatus = lettersResponse.status()
+  const lettersBody = await lettersResponse.json()
+  expect(lettersStatus).toBe(200)
+  expect(lettersBody).toEqual(['a', 'b', 'c'])
 
   await runtime.cleanup()
 })
@@ -30,13 +39,20 @@ test('allows requests to fall through with the option disabled', async () => {
   )
   await runtime.page.reload()
 
-  const res = await runtime.page.waitForResponse((res) => {
-    return res.url().includes('/numbers')
-  })
+  const [numbersResponse, lettersResponse] = await Promise.all([
+    runtime.page.waitForResponse((res) => {
+      return res.url().includes('/numbers')
+    }),
+    runtime.page.waitForResponse((res) => {
+      return res.url().includes('/letters')
+    }),
+  ])
 
-  const status = res.status()
+  const numbersStatus = numbersResponse.status()
+  expect(numbersStatus).toBe(404)
 
-  expect(status).toBe(404)
+  const lettersStatus = lettersResponse.status()
+  expect(lettersStatus).toBe(404)
 
   await runtime.cleanup()
 })

--- a/test/msw-api/setup-worker/start/wait-until-ready.test.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.test.ts
@@ -7,7 +7,7 @@ test('defers network requests until the worker is ready', async () => {
   )
 
   // Reload is necessary, because `runBrowserWith` has `{ waitUntil: 'networkidle0' }` predicate
-  // when openning a test scenario mock. Reload doesn't affect the worker state, and without
+  // when opening a test scenario mock. Reload doesn't affect the worker state, and without
   // the deferred network requests option it's still subjected to race condition.
   await runtime.page.reload()
 

--- a/test/msw-api/setup-worker/start/wait-until-ready.test.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.test.ts
@@ -1,0 +1,42 @@
+import * as path from 'path'
+import { runBrowserWith } from '../../../support/runBrowserWith'
+
+test('defers network requests until the worker is ready', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'wait-until-ready.mocks.ts'),
+  )
+
+  // Reload is necessary, because `runBrowserWith` has `{ waitUntil: 'networkidle0' }` predicate
+  // when openning a test scenario mock. Reload doesn't affect the worker state, and without
+  // the deferred network requests option it's still subjected to race condition.
+  await runtime.page.reload()
+
+  const res = await runtime.page.waitForResponse((res) => {
+    return res.url().includes('/numbers')
+  })
+
+  const status = res.status()
+  const body = await res.json()
+
+  expect(status).toBe(200)
+  expect(body).toEqual([1, 2, 3])
+
+  await runtime.cleanup()
+})
+
+test('allows requests to fall through with the option disabled', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'wait-until-ready.false.mocks.ts'),
+  )
+  await runtime.page.reload()
+
+  const res = await runtime.page.waitForResponse((res) => {
+    return res.url().includes('/numbers')
+  })
+
+  const status = res.status()
+
+  expect(status).toBe(404)
+
+  await runtime.cleanup()
+})


### PR DESCRIPTION
> This is a breaking change.

## Changes

- Adds the `waitUntilReady: boolean` option to the `worker.start()` function.
- By default, starting a Service Worker via `worker.start()` now **defers all network requests until worker is ready**. That is powered by stubbing `XMLHttpRequest.prototype.send` and `window.fetch`. Once the worker is ready, the stubs are removed.

## GitHub

- Fixes #190 