### PR TITLE
Disables hot reloading for test runs (WDS)

### DIFF
--- a/test/support/spawnServer.ts
+++ b/test/support/spawnServer.ts
@@ -16,6 +16,8 @@ export interface SpawnServerOptions {
   withRoutes?: WebpackDevServer.Configuration['after']
 }
 
+const IS_TEST = process.env.NODE_ENV === 'test'
+
 export const spawnServer = (
   mockDefs: string,
   options?: SpawnServerOptions,
@@ -82,6 +84,9 @@ Using Service Worker build:
     contentBase: path.resolve(__dirname, '../..'),
     publicPath: '/',
     noInfo: true,
+    hot: !IS_TEST,
+    inline: !IS_TEST,
+    liveReload: !IS_TEST,
     openPage: '/test/support/template/index.html',
     headers: {
       // Allow for the test-only Service Workers from "/tmp" directory


### PR DESCRIPTION
When inspecting a test suite, I've noticed that WDS runs in a hot reload mode during the tests. That may be one of the reasons #83 happens. I assume that hot reload affects the way TypeScript compilation is run, and the latter is the reason for the memory leaks.

## GitHub

- Fixes #83 :tada: