### PR TITLE
remove response delay in node

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,6 @@ module.exports = {
         allowDeclarations: true,
       },
     ],
+    '@typescript-eslint/no-namespace': 0,
   },
 }

--- a/src/context/delay.node.test.ts
+++ b/src/context/delay.node.test.ts
@@ -1,14 +1,15 @@
 /**
  * @jest-environment node
  */
-import { delay, SERVER_RESPONSE_TIME_NODE } from './delay'
+import { delay, NODE_SERVER_RESPONSE_TIME } from './delay'
 import { response } from '../response'
 
-describe('delay', () => {
-  describe('if no delay provided ', () => {
-    it('should set no delay on the response if the env is node', () => {
-      const endResponse = response(delay())
-      expect(endResponse.delay).toBe(SERVER_RESPONSE_TIME_NODE)
-    })
-  })
+test('sets a NodeJS-specific response delay when not provided', () => {
+  const resolvedResponse = response(delay())
+  expect(resolvedResponse).toHaveProperty('delay', NODE_SERVER_RESPONSE_TIME)
+})
+
+test('allows response delay duration overrides', () => {
+  const resolvedResponse = response(delay(1234))
+  expect(resolvedResponse).toHaveProperty('delay', 1234)
 })

--- a/src/context/delay.node.test.ts
+++ b/src/context/delay.node.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import { delay, SERVER_RESPONSE_TIME_NODE } from './delay'
+import { response } from '../response'
+
+describe('delay', () => {
+  describe('if no delay provided ', () => {
+    it('should set no delay on the response if the env is node', () => {
+      const endResponse = response(delay())
+      expect(endResponse.delay).toBe(SERVER_RESPONSE_TIME_NODE)
+    })
+  })
+})

--- a/src/context/delay.test.ts
+++ b/src/context/delay.test.ts
@@ -1,23 +1,17 @@
-import {
-  delay,
-  MIN_SERVER_RESPONSE_TIME,
-  MAX_SERVER_RESPONSE_TIME,
-} from './delay'
+/**
+ * @jest-environment jsdom
+ *
+ * Since jsdom also runs in NodeJS, expect a NodeJS-specific implicit delay.
+ */
+import { delay, NODE_SERVER_RESPONSE_TIME } from './delay'
 import { response } from '../response'
 
-describe('delay', () => {
-  describe('given a delay ', () => {
-    it('should set delay on the response', () => {
-      const endResponse = response(delay(1200))
-      expect(endResponse).toHaveProperty('delay', 1200)
-    })
-  })
+test('sets a NodeJS-specific response delay when not provided', () => {
+  const resolvedResponse = response(delay())
+  expect(resolvedResponse).toHaveProperty('delay', NODE_SERVER_RESPONSE_TIME)
+})
 
-  describe('if no delay provided ', () => {
-    it('should set random delay on the response', () => {
-      const endResponse = response(delay())
-      expect(endResponse.delay).toBeGreaterThanOrEqual(MIN_SERVER_RESPONSE_TIME)
-      expect(endResponse.delay).toBeLessThanOrEqual(MAX_SERVER_RESPONSE_TIME)
-    })
-  })
+test('allows response delay duration overrides', () => {
+  const resolvedResponse = response(delay(1234))
+  expect(resolvedResponse).toHaveProperty('delay', 1234)
 })

--- a/src/context/delay.ts
+++ b/src/context/delay.ts
@@ -2,13 +2,17 @@ import { ResponseTransformer } from '../response'
 
 export const MIN_SERVER_RESPONSE_TIME = 100
 export const MAX_SERVER_RESPONSE_TIME = 400
+export const SERVER_RESPONSE_TIME_NODE = 5
 
-const getRandomServerResponseTime = () =>
-  Math.floor(
+const getRandomServerResponseTime = () => {
+  if (typeof window === 'undefined') {
+    return SERVER_RESPONSE_TIME_NODE
+  }
+  return Math.floor(
     Math.random() * (MAX_SERVER_RESPONSE_TIME - MIN_SERVER_RESPONSE_TIME) +
       MIN_SERVER_RESPONSE_TIME,
   )
-
+}
 /**
  * Delays the current response for the given duration (in ms)
  * @example

--- a/src/context/delay.ts
+++ b/src/context/delay.ts
@@ -1,13 +1,15 @@
 import { ResponseTransformer } from '../response'
+import { isNodeProcess } from '../utils/isNodeProcess'
 
 export const MIN_SERVER_RESPONSE_TIME = 100
 export const MAX_SERVER_RESPONSE_TIME = 400
-export const SERVER_RESPONSE_TIME_NODE = 5
+export const NODE_SERVER_RESPONSE_TIME = 5
 
 const getRandomServerResponseTime = () => {
-  if (typeof window === 'undefined') {
-    return SERVER_RESPONSE_TIME_NODE
+  if (isNodeProcess()) {
+    return NODE_SERVER_RESPONSE_TIME
   }
+
   return Math.floor(
     Math.random() * (MAX_SERVER_RESPONSE_TIME - MIN_SERVER_RESPONSE_TIME) +
       MIN_SERVER_RESPONSE_TIME,
@@ -16,7 +18,8 @@ const getRandomServerResponseTime = () => {
 /**
  * Delays the current response for the given duration (in ms)
  * @example
- * res(delay(1500), json({ foo: 'bar' }))
+ * res(delay()) // realistic server response time
+ * res(delay(1500)) // explicit response delay duration
  */
 export const delay = (durationMs?: number): ResponseTransformer => {
   return (res) => {

--- a/src/response.ts
+++ b/src/response.ts
@@ -6,8 +6,8 @@ export interface MockedResponse {
   status: number
   statusText: string
   headers: Headers
-  delay: number
   once: boolean
+  delay?: number
 }
 
 export type ResponseTransformer = (res: MockedResponse) => MockedResponse

--- a/test/msw-api/context/delay.mocks.ts
+++ b/test/msw-api/context/delay.mocks.ts
@@ -1,0 +1,17 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    const delay = req.url.searchParams.get('delay')
+    const delayMs = delay ? Number(delay) : undefined
+
+    return res(
+      ctx.delay(delayMs),
+      ctx.json({
+        mocked: true,
+      }),
+    )
+  }),
+)
+
+worker.start()

--- a/test/msw-api/context/delay.test.ts
+++ b/test/msw-api/context/delay.test.ts
@@ -1,0 +1,92 @@
+import * as path from 'path'
+import { Page } from 'puppeteer'
+import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toRoughlyEqual(expected: number, deviation: number): R
+    }
+  }
+}
+
+expect.extend({
+  /**
+   * Asserts a given actual number to roughly equal to the expected number,
+   * taking the maximum allowed delta `deviation` into account.
+   */
+  toRoughlyEqual(actual: number, expected: number, deviation: number) {
+    const diff = Math.abs(actual - expected)
+    const passes = diff <= deviation
+
+    if (passes) {
+      return {
+        pass: true,
+        message: () =>
+          `expected ${actual} not to be roughly equal to ${expected} (deviation: ${deviation})`,
+      }
+    }
+
+    return {
+      pass: false,
+      message: () =>
+        `expected ${actual} to be roughly equal to ${expected} (deviation: ${deviation})`,
+    }
+  },
+})
+
+let runtime: TestAPI
+
+beforeAll(async () => {
+  runtime = await runBrowserWith(path.resolve(__dirname, 'delay.mocks.ts'))
+})
+
+afterAll(() => {
+  return runtime.cleanup()
+})
+
+function performanceNow(page: Page) {
+  return page.evaluate(() => new Date().getTime())
+}
+
+test('uses explicit server response delay', async () => {
+  const startPerf = await performanceNow(runtime.page)
+  const res = await runtime.request({
+    url: `${runtime.origin}/user?delay=1200`,
+  })
+  const endPerf = await performanceNow(runtime.page)
+
+  const responseTime = endPerf - startPerf
+  expect(responseTime).toRoughlyEqual(1200, 250)
+
+  const status = res.status()
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(status).toBe(200)
+  expect(body).toEqual({ mocked: true })
+})
+
+test('uses realistic server response delay, when not provided', async () => {
+  const startPerf = await performanceNow(runtime.page)
+  const res = await runtime.request({
+    url: `${runtime.origin}/user`,
+  })
+  const endPerf = await performanceNow(runtime.page)
+
+  // Actual response time should lie within min/max boundaries
+  // of the random realistic response time.
+  const responseTime = endPerf - startPerf
+  expect(responseTime).toRoughlyEqual(250, 150)
+
+  const status = res.status()
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(status).toBe(200)
+  expect(body).toEqual({
+    mocked: true,
+  })
+})


### PR DESCRIPTION
## Changes

- Sets an implicit response time (via `ctx.delay()`) to `5ms`, when run in a NodeJS environment.

## GitHub

- Closes #192 