### PR TITLE
Bumps NRI to implement "setNoDelay" on the polyfilled Socket class

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "graphql": "^15.0.0",
     "headers-utils": "^1.1.9",
     "node-match-path": "^0.4.2",
-    "node-request-interceptor": "^0.2.4",
+    "node-request-interceptor": "^0.2.5",
     "statuses": "^2.0.0",
     "yargs": "^15.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4319,15 +4319,15 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-headers-utils@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-1.1.3.tgz#1991ac7a9349cb5a74de4caec4202ae33c1c8b04"
-  integrity sha512-s8n0NWkmclKGwa2yHKLTdop+toi/BNDOkitP3KzgNMfUgaRVm8Nd3ZU/uMfEQk1VvE+fY/VF2T8A4x8ISH+F6Q==
-
 headers-utils@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-1.1.9.tgz#84eae341a4910095a09993d41b221917626a6964"
   integrity sha512-Pg1TMIu0Bp4yICyG/RLIm0qtZXjWvKljF6n6nKtZ+NnJjAec1d7Gov9CGoJCZ03iOAAGD9kKSAkCol5IiJ+2fQ==
+
+headers-utils@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-1.2.0.tgz#5e10d1bc9d2bccf789547afca5b991a3167241e8"
+  integrity sha512-4/BMXcWrJErw7JpM87gF8MNEXcIMLzepYZjNRv/P9ctgupl2Ywa3u1PgHtNhSRq84bHH9Ndlkdy7bSi+bZ9I9A==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -6097,13 +6097,13 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-node-request-interceptor@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.2.4.tgz#f03a1b874823d0bea311a14280227707be946298"
-  integrity sha512-/htjDLmygBczT5qYPaSxfAEtMkc0LGuH6jqAP1o+TKfQh6yQfFyTtac25cpY8+pb4EawHljCLUN7dCeed9SdPA==
+node-request-interceptor@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.2.5.tgz#4578a4b005e70e6ee14d20b7a331892091079a93"
+  integrity sha512-9iRH/E+8jipPUbDsGiNdhErea81ANqaaAeXbnk0M3agDCsIMli3dcCSB8uQKKYUFu4SQjsqClIotPX2kIo9Hug==
   dependencies:
     debug "^4.1.1"
-    headers-utils "^1.1.3"
+    headers-utils "^1.2.0"
 
 normalize-package-data@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
## Changes

- Updates `node-request-interceptor` to version `0.2.5` to have implemented `setNoDelay` and other `Socket` class methods (see NRI pull request below for more details).

## GitHub

- Fixes #209 
- Propagation of https://github.com/mswjs/node-request-interceptor/pull/20

## Tests

- See the [unit test](https://github.com/mswjs/node-request-interceptor/blob/64d4e7b92aea0e764461abf2e0ff146fb3f6d930/src/http/ClientRequest/normalizeHttpRequestParams.test.ts#L119-L148) for the `ClientRequest` normalization function that now handles partial `RequestOptions` object (i.e. the one created by `supertest` library).