### PR TITLE
graphql: Supports operations issued using GET method

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -13,6 +13,7 @@ import { prepareRequest } from './utils/logger/prepareRequest'
 import { prepareResponse } from './utils/logger/prepareResponse'
 import { getTimestamp } from './utils/logger/getTimestamp'
 import { styleStatusCode } from './utils/logger/styleStatusCode'
+import { jsonParse } from './utils/jsonParse'
 
 type GraphQLRequestHandlerSelector = RegExp | string
 
@@ -105,7 +106,9 @@ const createGraphQLHandler = (operationType: OperationTypeNode) => {
               return null
             }
 
-            const variables = variablesString ? JSON.parse(variablesString) : {}
+            const variables = variablesString
+              ? jsonParse<VariablesType>(variablesString)
+              : ({} as VariablesType)
             const { operationName } = parseQuery(query, operationType)
 
             return {

--- a/src/handlers/requestHandler.ts
+++ b/src/handlers/requestHandler.ts
@@ -58,7 +58,7 @@ export interface RequestHandler<
    * Parses a captured request to retrieve additional
    * information meant for internal usage in the request handler.
    */
-  parse?: (req: MockedRequest) => ParsedRequest
+  parse?: (req: MockedRequest) => ParsedRequest | null
 
   /**
    * Returns a modified request with necessary public properties appended.

--- a/src/utils/jsonParse.ts
+++ b/src/utils/jsonParse.ts
@@ -1,0 +1,7 @@
+export function jsonParse<T>(str: string): T | undefined {
+  try {
+    return JSON.parse(str)
+  } catch (error) {
+    return undefined
+  }
+}

--- a/test/graphql-api/query.test.ts
+++ b/test/graphql-api/query.test.ts
@@ -1,41 +1,72 @@
 import * as path from 'path'
-import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+import { runBrowserWith } from '../support/runBrowserWith'
 import { executeOperation } from './utils/executeOperation'
 
-describe('GraphQL: Query', () => {
-  let test: TestAPI
+test('mocks a GraphQL query issued with a GET request', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'query.mocks.ts'),
+  )
 
-  beforeAll(async () => {
-    test = await runBrowserWith(path.resolve(__dirname, 'query.mocks.ts'))
-  })
-
-  afterAll(() => {
-    return test.cleanup()
-  })
-
-  it('should mock the query response', async () => {
-    const res = await executeOperation(test.page, {
+  const res = await executeOperation(
+    runtime.page,
+    {
       query: `
-        query GetUserDetail {
-          user {
-            firstName
-            lastName
-          }
+      query GetUserDetail {
+        user {
+          firstName
+          lastName
         }
-      `,
-    })
-    const headers = res.headers()
-    const body = await res.json()
+      }
+    `,
+    },
+    'GET',
+  )
 
-    expect(res.status()).toEqual(200)
-    expect(headers).toHaveProperty('content-type', 'application/json')
-    expect(body).toEqual({
-      data: {
-        user: {
-          firstName: 'John',
-          lastName: 'Maverick',
-        },
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(res.status()).toEqual(200)
+  expect(headers).toHaveProperty('content-type', 'application/json')
+  expect(body).toEqual({
+    data: {
+      user: {
+        firstName: 'John',
+        lastName: 'Maverick',
       },
-    })
+    },
   })
+
+  await runtime.cleanup()
+})
+
+test('mocks a GraphQL query issued with a POST request', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'query.mocks.ts'),
+  )
+
+  const res = await executeOperation(runtime.page, {
+    query: `
+      query GetUserDetail {
+        user {
+          firstName
+          lastName
+        }
+      }
+    `,
+  })
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(res.status()).toEqual(200)
+  expect(headers).toHaveProperty('content-type', 'application/json')
+  expect(body).toEqual({
+    data: {
+      user: {
+        firstName: 'John',
+        lastName: 'Maverick',
+      },
+    },
+  })
+
+  await runtime.cleanup()
 })


### PR DESCRIPTION
## Changes

- Handles a GET request with a GraphQL operation (query/variables) sent in a query string during the `parse` event of the `graphql` request handler.
- Adjusted the testing utility for issuing GraphQL requests to be able to issue a GET request.

## GitHub

- Fixes #210 

## Roadmap

- [x] Use safe `JSON.parse` to prevent an exception being thrown on invalid user input.