### PR TITLE
Uses a non-existing domain in integration tests

### DIFF
--- a/test/msw-api/setup-server/resetHandlers.test.ts
+++ b/test/msw-api/setup-server/resetHandlers.test.ts
@@ -6,7 +6,7 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 
 const server = setupServer(
-  rest.get('https://mswjs.io/books', (req, res, ctx) => {
+  rest.get('https://test.mswjs.io/books', (req, res, ctx) => {
     return res(ctx.json({ title: 'Original title' }))
   }),
 )
@@ -16,13 +16,13 @@ afterAll(() => server.close())
 
 test('removes all runtime request handlers when resetting without explicit next handlers', async () => {
   server.use(
-    rest.post('https://mswjs.io/login', (req, res, ctx) => {
+    rest.post('https://test.mswjs.io/login', (req, res, ctx) => {
       return res(ctx.json({ accepted: true }))
     }),
   )
 
   // Request handlers added on runtime affect the network communication.
-  const loginResponse = await fetch('https://mswjs.io/login', {
+  const loginResponse = await fetch('https://test.mswjs.io/login', {
     method: 'POST',
   })
   const loginBody = await loginResponse.json()
@@ -32,13 +32,13 @@ test('removes all runtime request handlers when resetting without explicit next 
   // Once reset, all the runtime request handlers are removed.
   server.resetHandlers()
 
-  const secondLoginResponse = await fetch('https://mswjs.io/login', {
+  const secondLoginResponse = await fetch('https://test.mswjs.io/login', {
     method: 'POST',
   })
   expect(secondLoginResponse.status).toBe(404)
 
   // Initial request handlers (given to `setupServer`) are not affected.
-  const booksResponse = await fetch('https://mswjs.io/books')
+  const booksResponse = await fetch('https://test.mswjs.io/books')
   const booksBody = await booksResponse.json()
   expect(booksResponse.status).toBe(200)
   expect(booksBody).toEqual({ title: 'Original title' })
@@ -46,7 +46,7 @@ test('removes all runtime request handlers when resetting without explicit next 
 
 test('replaces all handlers with the explicit next runtime handlers upon reset', async () => {
   server.use(
-    rest.post('https://mswjs.io/login', (req, res, ctx) => {
+    rest.post('https://test.mswjs.io/login', (req, res, ctx) => {
       return res(ctx.json({ accepted: true }))
     }),
   )
@@ -54,18 +54,18 @@ test('replaces all handlers with the explicit next runtime handlers upon reset',
   // Once reset with explicit next requets handlers,
   // replaces all present requets handlers with those.
   server.resetHandlers(
-    rest.get('https://mswjs.io/products', (req, res, ctx) => {
+    rest.get('https://test.mswjs.io/products', (req, res, ctx) => {
       return res(ctx.json([1, 2, 3]))
     }),
   )
 
-  const loginResponse = await fetch('https://mswjs.io/login')
+  const loginResponse = await fetch('https://test.mswjs.io/login')
   expect(loginResponse.status).toBe(404)
 
-  const booksResponse = await fetch('https://mswjs.io/books')
+  const booksResponse = await fetch('https://test.mswjs.io/books')
   expect(booksResponse.status).toBe(404)
 
-  const productsResponse = await fetch('https://mswjs.io/products')
+  const productsResponse = await fetch('https://test.mswjs.io/products')
   const productsBody = await productsResponse.json()
   expect(productsResponse.status).toBe(200)
   expect(productsBody).toEqual([1, 2, 3])

--- a/test/msw-api/setup-server/restoreHandlers.test.ts
+++ b/test/msw-api/setup-server/restoreHandlers.test.ts
@@ -6,7 +6,7 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 
 const server = setupServer(
-  rest.get('https://mswjs.io/book/:bookId', (req, res, ctx) => {
+  rest.get('https://test.mswjs.io/book/:bookId', (req, res, ctx) => {
     return res(ctx.json({ title: 'Original title' }))
   }),
 )
@@ -16,24 +16,24 @@ afterAll(() => server.close())
 
 test('returns a mocked response from the used one-time request handler when restored', async () => {
   server.use(
-    rest.get('https://mswjs.io/book/:bookId', (req, res, ctx) => {
+    rest.get('https://test.mswjs.io/book/:bookId', (req, res, ctx) => {
       return res.once(ctx.json({ title: 'Overridden title' }))
     }),
   )
 
-  const firstResponse = await fetch('https://mswjs.io/book/abc-123')
+  const firstResponse = await fetch('https://test.mswjs.io/book/abc-123')
   const firstBody = await firstResponse.json()
   expect(firstResponse.status).toBe(200)
   expect(firstBody).toEqual({ title: 'Overridden title' })
 
-  const secondResponse = await fetch('https://mswjs.io/book/abc-123')
+  const secondResponse = await fetch('https://test.mswjs.io/book/abc-123')
   const secondBody = await secondResponse.json()
   expect(secondResponse.status).toBe(200)
   expect(secondBody).toEqual({ title: 'Original title' })
 
   server.restoreHandlers()
 
-  const thirdResponse = await fetch('https://mswjs.io/book/abc-123')
+  const thirdResponse = await fetch('https://test.mswjs.io/book/abc-123')
   const thirdBody = await thirdResponse.json()
   expect(firstResponse.status).toBe(200)
   expect(thirdBody).toEqual({ title: 'Overridden title' })

--- a/test/msw-api/setup-server/use.test.ts
+++ b/test/msw-api/setup-server/use.test.ts
@@ -6,7 +6,7 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 
 const server = setupServer(
-  rest.get('https://mswjs.io/book/:bookId', (req, res, ctx) => {
+  rest.get('https://test.mswjs.io/book/:bookId', (req, res, ctx) => {
     return res(ctx.json({ title: 'Original title' }))
   }),
 )
@@ -17,13 +17,13 @@ afterAll(() => server.close())
 
 test('returns a mocked response from a runtime request handler upon match', async () => {
   server.use(
-    rest.post('https://mswjs.io/login', (req, res, ctx) => {
+    rest.post('https://test.mswjs.io/login', (req, res, ctx) => {
       return res(ctx.json({ accepted: true }))
     }),
   )
 
   // Request handlers added on runtime affect network communication as usual.
-  const loginResponse = await fetch('https://mswjs.io/login', {
+  const loginResponse = await fetch('https://test.mswjs.io/login', {
     method: 'POST',
   })
   const loginBody = await loginResponse.json()
@@ -31,7 +31,7 @@ test('returns a mocked response from a runtime request handler upon match', asyn
   expect(loginBody).toEqual({ accepted: true })
 
   // Other request handlers are preserved, if there are no overlaps.
-  const bookResponse = await fetch('https://mswjs.io/book/abc-123')
+  const bookResponse = await fetch('https://test.mswjs.io/book/abc-123')
   const bookBody = await bookResponse.json()
   expect(bookResponse.status).toBe(200)
   expect(bookBody).toEqual({ title: 'Original title' })
@@ -39,17 +39,17 @@ test('returns a mocked response from a runtime request handler upon match', asyn
 
 test('returns a mocked response from a persistent request handler override', async () => {
   server.use(
-    rest.get('https://mswjs.io/book/:bookId', (req, res, ctx) => {
+    rest.get('https://test.mswjs.io/book/:bookId', (req, res, ctx) => {
       return res(ctx.json({ title: 'Permanent override' }))
     }),
   )
 
-  const bookResponse = await fetch('https://mswjs.io/book/abc-123')
+  const bookResponse = await fetch('https://test.mswjs.io/book/abc-123')
   const bookBody = await bookResponse.json()
   expect(bookResponse.status).toBe(200)
   expect(bookBody).toEqual({ title: 'Permanent override' })
 
-  const anotherBookResponse = await fetch('https://mswjs.io/book/abc-123')
+  const anotherBookResponse = await fetch('https://test.mswjs.io/book/abc-123')
   const anotherBookBody = await anotherBookResponse.json()
   expect(anotherBookResponse.status).toBe(200)
   expect(anotherBookBody).toEqual({ title: 'Permanent override' })
@@ -57,17 +57,17 @@ test('returns a mocked response from a persistent request handler override', asy
 
 test('returns a mocked response from a one-time request handler override only upon first request match', async () => {
   server.use(
-    rest.get('https://mswjs.io/book/:bookId', (req, res, ctx) => {
+    rest.get('https://test.mswjs.io/book/:bookId', (req, res, ctx) => {
       return res.once(ctx.json({ title: 'One-time override' }))
     }),
   )
 
-  const bookResponse = await fetch('https://mswjs.io/book/abc-123')
+  const bookResponse = await fetch('https://test.mswjs.io/book/abc-123')
   const bookBody = await bookResponse.json()
   expect(bookResponse.status).toBe(200)
   expect(bookBody).toEqual({ title: 'One-time override' })
 
-  const anotherBookResponse = await fetch('https://mswjs.io/book/abc-123')
+  const anotherBookResponse = await fetch('https://test.mswjs.io/book/abc-123')
   const anotherBookBody = await anotherBookResponse.json()
   expect(anotherBookResponse.status).toBe(200)
   expect(anotherBookBody).toEqual({ title: 'Original title' })

--- a/test/rest-api/request-matching/uri.test.ts
+++ b/test/rest-api/request-matching/uri.test.ts
@@ -122,7 +122,7 @@ describe('REST: Request matching (URI)', () => {
   describe('given RegExp for request URI', () => {
     it('should match a request URI matching the expression', async () => {
       const res = await test.request({
-        url: 'https://msw.google.com/path',
+        url: 'https://mswjs.google.com/path',
       })
       const status = res.status()
       const headers = res.headers()
@@ -137,7 +137,7 @@ describe('REST: Request matching (URI)', () => {
 
     it('should not match a request URI not matching the expression', async () => {
       const res = await test.page.evaluate(() =>
-        fetch('https://msw.google.com/other').catch(() => null),
+        fetch('https://mswjs.google.com/other').catch(() => null),
       )
 
       expect(res).toBeNull()


### PR DESCRIPTION
## Changes

- Uses a non-existing domain (`test.mswjs.io`) for integration tests. Performing a `POST` request to `mswjs.io/login` (non-existing page) returns `405 Method Not Allowed` instead of `404 Not Found`. Using a non-existing domain always resolves to 404.

## GitHub

- Related to #219 

