### PR TITLE
Update test domain to mswjs.io

### DIFF
--- a/test/msw-api/setup-server/scenarios/fetch.test.ts
+++ b/test/msw-api/setup-server/scenarios/fetch.test.ts
@@ -4,7 +4,7 @@ import { setupServer } from 'msw/node'
 
 describe('setupServer / fetch', () => {
   const server = setupServer(
-    rest.get('http://test.msw.io', (req, res, ctx) => {
+    rest.get('http://test.mswjs.io', (req, res, ctx) => {
       return res(
         ctx.status(401),
         ctx.set('x-header', 'yes'),
@@ -14,7 +14,7 @@ describe('setupServer / fetch', () => {
         }),
       )
     }),
-    rest.post('https://test.msw.io', (req, res, ctx) => {
+    rest.post('https://test.mswjs.io', (req, res, ctx) => {
       return res(
         ctx.status(403),
         ctx.set('x-header', 'yes'),
@@ -35,7 +35,7 @@ describe('setupServer / fetch', () => {
     let res: Response
 
     beforeAll(async () => {
-      res = await fetch('http://test.msw.io')
+      res = await fetch('http://test.mswjs.io')
     })
 
     it('should return mocked status code', async () => {
@@ -61,7 +61,7 @@ describe('setupServer / fetch', () => {
     let res: Response
 
     beforeAll(async () => {
-      res = await fetch('https://test.msw.io', {
+      res = await fetch('https://test.mswjs.io', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/test/msw-api/setup-server/scenarios/http.test.ts
+++ b/test/msw-api/setup-server/scenarios/http.test.ts
@@ -7,7 +7,7 @@ import { setupServer } from 'msw/node'
 
 describe('setupServer / http', () => {
   const server = setupServer(
-    rest.get('http://test.msw.io', (req, res, ctx) => {
+    rest.get('http://test.mswjs.io', (req, res, ctx) => {
       return res(
         ctx.status(401),
         ctx.set('x-header', 'yes'),
@@ -31,7 +31,7 @@ describe('setupServer / http', () => {
     let resBody = ''
 
     beforeAll((done) => {
-      http.get('http://test.msw.io', (message) => {
+      http.get('http://test.mswjs.io', (message) => {
         res = message
         res.setEncoding('utf8')
         res.on('data', (chunk) => (resBody += chunk))
@@ -58,7 +58,7 @@ describe('setupServer / http', () => {
     let resBody = ''
 
     beforeAll((done) => {
-      const req = http.request('http://test.msw.io', (message) => {
+      const req = http.request('http://test.mswjs.io', (message) => {
         res = message
         res.setEncoding('utf8')
         res.on('data', (chunk) => (resBody += chunk))

--- a/test/msw-api/setup-server/scenarios/https.test.ts
+++ b/test/msw-api/setup-server/scenarios/https.test.ts
@@ -8,7 +8,7 @@ import { setupServer } from 'msw/node'
 
 describe('setupServer / https', () => {
   const server = setupServer(
-    rest.get('https://test.msw.io', (req, res, ctx) => {
+    rest.get('https://test.mswjs.io', (req, res, ctx) => {
       return res(
         ctx.status(401),
         ctx.set('x-header', 'yes'),
@@ -32,7 +32,7 @@ describe('setupServer / https', () => {
     let resBody = ''
 
     beforeAll((done) => {
-      https.get('https://test.msw.io', (message) => {
+      https.get('https://test.mswjs.io', (message) => {
         res = message
         res.setEncoding('utf8')
         res.on('data', (chunk) => (resBody += chunk))
@@ -59,7 +59,7 @@ describe('setupServer / https', () => {
     let resBody = ''
 
     beforeAll((done) => {
-      const req = https.request('https://test.msw.io', (message) => {
+      const req = https.request('https://test.mswjs.io', (message) => {
         res = message
         res.setEncoding('utf8')
         res.on('data', (chunk) => (resBody += chunk))

--- a/test/msw-api/setup-server/scenarios/xhr.test.ts
+++ b/test/msw-api/setup-server/scenarios/xhr.test.ts
@@ -4,7 +4,7 @@ import { stringToHeaders } from 'headers-utils'
 
 describe('setupServer / XHR', () => {
   const server = setupServer(
-    rest.get('http://test.msw.io', (req, res, ctx) => {
+    rest.get('http://test.mswjs.io', (req, res, ctx) => {
       return res(
         ctx.status(401),
         ctx.set('x-header', 'yes'),
@@ -31,7 +31,7 @@ describe('setupServer / XHR', () => {
 
     beforeAll((done) => {
       const req = new XMLHttpRequest()
-      req.open('GET', 'http://test.msw.io')
+      req.open('GET', 'http://test.mswjs.io')
       req.onload = function () {
         statusCode = this.status
         body = JSON.parse(this.response)

--- a/test/rest-api/context.mocks.ts
+++ b/test/rest-api/context.mocks.ts
@@ -1,7 +1,7 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.get('https://test.msw.io/', (req, res, ctx) => {
+  rest.get('https://test.mswjs.io/', (req, res, ctx) => {
     return res(
       ctx.delay(2000),
       ctx.set({

--- a/test/rest-api/context.test.ts
+++ b/test/rest-api/context.test.ts
@@ -14,7 +14,7 @@ describe('REST: Context utilities', () => {
 
   it('should receive mocked response', async () => {
     const res = await test.request({
-      url: 'https://test.msw.io/',
+      url: 'https://test.mswjs.io/',
     })
     const headers = res.headers()
     const body = await res.json()

--- a/test/rest-api/custom-request-handler.test.ts
+++ b/test/rest-api/custom-request-handler.test.ts
@@ -17,7 +17,7 @@ describe('REST: Custom request handler', () => {
   describe('given a request handler with default context', () => {
     it('should intercept request by a custom handler', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io/url/matters/not',
+        url: 'https://test.mswjs.io/url/matters/not',
         fetchOptions: {
           headers: {
             'x-custom-header': 'true',

--- a/test/rest-api/headers-multiple.mocks.ts
+++ b/test/rest-api/headers-multiple.mocks.ts
@@ -1,7 +1,7 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.post('https://test.msw.io', (req, res, ctx) => {
+  rest.post('https://test.mswjs.io', (req, res, ctx) => {
     return res(
       ctx.json({
         'x-header': req.headers.get('x-header'),
@@ -9,7 +9,7 @@ const worker = setupWorker(
     )
   }),
 
-  rest.get('https://test.msw.io', (req, res, ctx) => {
+  rest.get('https://test.mswjs.io', (req, res, ctx) => {
     return res(
       ctx.set({
         Accept: ['application/json', 'image/png'],

--- a/test/rest-api/headers-multiple.test.ts
+++ b/test/rest-api/headers-multiple.test.ts
@@ -20,7 +20,7 @@ describe('REST: Multiple headers with the same name', () => {
       headers.append('x-header', 'application/hal+json')
 
       const res = await test.request({
-        url: 'https://test.msw.io',
+        url: 'https://test.mswjs.io',
         fetchOptions: {
           method: 'POST',
           headers,
@@ -39,7 +39,7 @@ describe('REST: Multiple headers with the same name', () => {
   describe('given mocking a header with multiple values', () => {
     it('should receive all the headers', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io',
+        url: 'https://test.mswjs.io',
       })
       const status = res.status()
       const headers = res.headers()

--- a/test/rest-api/query.mocks.ts
+++ b/test/rest-api/query.mocks.ts
@@ -1,7 +1,7 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.get('https://test.msw.io/api/books', (req, res, ctx) => {
+  rest.get('https://test.mswjs.io/api/books', (req, res, ctx) => {
     const bookId = req.url.searchParams.get('id')
 
     return res(
@@ -11,7 +11,7 @@ const worker = setupWorker(
     )
   }),
 
-  rest.post('https://test.msw.io/products', (req, res, ctx) => {
+  rest.post('https://test.mswjs.io/products', (req, res, ctx) => {
     const productIds = req.url.searchParams.getAll('id')
 
     return res(

--- a/test/rest-api/query.test.ts
+++ b/test/rest-api/query.test.ts
@@ -15,7 +15,7 @@ describe('REST: Query parameters', () => {
   describe('given a single query parameter', () => {
     it('should retrieve parameters from the URI', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io/api/books?id=abc-123',
+        url: 'https://test.mswjs.io/api/books?id=abc-123',
       })
       const status = res.status()
       const headers = res.headers()
@@ -32,7 +32,7 @@ describe('REST: Query parameters', () => {
   describe('given multiple query parameters', () => {
     it('should return the list of values by parameter name', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io/products?id=1&id=2&id=3',
+        url: 'https://test.mswjs.io/products?id=1&id=2&id=3',
         fetchOptions: {
           method: 'POST',
         },

--- a/test/rest-api/request-matching/uri.mocks.ts
+++ b/test/rest-api/request-matching/uri.mocks.ts
@@ -9,7 +9,7 @@ const worker = setupWorker(
     )
   }),
 
-  rest.get('https://test.msw.io/messages/:messageId', (req, res, ctx) => {
+  rest.get('https://test.mswjs.io/messages/:messageId', (req, res, ctx) => {
     const { messageId } = req.params
 
     return res(
@@ -19,15 +19,18 @@ const worker = setupWorker(
     )
   }),
 
-  rest.get('https://test.msw.io/messages/:messageId/items', (req, res, ctx) => {
-    const { messageId } = req.params
+  rest.get(
+    'https://test.mswjs.io/messages/:messageId/items',
+    (req, res, ctx) => {
+      const { messageId } = req.params
 
-    return res(
-      ctx.json({
-        messageId,
-      }),
-    )
-  }),
+      return res(
+        ctx.json({
+          messageId,
+        }),
+      )
+    },
+  ),
 
   rest.get(/(.+?)\.google\.com\/path/, (req, res, ctx) => {
     return res(

--- a/test/rest-api/request-matching/uri.test.ts
+++ b/test/rest-api/request-matching/uri.test.ts
@@ -67,7 +67,7 @@ describe('REST: Request matching (URI)', () => {
   describe('given mask for request URI', () => {
     it('should match a request that matches the mask', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io/messages/abc-123',
+        url: 'https://test.mswjs.io/messages/abc-123',
       })
       const status = res.status()
       const headers = res.headers()
@@ -82,7 +82,7 @@ describe('REST: Request matching (URI)', () => {
 
     it('should not match a request that does not match the mask', async () => {
       const res = await test.page.evaluate(() =>
-        fetch('https://test.msw.io/users/def-456').catch(() => null),
+        fetch('https://test.mswjs.io/users/def-456').catch(() => null),
       )
 
       expect(res).toBeNull()
@@ -90,7 +90,7 @@ describe('REST: Request matching (URI)', () => {
 
     it('should match a request with query parameters that matches the mask', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io/messages/abc-123/items?hello=true',
+        url: 'https://test.mswjs.io/messages/abc-123/items?hello=true',
       })
       const status = res.status()
       const headers = res.headers()
@@ -105,7 +105,7 @@ describe('REST: Request matching (URI)', () => {
 
     it('should match a request with a hash that matches the mask', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io/messages/abc-123/items#hello',
+        url: 'https://test.mswjs.io/messages/abc-123/items#hello',
       })
       const status = res.status()
       const headers = res.headers()

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -1,7 +1,7 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.get('https://test.msw.io/user', async (req, res, ctx) => {
+  rest.get('https://test.mswjs.io/user', async (req, res, ctx) => {
     const originalResponse = await ctx.fetch(
       'https://api.github.com/users/octocat',
     )
@@ -29,7 +29,7 @@ const worker = setupWorker(
     },
   ),
 
-  rest.get('https://test.msw.io/headers', async (req, res, ctx) => {
+  rest.get('https://test.mswjs.io/headers', async (req, res, ctx) => {
     const originalResponse = await ctx.fetch('/headers-proxy', {
       method: 'POST',
       headers: req.headers.getAllHeaders(),

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -35,7 +35,7 @@ describe('REST: Response patching', () => {
   describe('given mocked and original requests differ', () => {
     it('should return a combination of mocked and original responses', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io/user',
+        url: 'https://test.mswjs.io/user',
       })
       const status = res.status()
       const headers = res.headers()
@@ -80,7 +80,7 @@ describe('REST: Response patching', () => {
   describe('given a mocked request with custom headers', () => {
     it('should forward the headers to the original request', async () => {
       const res = await test.request({
-        url: 'https://test.msw.io/headers',
+        url: 'https://test.mswjs.io/headers',
         fetchOptions: {
           headers: {
             Authorization: 'token',


### PR DESCRIPTION
This pull request replaces `https://test.msw.io` with `https://test.mswjs.io` in all tests.

Please note that `test/rest-api/request-matching/uri.mocks.ts` was slightly reformatted to be compliant with the linting rules.