### PR TITLE
fix: add warning when mocking url with query params

### DIFF
--- a/src/rest.ts
+++ b/src/rest.ts
@@ -51,6 +51,12 @@ const createRestHandler = (method: RESTMethods) => {
     mask: Mask,
     resolver: ResponseResolver<MockedRequest, typeof restContext>,
   ): RequestHandler<MockedRequest, typeof restContext> => {
+    if (typeof mask === 'string' && new RegExp(/\?.+=.*/g).test(mask)) {
+      console.warn(
+        `It should not be good to add query parameters in the mask. 
+        It's better to use without them`,
+      )
+    }
     return {
       predicate(req) {
         // Ignore query parameters and hash when matching requests URI

--- a/src/setupWorker/setupWorker.test.ts
+++ b/src/setupWorker/setupWorker.test.ts
@@ -1,16 +1,15 @@
 import { setupWorker } from './setupWorker'
 import { rest, restContext } from '../rest'
 import { MockedRequest, ResponseResolver } from '../handlers/requestHandler'
+const simpleResolver: ResponseResolver<MockedRequest, typeof restContext> = (
+  req,
+  res,
+  { json },
+) => {
+  return res(json({ a: 2 }))
+}
 
 test('Generates schema based on provided handlers', () => {
-  const simpleResolver: ResponseResolver<MockedRequest, typeof restContext> = (
-    req,
-    res,
-    { json },
-  ) => {
-    return res(json({ a: 2 }))
-  }
-
   const api = setupWorker(
     rest.get('https://api.github.com/users/:username', simpleResolver),
     rest.get('foo', simpleResolver),
@@ -21,4 +20,24 @@ test('Generates schema based on provided handlers', () => {
   expect(api.start).toBeInstanceOf(Function)
   expect(api).toHaveProperty('stop')
   expect(api.stop).toBeInstanceOf(Function)
+})
+
+test('should show a warning if the user try to mock api whit query params', () => {
+  const spy = jest
+    .spyOn(console, 'warn')
+    .mockImplementationOnce((message) => message)
+  const simpleResolver: ResponseResolver<MockedRequest, typeof restContext> = (
+    req,
+    res,
+    { json },
+  ) => {
+    return res(json({ a: 2 }))
+  }
+
+  setupWorker(
+    rest.get('https://test.mswjs.io/api/libraries?size=10', simpleResolver),
+  )
+
+  expect(console.warn).toHaveBeenCalled()
+  spy.mockClear()
 })


### PR DESCRIPTION
fix #231 

When you try to add a rest api where the `Mask` contains query parameters should give a warning.

I don't know if a warning message is useful because then you can't use the API, because if you try to call the API `getCleanUrl` will clean everything from URL.

Could be better to throw an error?
