### PR TITLE
Warns on the redundant usage of query parameters

### DIFF
--- a/src/utils/resolveMask.test.ts
+++ b/src/utils/resolveMask.test.ts
@@ -1,0 +1,27 @@
+import { resolveMask } from './resolveMask'
+
+test('returns regular expression as-is', () => {
+  expect(resolveMask(/\/user\//g)).toEqual(/\/user\//g)
+})
+
+test('creates a URL instance from a valid relative URL', () => {
+  const url = resolveMask('/user') as URL
+  expect(url).toBeInstanceOf(URL)
+  expect(url.toString()).toBe('http://localhost/user')
+})
+
+test('created a URL instance from a valid absolute URL', () => {
+  const url = resolveMask('https://test.mswjs.io/user') as URL
+  expect(url).toBeInstanceOf(URL)
+  expect(url.toString()).toBe('https://test.mswjs.io/user')
+})
+
+test('creates a URL instance given a path with parameters', () => {
+  const url = resolveMask('/user/:userId') as URL
+  expect(url).toBeInstanceOf(URL)
+  expect(url.toString()).toBe('http://localhost/user/:userId')
+})
+
+test('returns a path string as-is', () => {
+  expect(resolveMask('*')).toBe('*')
+})

--- a/src/utils/resolveMask.ts
+++ b/src/utils/resolveMask.ts
@@ -1,0 +1,22 @@
+import { Mask } from '../setupWorker/glossary'
+import { resolveRelativeUrl } from './resolveRelativeUrl'
+
+/**
+ * Converts a given request handler mask into a URL, if given a valid URL string.
+ * Otherwise, returns the mask as-is.
+ */
+export function resolveMask(mask: Mask): URL | RegExp | string {
+  if (mask instanceof RegExp) {
+    return mask
+  }
+
+  try {
+    // Attempt to create a URL instance out of the mask string.
+    // Resolve mask to an absolute URL, because even a valid relative URL
+    // cannot be converted into the URL instance (required absolute URL only).
+    return new URL(resolveRelativeUrl(mask))
+  } catch (error) {
+    // Otherwise, the mask is a path string.
+    return mask
+  }
+}

--- a/src/utils/resolveRelativeUrl.ts
+++ b/src/utils/resolveRelativeUrl.ts
@@ -4,12 +4,12 @@ import { Mask } from '../setupWorker/glossary'
  * Resolves a relative URL to the absolute URL with the same hostname.
  * Ignores regular expressions.
  */
-export const resolveRelativeUrl = (mask: Mask) => {
+export const resolveRelativeUrl = <T extends Mask>(mask: T): T => {
   // Global `location` object doesn't exist in Node.
   // Relative request predicate URL cannot become absolute.
   const hasLocation = typeof location !== 'undefined'
 
   return typeof mask === 'string' && mask.startsWith('/')
-    ? `${hasLocation ? location.origin : ''}${mask}`
+    ? ((`${hasLocation ? location.origin : ''}${mask}` as string) as T)
     : mask
 }

--- a/test/rest-api/query-params-warning.mocks.ts
+++ b/test/rest-api/query-params-warning.mocks.ts
@@ -1,0 +1,11 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  // WARNING: Intentionally invalid example of including a query parameter
+  // in the request handler URL. Don't do that, consider matching against a path
+  // and accessing query parameters in the response resolver instead.
+  rest.get('/user?name=admin', (req, res, ctx) => res()),
+  rest.post('/login?id=123&type=auth', (req, res, ctx) => res()),
+)
+
+worker.start()

--- a/test/rest-api/query-params-warning.test.ts
+++ b/test/rest-api/query-params-warning.test.ts
@@ -1,0 +1,77 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+import { captureConsole } from '../support/captureConsole'
+import { warn } from 'console'
+
+let runtime: TestAPI
+
+beforeAll(async () => {
+  runtime = await runBrowserWith(
+    path.resolve(__dirname, 'query-params-warning.mocks.ts'),
+  )
+})
+
+afterAll(() => runtime.cleanup())
+
+function findQueryParametersWarning(logs: string[]) {
+  return logs.find((message) => {
+    return message.startsWith(
+      '[MSW] Found a redundant usage of query parameters in the request handler URL',
+    )
+  })
+}
+
+function findQueryParametersSuggestions(logs: string[], params: string[]) {
+  return logs.find((message) => {
+    return params.every((paramName) =>
+      message.includes(`const ${paramName} = query.get("${paramName}")`),
+    )
+  })
+}
+
+test('warns when a request handler URL contains a single query parameter', async () => {
+  const warnings: string[] = []
+  captureConsole(runtime.page, warnings, (message) => {
+    return message.type() === 'warning'
+  })
+
+  await runtime.reload()
+  expect(findQueryParametersWarning(warnings)).toBeUndefined()
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/user?id=123`,
+  })
+  expect(res.status()).toBe(200)
+
+  // Should produce a friendly warning.
+  expect(findQueryParametersWarning(warnings)).not.toBeUndefined()
+
+  // Should suggest how to reference query parameters in the response resolver.
+  expect(findQueryParametersSuggestions(warnings, ['name'])).not.toBeUndefined()
+})
+
+test('warns when a request handler URL contains multiple query parameters', async () => {
+  const warnings: string[] = []
+  captureConsole(runtime.page, warnings, (message) => {
+    return message.type() === 'warning'
+  })
+
+  await runtime.reload()
+  expect(findQueryParametersWarning(warnings)).toBeUndefined()
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/login?id=123`,
+    fetchOptions: {
+      method: 'POST',
+    },
+  })
+  expect(res.status()).toBe(200)
+
+  // Should produce a friendly warning.
+  expect(findQueryParametersWarning(warnings)).not.toBeUndefined()
+
+  // Should suggest how to reference query parameters in the response resolver.
+  expect(
+    findQueryParametersSuggestions(warnings, ['id', 'type']),
+  ).not.toBeUndefined()
+})


### PR DESCRIPTION
## Changes

- Resolves a `rest.*` mask to a `URL` instance, if possible. That instance is later used for both request matching in predicate and retrieving URL query params to produce a meaningful warning message on redundant query parameters.

## GitHub

- Fixes #231