### PR TITLE
Removes "composeMocks" API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as context from './context'
 
-export { setupWorker, composeMocks } from './setupWorker/setupWorker'
+export { setupWorker } from './setupWorker/setupWorker'
 export { MockedResponse, ResponseTransformer, response } from './response'
 export { context }
 

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -4,7 +4,7 @@ import { MockedResponse } from '../response'
 
 export type Mask = RegExp | string
 
-export interface ComposeMocksInternalContext {
+export interface SetupWorkerInternalContext {
   worker: ServiceWorker | null
   registration: ServiceWorkerRegistration | null
   requestHandlers: RequestHandler<any, any>[]

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -1,4 +1,4 @@
-import { ComposeMocksInternalContext, RequestHandlersList } from './glossary'
+import { SetupWorkerInternalContext, RequestHandlersList } from './glossary'
 import { createStart } from './start/createStart'
 import { createStop } from './stop/createStop'
 import * as requestHandlerUtils from '../utils/requestHandlerUtils'
@@ -30,7 +30,7 @@ export interface SetupWorkerApi {
 export function setupWorker(
   ...requestHandlers: RequestHandlersList
 ): SetupWorkerApi {
-  const context: ComposeMocksInternalContext = {
+  const context: SetupWorkerInternalContext = {
     worker: null,
     registration: null,
     requestHandlers: [...requestHandlers],
@@ -62,15 +62,4 @@ export function setupWorker(
       )
     },
   }
-}
-
-/**
- * Composes multiple request handlers into a single mocking schema.
- * @deprecated
- */
-export function composeMocks(...requestHandlers: RequestHandlersList) {
-  console.warn(
-    '[MSW] The `composeMocks()` function is deprecated and will be removed in the next release. Please use the `setupWorker()` function instead.',
-  )
-  return setupWorker(...requestHandlers)
 }

--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -2,7 +2,7 @@ import { until } from '@open-draft/until'
 import { getWorkerInstance } from './utils/getWorkerInstance'
 import { activateMocking } from './utils/activateMocking'
 import {
-  ComposeMocksInternalContext,
+  SetupWorkerInternalContext,
   ServiceWorkerInstanceTuple,
   StartOptions,
 } from '../glossary'
@@ -19,7 +19,7 @@ const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
   waitUntilReady: true,
 }
 
-export const createStart = (context: ComposeMocksInternalContext) => {
+export const createStart = (context: SetupWorkerInternalContext) => {
   /**
    * Registers and activates the mock Service Worker.
    */

--- a/src/setupWorker/stop/createStop.ts
+++ b/src/setupWorker/stop/createStop.ts
@@ -1,6 +1,6 @@
-import { ComposeMocksInternalContext } from '../glossary'
+import { SetupWorkerInternalContext } from '../glossary'
 
-export const createStop = (context: ComposeMocksInternalContext) => {
+export const createStop = (context: SetupWorkerInternalContext) => {
   /**
    * Stop the active running instance of the Service Worker.
    */

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -2,7 +2,7 @@ import { Headers, headersToList } from 'headers-utils'
 import {
   StartOptions,
   ResponseWithSerializedHeaders,
-  ComposeMocksInternalContext,
+  SetupWorkerInternalContext,
 } from '../setupWorker/glossary'
 import { MockedRequest } from '../handlers/requestHandler'
 import {
@@ -14,7 +14,7 @@ import { parseRequestBody } from './parseRequestBody'
 import { isStringEqual } from './isStringEqual'
 
 export const handleRequestWith = (
-  context: ComposeMocksInternalContext,
+  context: SetupWorkerInternalContext,
   options: StartOptions,
 ) => {
   return async (event: MessageEvent) => {


### PR DESCRIPTION
> This change is meant for the next minor release `0.20.0`.

## Changes

- Removes `composeMocks` function from the public API (officially deprecated).
- Changes the name of the internal context interface to use `SetupWorker` prefix.

## GitHub

- Closes #236 