### PR TITLE
graphql: Exports request, context, and other types

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -17,7 +17,7 @@ import { jsonParse } from './utils/jsonParse'
 
 type GraphQLRequestHandlerSelector = RegExp | string
 
-type GraphQLMockedRequest<
+export type GraphQLMockedRequest<
   VariablesType = Record<string, any>
 > = MockedRequest & {
   variables: VariablesType
@@ -26,7 +26,7 @@ type GraphQLMockedRequest<
 // GraphQL related context should contain utility functions
 // useful for GraphQL. Functions like `xml()` bear no value
 // in the GraphQL universe.
-interface GraphQLMockedContext<QueryType> {
+export interface GraphQLMockedContext<QueryType> {
   set: typeof set
   status: typeof status
   delay: typeof delay
@@ -44,13 +44,13 @@ export const graphqlContext: GraphQLMockedContext<any> = {
   errors,
 }
 
-type GraphQLResponseResolver<QueryType, VariablesType> = (
+export type GraphQLResponseResolver<QueryType, VariablesType> = (
   req: GraphQLMockedRequest<VariablesType>,
   res: ResponseComposition,
   context: GraphQLMockedContext<QueryType>,
 ) => MockedResponse
 
-interface GraphQLRequestPayload<VariablesType> {
+export interface GraphQLRequestPayload<VariablesType> {
   query: string
   variables?: VariablesType
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,4 +14,11 @@ export {
   defaultContext,
 } from './handlers/requestHandler'
 export { rest, restContext, RESTMethods } from './rest'
-export { graphql, graphqlContext } from './graphql'
+export {
+  graphql,
+  graphqlContext,
+  GraphQLMockedRequest,
+  GraphQLMockedContext,
+  GraphQLRequestPayload,
+  GraphQLResponseResolver,
+} from './graphql'


### PR DESCRIPTION
## Changes

Exports the following TypeScript interfaces from the library's package:

- `GraphQLMockedRequest`
- `GraphQLMockedContext`
- `GraphQLRequestPayload`
- `GraphQLResponseResolver`

## GitHub

- Resolves #213