### PR TITLE
fix: improve error message on registration failed 

### DIFF
--- a/src/setupWorker/start/utils/activateMocking.ts
+++ b/src/setupWorker/start/utils/activateMocking.ts
@@ -18,7 +18,7 @@ export const activateMocking = (
             'color:orangered;font-weight:bold;',
           )
           console.log(
-            '%cDocumentation: %chttps://redd.gitbook.io/msw',
+            '%cDocumentation: %chttps://mswjs.io/docs',
             'font-weight:bold',
             'font-weight:normal',
           )

--- a/src/setupWorker/start/utils/getWorkerInstance.ts
+++ b/src/setupWorker/start/utils/getWorkerInstance.ts
@@ -54,9 +54,26 @@ export const getWorkerInstance = async (
   )
 
   if (error) {
+    const isWorkerMissing = error.message.includes('(404)')
+
+    // Produce a custom error message when given a non-existing Service Worker url.
+    // Suggest developers to check their setup.
+    if (isWorkerMissing) {
+      const scopeUrl = new URL(options?.scope || '/', location.href)
+
+      console.error(`\
+[MSW] Failed to register a Service Worker for scope ('${scopeUrl.href}') with script ('${absoluteWorkerUrl}'): Service Worker script does not exist at the given path.
+
+Did you forget to run "npx msw init <PUBLIC_DIR>"?
+
+Learn more about creating the Service Worker script: https://mswjs.io/docs/cli/init`)
+
+      return null
+    }
+
+    // Fallback error message for any other registration errors.
     console.error(
-      `[MSW] ${error.message} 
-      If the worker file has not been found maybe you didn't run "npx msw init <PUBLIC_DIR>"`,
+      `[MSW] Failed to register a Service Worker:\n\m${error.message}`,
     )
     return null
   }

--- a/src/setupWorker/start/utils/getWorkerInstance.ts
+++ b/src/setupWorker/start/utils/getWorkerInstance.ts
@@ -46,7 +46,6 @@ export const getWorkerInstance = async (
       ]
     })
   }
-
   const [error, instance] = await until<ServiceWorkerInstanceTuple>(
     async () => {
       const registration = await navigator.serviceWorker.register(url, options)
@@ -56,9 +55,8 @@ export const getWorkerInstance = async (
 
   if (error) {
     console.error(
-      '[MSW] Failed to register Service Worker (%s). %o',
-      url,
-      error,
+      `[MSW] ${error.message} 
+      If the worker file has not been found maybe you didn't run "npx msw init <PUBLIC_DIR>"`,
     )
     return null
   }

--- a/test/msw-api/setup-worker/start/error.mocks.ts
+++ b/test/msw-api/setup-worker/start/error.mocks.ts
@@ -1,0 +1,15 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        firstName: 'John',
+        age: 32,
+      }),
+    )
+  }),
+)
+
+// @ts-ignore
+window.__MSW_START__ = worker.start

--- a/test/msw-api/setup-worker/start/error.mocks.ts
+++ b/test/msw-api/setup-worker/start/error.mocks.ts
@@ -2,12 +2,7 @@ import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
   rest.get('/user', (req, res, ctx) => {
-    return res(
-      ctx.json({
-        firstName: 'John',
-        age: 32,
-      }),
-    )
+    return res(ctx.status(200))
   }),
 )
 

--- a/test/msw-api/setup-worker/start/error.test.ts
+++ b/test/msw-api/setup-worker/start/error.test.ts
@@ -21,7 +21,7 @@ describe('API: setupWorker / start with error', () => {
     })
     expect(logs).toHaveLength(1)
     expect(logs[0]).toMatchInlineSnapshot(`
-      "[MSW] Failed to register a ServiceWorker for scope ('http://localhost:62036/') with script ('http://localhost:62036/invalidServiceWorker'): A bad HTTP response code (404) was received when fetching the script. 
+      "[MSW] Failed to register a ServiceWorker for scope ('${runtime.page.url()}') with script ('${runtime.page.url()}invalidServiceWorker'): A bad HTTP response code (404) was received when fetching the script. 
             If the worker file has not been found maybe you didn't run \\"npx msw init <PUBLIC_DIR>\\""
     `)
     runtime.cleanup()

--- a/test/msw-api/setup-worker/start/error.test.ts
+++ b/test/msw-api/setup-worker/start/error.test.ts
@@ -1,0 +1,29 @@
+import * as path from 'path'
+import { runBrowserWith } from '../../../support/runBrowserWith'
+import { captureConsole } from '../../../support/captureConsole'
+
+describe('API: setupWorker / start with error', () => {
+  it('should print an error if we try to start woker with a non existent worker file', async () => {
+    const logs = []
+    const runtime = await runBrowserWith(
+      path.resolve(__dirname, 'error.mocks.ts'),
+    )
+    captureConsole(runtime.page, logs, (message) => {
+      return message.type() === 'error'
+    })
+    await runtime.page.evaluate(() => {
+      // @ts-ignore
+      return window.window.__MSW_START__({
+        serviceWorker: {
+          url: 'invalidServiceWorker',
+        },
+      })
+    })
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchInlineSnapshot(`
+      "[MSW] Failed to register a ServiceWorker for scope ('http://localhost:62036/') with script ('http://localhost:62036/invalidServiceWorker'): A bad HTTP response code (404) was received when fetching the script. 
+            If the worker file has not been found maybe you didn't run \\"npx msw init <PUBLIC_DIR>\\""
+    `)
+    runtime.cleanup()
+  })
+})

--- a/test/msw-api/setup-worker/start/error.test.ts
+++ b/test/msw-api/setup-worker/start/error.test.ts
@@ -1,29 +1,38 @@
 import * as path from 'path'
-import { runBrowserWith } from '../../../support/runBrowserWith'
+import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
 
-describe('API: setupWorker / start with error', () => {
-  it('should print an error if we try to start woker with a non existent worker file', async () => {
-    const logs = []
-    const runtime = await runBrowserWith(
-      path.resolve(__dirname, 'error.mocks.ts'),
-    )
-    captureConsole(runtime.page, logs, (message) => {
-      return message.type() === 'error'
-    })
-    await runtime.page.evaluate(() => {
-      // @ts-ignore
-      return window.window.__MSW_START__({
-        serviceWorker: {
-          url: 'invalidServiceWorker',
-        },
-      })
-    })
-    expect(logs).toHaveLength(1)
-    expect(logs[0]).toMatchInlineSnapshot(`
-      "[MSW] Failed to register a ServiceWorker for scope ('${runtime.page.url()}') with script ('${runtime.page.url()}invalidServiceWorker'): A bad HTTP response code (404) was received when fetching the script. 
-            If the worker file has not been found maybe you didn't run \\"npx msw init <PUBLIC_DIR>\\""
-    `)
-    runtime.cleanup()
+let runtime: TestAPI
+
+beforeAll(async () => {
+  runtime = await runBrowserWith(path.resolve(__dirname, 'error.mocks.ts'))
+})
+
+afterAll(() => runtime.cleanup())
+
+test('prints a custom error message when given a non-existing worker script', async () => {
+  const errors: string[] = []
+  captureConsole(runtime.page, errors, (message) => {
+    return message.type() === 'error'
   })
+
+  await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.window.__MSW_START__({
+      serviceWorker: {
+        url: 'invalidServiceWorker',
+      },
+    })
+  })
+
+  const workerNotFoundMessage = errors.find((message) => {
+    return (
+      message.startsWith(
+        `[MSW] Failed to register a Service Worker for scope ('${runtime.page.url()}')`,
+      ) &&
+      message.includes('Did you forget to run "npx msw init <PUBLIC_DIR>"?')
+    )
+  })
+
+  expect(workerNotFoundMessage).toBeTruthy()
 })


### PR DESCRIPTION
I have changed the error message that will be shown if  `navigator.serviceWorker.register` throw an error.

Now the error shows the complete message text from error object and a tip in the case the user didn't run `npx msw init <PUBLIC_DIR>` in his project.

An example of message is:

`[MSW] Failed to register a ServiceWorker for scope ('http://localhost:62036/') with script ('http://localhost:62036/invalidServiceWorker'): A bad HTTP response code (404) was received when fetching the script. 
            If the worker file has not been found maybe you didn't run "npx msw init <PUBLIC_DIR>"`