### PR TITLE
setupServer: use timers module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-namespace': 0,
+    '@typescript-eslint/no-var-requires': 0,
   },
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -72,6 +72,7 @@ const buildNode = {
     'events',
     'tty',
     'os',
+    'timers',
     'node-request-interceptor',
   ],
   output: {

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,3 +1,4 @@
+import timers from 'timers'
 import { Headers, flattenHeadersObject } from 'headers-utils'
 import {
   RequestInterceptor,
@@ -65,7 +66,9 @@ export const setupServer = (...requestHandlers: RequestHandlersList) => {
         }
 
         return new Promise<MockedInterceptedResponse>((resolve) => {
-          setTimeout(() => {
+          // using the timers module to ensure @sinon/fake-timers or jest fake timers
+          // don't affect this timeout.
+          timers.setTimeout(() => {
             resolve({
               status: response.status,
               statusText: response.statusText,

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -75,7 +75,7 @@ export const setupServer = (...requestHandlers: RequestHandlersList) => {
               headers: response.headers.getAllHeaders(),
               body: response.body,
             })
-          }, response.delay)
+          }, response.delay ?? 0)
         })
       })
     },

--- a/test/msw-api/setup-server/scenarios/fake-timers.test.ts
+++ b/test/msw-api/setup-server/scenarios/fake-timers.test.ts
@@ -1,0 +1,23 @@
+import fetch from 'node-fetch'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/pull', (req, res, ctx) => {
+    return res(ctx.json({ status: 'pulled' }))
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+test('tolerates fake timers', async () => {
+  jest.useFakeTimers()
+
+  const res = await fetch('https://test.mswjs.io/pull')
+  const body = await res.json()
+
+  jest.useRealTimers()
+
+  expect(body).toEqual({ status: 'pulled' })
+})


### PR DESCRIPTION
This is all that needs to be done to avoid issues with this code:

```javascript
test('tolerates fake timers', async () => {
  server.use(
    rest.get('https://test.mswjs.io/pull', (req, res, ctx) => {
      return res(ctx.json({status: 'pulled'}))
    }),
  )
  jest.useFakeTimers()

  const res = await fetch('https://test.mswjs.io/pull')
  const body = await res.json()

  jest.useRealTimers()

  expect(body).toEqual({status: 'pulled'})
})
```