### PR TITLE
Added feature: res.networkError() mocks a network error

### DIFF
--- a/src/handlers/requestHandler.ts
+++ b/src/handlers/requestHandler.ts
@@ -40,6 +40,8 @@ export type RequestParams = {
   [paramName: string]: any
 }
 
+type ResponseResolverReturnType = MockedResponse | undefined | void
+
 export type ResponseResolver<
   RequestType = MockedRequest,
   ContextType = typeof defaultContext
@@ -47,7 +49,7 @@ export type ResponseResolver<
   req: RequestType,
   res: ResponseComposition,
   context: ContextType,
-) => Promise<MockedResponse> | MockedResponse
+) => Promise<ResponseResolverReturnType> | ResponseResolverReturnType
 
 export interface RequestHandler<
   RequestType = MockedRequest,

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -79,7 +79,7 @@ self.addEventListener('fetch', async function (event) {
   }
 
   event.respondWith(
-    new Promise(async (resolve) => {
+    new Promise(async (resolve, reject) => {
       const client = await event.target.clients.get(clientId)
 
       if (
@@ -142,6 +142,15 @@ self.addEventListener('fetch', async function (event) {
 
         case 'MOCK_NOT_FOUND': {
           return resolve(getOriginalResponse())
+        }
+
+        case 'NETWORK_ERROR': {
+          const { name, message } = clientMessage.payload
+          const networkError = new Error(message)
+          networkError.name = name
+
+          // Rejecting a request Promise emulates a network error.
+          return reject(networkError)
         }
 
         case 'INTERNAL_ERROR': {

--- a/src/response.ts
+++ b/src/response.ts
@@ -20,6 +20,7 @@ export type ResponseComposition = ResponseFunction & {
    * Does not affect any subsequent captured requests.
    */
   once: ResponseFunction
+  networkError: () => never
 }
 
 export const defaultResponse: Omit<MockedResponse, 'headers'> = {
@@ -57,5 +58,8 @@ export const response: ResponseComposition = Object.assign(
   createResponseComposition(),
   {
     once: createResponseComposition({ once: true }),
+    networkError: () => {
+      throw new Error('Network error')
+    },
   },
 )

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,5 +1,6 @@
 import { Headers } from 'headers-utils'
 import { compose } from './utils/internal/compose'
+import { NetworkError } from './utils/NetworkError'
 
 export interface MockedResponse {
   body: any
@@ -59,7 +60,7 @@ export const response: ResponseComposition = Object.assign(
   {
     once: createResponseComposition({ once: true }),
     networkError(message: string) {
-      Promise.reject(new Error(message))
+      throw new NetworkError(message)
     },
   },
 )

--- a/src/response.ts
+++ b/src/response.ts
@@ -20,7 +20,7 @@ export type ResponseComposition = ResponseFunction & {
    * Does not affect any subsequent captured requests.
    */
   once: ResponseFunction
-  networkError: () => never
+  networkError: (message: string) => void
 }
 
 export const defaultResponse: Omit<MockedResponse, 'headers'> = {
@@ -58,8 +58,8 @@ export const response: ResponseComposition = Object.assign(
   createResponseComposition(),
   {
     once: createResponseComposition({ once: true }),
-    networkError: () => {
-      throw new Error('Network error')
+    networkError(message: string) {
+      Promise.reject(new Error(message))
     },
   },
 )

--- a/src/utils/NetworkError.ts
+++ b/src/utils/NetworkError.ts
@@ -1,0 +1,6 @@
+export class NetworkError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NetworkError'
+  }
+}

--- a/src/utils/createBroadcastChannel.ts
+++ b/src/utils/createBroadcastChannel.ts
@@ -6,6 +6,7 @@ export interface ServiceWorkerMessage<T> {
 export type ClientMessageTypes =
   | 'MOCK_NOT_FOUND'
   | 'MOCK_SUCCESS'
+  | 'NETWORK_ERROR'
   | 'INTERNAL_ERROR'
 
 /**

--- a/src/utils/getResponse.ts
+++ b/src/utils/getResponse.ts
@@ -59,11 +59,7 @@ export const getResponse = async <
     : req
   const context = defineContext ? defineContext(publicRequest) : defaultContext
 
-  const mockedResponse: MockedResponse | undefined = await resolver(
-    publicRequest,
-    response,
-    context,
-  )
+  const mockedResponse = await resolver(publicRequest, response, context)
 
   // Handle a scenario when a request handler is present,
   // but returns no mocked response (i.e. misses a `return res()` statement).

--- a/test/msw-api/res/network-error.mocks.ts
+++ b/test/msw-api/res/network-error.mocks.ts
@@ -1,0 +1,10 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (_, res) => {
+    return res.networkError()
+  }),
+)
+
+// @ts-ignore
+window.__MSW_START__ = worker.start

--- a/test/msw-api/res/network-error.mocks.ts
+++ b/test/msw-api/res/network-error.mocks.ts
@@ -1,8 +1,8 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.get('http://test.io/user', (_, res) => {
-    return res.networkError('Network error')
+  rest.get('/user', (_, res) => {
+    return res.networkError('Custom network error message')
   }),
 )
 

--- a/test/msw-api/res/network-error.mocks.ts
+++ b/test/msw-api/res/network-error.mocks.ts
@@ -6,5 +6,4 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.__MSW_START__ = worker.start
+worker.start()

--- a/test/msw-api/res/network-error.mocks.ts
+++ b/test/msw-api/res/network-error.mocks.ts
@@ -1,7 +1,7 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.get('/user', (_, res) => {
+  rest.get('http://test.io', (_, res) => {
     return res.networkError()
   }),
 )

--- a/test/msw-api/res/network-error.mocks.ts
+++ b/test/msw-api/res/network-error.mocks.ts
@@ -1,8 +1,8 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.get('http://test.io', (_, res) => {
-    return res.networkError()
+  rest.get('http://test.io/user', (_, res) => {
+    return res.networkError('Network error')
   }),
 )
 

--- a/test/msw-api/res/network-error.node.test.ts
+++ b/test/msw-api/res/network-error.node.test.ts
@@ -12,10 +12,10 @@ afterAll(() => server.close())
 
 test('res.networkError causes Fetch API to throw error', async () => {
   server.use(
-    rest.get('http://test.io', (_, res) => {
-      return res.networkError()
+    rest.get('http://test.io/user', (_, res) => {
+      return res.networkError('Network error')
     }),
   )
 
-  await expect(fetch('http://test.io')).rejects.toThrow()
+  await expect(fetch('http://test.io/user')).rejects.toThrow('Network error')
 })

--- a/test/msw-api/res/network-error.node.test.ts
+++ b/test/msw-api/res/network-error.node.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import fetch from 'node-fetch'
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+test('res.networkError causes Fetch API to throw error', async () => {
+  server.use(
+    rest.get('https://api.backend.com/path', (_, res) => {
+      return res.networkError()
+    }),
+  )
+
+  expect(fetch('https://api.backend.com/path')).toThrow(
+    'Mocked network error message',
+  )
+})

--- a/test/msw-api/res/network-error.node.test.ts
+++ b/test/msw-api/res/network-error.node.test.ts
@@ -1,21 +1,23 @@
 /**
  * @jest-environment node
  */
+import fetch from 'node-fetch'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
-import fetch from 'node-fetch'
 
 const server = setupServer()
 
 beforeAll(() => server.listen())
 afterAll(() => server.close())
 
-test('res.networkError causes Fetch API to throw error', async () => {
+test('throws a network error when used with fetch', async () => {
   server.use(
     rest.get('http://test.io/user', (_, res) => {
-      return res.networkError('Network error')
+      return res.networkError('Custom network error message')
     }),
   )
 
-  await expect(fetch('http://test.io/user')).rejects.toThrow('Network error')
+  await expect(fetch('http://test.io/user')).rejects.toThrow(
+    'Custom network error message',
+  )
 })

--- a/test/msw-api/res/network-error.node.test.ts
+++ b/test/msw-api/res/network-error.node.test.ts
@@ -12,12 +12,10 @@ afterAll(() => server.close())
 
 test('res.networkError causes Fetch API to throw error', async () => {
   server.use(
-    rest.get('https://api.backend.com/path', (_, res) => {
+    rest.get('http://test.io', (_, res) => {
       return res.networkError()
     }),
   )
 
-  expect(fetch('https://api.backend.com/path')).toThrow(
-    'Mocked network error message',
-  )
+  await expect(fetch('http://test.io')).rejects.toThrow()
 })

--- a/test/msw-api/res/network-error.test.ts
+++ b/test/msw-api/res/network-error.test.ts
@@ -1,0 +1,16 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
+
+let runtime: TestAPI
+
+beforeAll(async () => {
+  runtime = await runBrowserWith(
+    path.resolve(__dirname, 'network-error.mocks.ts'),
+  )
+})
+
+afterAll(() => runtime.cleanup())
+
+test('res.networkError causes Fetch API to throw error', async () => {
+  expect(runtime.request({ url: `${runtime.origin}/user` })).toThrow()
+})

--- a/test/msw-api/res/network-error.test.ts
+++ b/test/msw-api/res/network-error.test.ts
@@ -12,5 +12,5 @@ beforeAll(async () => {
 afterAll(() => runtime.cleanup())
 
 test('res.networkError causes Fetch API to throw error', async () => {
-  expect(runtime.request({ url: `${runtime.origin}/user` })).toThrow()
+  expect(runtime.request({ url: `http://test.io` })).rejects.toThrow()
 })

--- a/test/msw-api/res/network-error.test.ts
+++ b/test/msw-api/res/network-error.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../../support/runBrowserWith'
+import { captureConsole } from '../../support/captureConsole'
 
 let runtime: TestAPI
 
@@ -11,8 +12,25 @@ beforeAll(async () => {
 
 afterAll(() => runtime.cleanup())
 
-test('res.networkError causes Fetch API to throw error', async () => {
-  expect(runtime.request({ url: 'http://test.io/user' })).rejects.toThrow(
-    'Network error',
+test('throws a network error', async () => {
+  const errors: string[] = []
+  captureConsole(runtime.page, errors, (message) => {
+    return message.type() === 'error'
+  })
+
+  // Do not use `runtime.request()`, because it always awaits a response.
+  // In this case we await a network error, performing a request manually.
+  const requestPromise = runtime.page.evaluate(() => {
+    return fetch('/user')
+  })
+
+  await expect(requestPromise).rejects.toThrow(
+    // The `fetch` call itself rejects with the "Failed to fetch" error,
+    // the same error that happens on a regular network error.
+    'Evaluation failed: TypeError: Failed to fetch',
   )
+
+  // Assert a network error message printed into the console
+  // before `fetch` rejects.
+  expect(errors).toContain('Failed to load resource: net::ERR_FAILED')
 })

--- a/test/msw-api/res/network-error.test.ts
+++ b/test/msw-api/res/network-error.test.ts
@@ -12,5 +12,7 @@ beforeAll(async () => {
 afterAll(() => runtime.cleanup())
 
 test('res.networkError causes Fetch API to throw error', async () => {
-  expect(runtime.request({ url: `http://test.io` })).rejects.toThrow()
+  expect(runtime.request({ url: 'http://test.io/user' })).rejects.toThrow(
+    'Network error',
+  )
 })


### PR DESCRIPTION
I added the feature so you can now use `res.networkError()` inside a request handler to mock a network request. This is useful because this will trigger the Fetch API to throw an error, and you can thus test whether your function handles this error correctly. 

## GitHub

- Fixes #280
