### PR TITLE
fix(isNodeProcess): avoid undefined error

### DIFF
--- a/src/utils/isNodeProcess.react-native.test.ts
+++ b/src/utils/isNodeProcess.react-native.test.ts
@@ -1,25 +1,47 @@
 // @ts-nocheck
 /**
+ * @jest-environment jsdom
+ */
+/**
  * Test in React Native Environment
+ * Please see https://github.com/mswjs/msw/pull/255
  */
 
 import { isNodeProcess } from './isNodeProcess'
 
-test('returns true when run in a react native environment', () => {
-  const originalProcess = global.process
+// need to mock process and navigator in React Native and restore them
+let originalNavigator
+let originalProcess
+
+beforeAll(() => {
+  // back up
+  originalNavigator = global.navigator
+  originalProcess = global.process
+
+  /**
+   * because it runs in node, Object.proyotype.toString(global.process) will equal '[object process]',
+   * we need to mock global.process and global.navigator. let them behave like in React Native
+   * PLease see https://github.com/facebook/react-native/blob/master/Libraries/Core/setUpNavigator.js and
+   * https://github.com/facebook/react-native/blob/master/Libraries/Core/setUpGlobals.js
+   */
   global.process = {
     env: {
       NODE_ENV: 'development',
     },
   }
-
-  const originalNavigator = global.navigator
   Object.defineProperty(global.navigator, 'product', {
     get: () => {
       return 'ReactNative'
     },
   })
+})
+
+test('returns true when run in a react native environment', () => {
   expect(isNodeProcess()).toBe(true)
+})
+
+afterAll(() => {
+  // restore them
   global.process = originalProcess
   global.navigator = originalNavigator
 })

--- a/src/utils/isNodeProcess.react-native.test.ts
+++ b/src/utils/isNodeProcess.react-native.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+/**
+ * Test in React Native Environment
+ */
+
+import { isNodeProcess } from './isNodeProcess'
+
+test('returns true when run in a react native environment', () => {
+  const originalProcess = global.process
+  global.process = {
+    env: {
+      NODE_ENV: 'development',
+    },
+  }
+
+  const originalNavigator = global.navigator
+  Object.defineProperty(global.navigator, 'product', {
+    get: () => {
+      return 'ReactNative'
+    },
+  })
+  expect(isNodeProcess()).toBe(true)
+  global.process = originalProcess
+  global.navigator = originalNavigator
+})

--- a/src/utils/isNodeProcess.ts
+++ b/src/utils/isNodeProcess.ts
@@ -2,5 +2,5 @@
  * Returns a boolean indicating if the current process is running in NodeJS environment.
  */
 export function isNodeProcess() {
-  return Object.prototype.toString.call(global.process) === '[object process]'
+  return typeof process === 'object'
 }

--- a/src/utils/isNodeProcess.ts
+++ b/src/utils/isNodeProcess.ts
@@ -1,6 +1,18 @@
 /**
  * Returns a boolean indicating if the current process is running in NodeJS environment.
  */
+// Please see https://github.com/mswjs/msw/pull/255
 export function isNodeProcess() {
-  return typeof process === 'object'
+  if (typeof global !== 'object') {
+    // check browser environment
+    return false
+  }
+
+  if (
+    Object.prototype.toString.call(global.process) === '[object process]' ||
+    navigator.product === 'ReactNative'
+  ) {
+    // check nodejs or react native environment
+    return true
+  }
 }


### PR DESCRIPTION
Hi, Thanks for the amazing tool. I try to use it in a browser, but `global is not defined` came out. I think it maybe caused by `isNodeProcess` function. Change it to `typeof process ==='object'` may solve this problem.