### PR TITLE
Add an option to warn/error on unhandled requests

### DIFF
--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,3 +1,0 @@
-import { SharedOptions } from '../sharedOptions'
-
-export type ListenOptions = SharedOptions

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,0 +1,5 @@
+import { OnUnhandledRequest } from '../onUnhandledRequest'
+
+export interface ListenOptions {
+  onUnhandledRequest?: OnUnhandledRequest
+}

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,5 +1,3 @@
-import { OnUnhandledRequest } from '../onUnhandledRequest'
+import { SharedOptions } from '../sharedOptions'
 
-export interface ListenOptions {
-  onUnhandledRequest?: OnUnhandledRequest
-}
+export type ListenOptions = SharedOptions

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -11,8 +11,9 @@ import { parseRequestBody } from '../utils/request/parseRequestBody'
 import { isNodeProcess } from '../utils/isNodeProcess'
 import * as requestHandlerUtils from '../utils/requestHandlerUtils'
 import { ListenOptions } from './glossary'
+import { onUnhandledRequest } from '../onUnhandledRequest'
 
-const DEFAULT_LISTEN_OPTIONS: DeepRequired<ListenOptions> = {
+const DEFAULT_LISTEN_OPTIONS: ListenOptions = {
   onUnhandledRequest: 'bypass',
 }
 
@@ -81,29 +82,7 @@ export const setupServer = (...requestHandlers: RequestHandlersList) => {
         const { response } = await getResponse(mockedRequest, currentHandlers)
 
         if (!response) {
-          if (resolvedOptions.onUnhandledRequest === 'warn') {
-            // Produce a developer-friendly warning
-            return console.warn(
-              `A request to ${mockedRequest.url} was detected but not mocked because no request handler matching the URL exists.`,
-            )
-          }
-
-          if (resolvedOptions.onUnhandledRequest === 'error') {
-            // Throw an exception
-
-            // throw new Error(`A request to ${req.url} was detected but not mocked because no request handler matching the URL exists.`)
-            return
-          }
-
-          if (typeof resolvedOptions.onUnhandledRequest === 'function') {
-            resolvedOptions.onUnhandledRequest(mockedRequest)
-            return
-          }
-
-          // resolvedOptions.onUnhandledRequest === 'bypass'
-
-          // Return nothing, if no mocked response associated with this request.
-          // That makes `node-request-interceptor` to perform the request as-is.
+          onUnhandledRequest(mockedRequest, resolvedOptions.onUnhandledRequest)
           return
         }
 

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -10,8 +10,10 @@ import { getResponse } from '../utils/getResponse'
 import { parseRequestBody } from '../utils/request/parseRequestBody'
 import { isNodeProcess } from '../utils/isNodeProcess'
 import * as requestHandlerUtils from '../utils/requestHandlerUtils'
-import { ListenOptions } from './glossary'
+import { SharedOptions } from '../sharedOptions'
 import { onUnhandledRequest } from '../onUnhandledRequest'
+
+type ListenOptions = SharedOptions
 
 const DEFAULT_LISTEN_OPTIONS: ListenOptions = {
   onUnhandledRequest: 'bypass',

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -96,7 +96,8 @@ export const setupServer = (...requestHandlers: RequestHandlersList) => {
           }
 
           if (typeof resolvedOptions.onUnhandledRequest === 'function') {
-            return resolvedOptions.onUnhandledRequest(mockedRequest)
+            resolvedOptions.onUnhandledRequest(mockedRequest)
+            return
           }
 
           // resolvedOptions.onUnhandledRequest === 'bypass'

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -83,16 +83,20 @@ export const setupServer = (...requestHandlers: RequestHandlersList) => {
         if (!response) {
           if (resolvedOptions.onUnhandledRequest === 'warn') {
             // Produce a developer-friendly warning
-            return
+            return console.warn(
+              `A request to ${mockedRequest.url} was detected but not mocked because no request handler matching the URL exists.`,
+            )
           }
 
           if (resolvedOptions.onUnhandledRequest === 'error') {
             // Throw an exception
+
+            // throw new Error(`A request to ${req.url} was detected but not mocked because no request handler matching the URL exists.`)
             return
           }
 
           if (typeof resolvedOptions.onUnhandledRequest === 'function') {
-            return
+            return resolvedOptions.onUnhandledRequest(mockedRequest)
           }
 
           // resolvedOptions.onUnhandledRequest === 'bypass'

--- a/src/onUnhandledRequest.ts
+++ b/src/onUnhandledRequest.ts
@@ -6,7 +6,7 @@ export type OnUnhandledRequest = 'bypass' | 'warn' | 'error' | CustomFunction
 
 export function onUnhandledRequest(
   request: MockedRequest,
-  onUnhandledRequest: OnUnhandledRequest,
+  onUnhandledRequest: OnUnhandledRequest = 'bypass',
 ) {
   if (typeof onUnhandledRequest === 'function') {
     onUnhandledRequest(request)

--- a/src/onUnhandledRequest.ts
+++ b/src/onUnhandledRequest.ts
@@ -1,28 +1,34 @@
 import { MockedRequest } from './handlers/requestHandler'
 
-type CustomFunction = (req: MockedRequest) => void
+type UnhandledRequestCallback = (req: MockedRequest) => void
 
-export type OnUnhandledRequest = 'bypass' | 'warn' | 'error' | CustomFunction
+export type OnUnhandledRequest =
+  | 'bypass'
+  | 'warn'
+  | 'error'
+  | UnhandledRequestCallback
 
 export function onUnhandledRequest(
   request: MockedRequest,
   onUnhandledRequest: OnUnhandledRequest = 'bypass',
-) {
+): void {
   if (typeof onUnhandledRequest === 'function') {
     onUnhandledRequest(request)
     return
   }
 
-  if (['warn', 'error'].includes(onUnhandledRequest)) {
-    const message = `[MSW] A request to ${request.url} was detected but not mocked because no request handler matching the URL exists.`
+  const message = `captured a ${request.method} ${request.url} request without a corresponding request handler.`
 
-    if (onUnhandledRequest === 'warn') {
-      console.warn(message)
-    } else {
-      throw new Error(message)
+  switch (onUnhandledRequest) {
+    case 'error': {
+      throw new Error(`[MSW] Error: ${message}`)
     }
-    return
-  }
 
-  // if onUnhandledRequest is 'bypass' we have nothing to do.
+    case 'warn': {
+      console.warn(`[MSW] Warning: ${message}`)
+    }
+
+    default:
+      return
+  }
 }

--- a/src/onUnhandledRequest.ts
+++ b/src/onUnhandledRequest.ts
@@ -3,3 +3,26 @@ import { MockedRequest } from './handlers/requestHandler'
 type CustomFunction = (req: MockedRequest) => void
 
 export type OnUnhandledRequest = 'bypass' | 'warn' | 'error' | CustomFunction
+
+export function onUnhandledRequest(
+  request: MockedRequest,
+  onUnhandledRequest: OnUnhandledRequest,
+) {
+  if (typeof onUnhandledRequest === 'function') {
+    onUnhandledRequest(request)
+    return
+  }
+
+  if (['warn', 'error'].includes(onUnhandledRequest)) {
+    const message = `[MSW] A request to ${request.url} was detected but not mocked because no request handler matching the URL exists.`
+
+    if (onUnhandledRequest === 'warn') {
+      console.warn(message)
+    } else {
+      throw new Error(message)
+    }
+    return
+  }
+
+  // if onUnhandledRequest is 'bypass' we have nothing to do.
+}

--- a/src/onUnhandledRequest.ts
+++ b/src/onUnhandledRequest.ts
@@ -1,3 +1,5 @@
-type CustomFunction = () => void
+import { MockedRequest } from './handlers/requestHandler'
+
+type CustomFunction = (req: MockedRequest) => void
 
 export type OnUnhandledRequest = 'bypass' | 'warn' | 'error' | CustomFunction

--- a/src/onUnhandledRequest.ts
+++ b/src/onUnhandledRequest.ts
@@ -1,0 +1,3 @@
+type CustomFunction = () => void
+
+export type OnUnhandledRequest = 'bypass' | 'warn' | 'error' | CustomFunction

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -1,6 +1,7 @@
 import { HeadersList } from 'headers-utils'
 import { RequestHandler } from '../handlers/requestHandler'
 import { MockedResponse } from '../response'
+import { OnUnhandledRequest } from '../onUnhandledRequest'
 
 export type Mask = RegExp | string
 
@@ -32,6 +33,8 @@ export interface StartOptions {
    * instance is ready. Defaults to `true`.
    */
   waitUntilReady?: boolean
+
+  onUnhandledRequest?: OnUnhandledRequest
 }
 
 export type RequestHandlersList = RequestHandler<any, any>[]

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -1,7 +1,7 @@
 import { HeadersList } from 'headers-utils'
 import { RequestHandler } from '../handlers/requestHandler'
 import { MockedResponse } from '../response'
-import { OnUnhandledRequest } from '../onUnhandledRequest'
+import { SharedOptions } from '../sharedOptions'
 
 export type Mask = RegExp | string
 
@@ -16,7 +16,7 @@ export type ServiceWorkerInstanceTuple = [
   ServiceWorkerRegistration,
 ]
 
-export interface StartOptions {
+export interface StartOptions extends SharedOptions {
   serviceWorker?: {
     url?: string
     options?: RegistrationOptions
@@ -33,8 +33,6 @@ export interface StartOptions {
    * instance is ready. Defaults to `true`.
    */
   waitUntilReady?: boolean
-
-  onUnhandledRequest?: OnUnhandledRequest
 }
 
 export type RequestHandlersList = RequestHandler<any, any>[]

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -16,7 +16,7 @@ export type ServiceWorkerInstanceTuple = [
   ServiceWorkerRegistration,
 ]
 
-export interface StartOptions extends SharedOptions {
+export type StartOptions = SharedOptions & {
   serviceWorker?: {
     url?: string
     options?: RegistrationOptions

--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -17,6 +17,7 @@ const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
   },
   quiet: false,
   waitUntilReady: true,
+  onUnhandledRequest: 'bypass',
 }
 
 export const createStart = (context: SetupWorkerInternalContext) => {

--- a/src/sharedOptions.ts
+++ b/src/sharedOptions.ts
@@ -1,0 +1,5 @@
+import { OnUnhandledRequest } from './onUnhandledRequest'
+
+export interface SharedOptions {
+  onUnhandledRequest?: OnUnhandledRequest
+}

--- a/src/sharedOptions.ts
+++ b/src/sharedOptions.ts
@@ -1,5 +1,12 @@
 import { OnUnhandledRequest } from './onUnhandledRequest'
 
 export interface SharedOptions {
+  /**
+   * Specifies how to react to a request that has no corresponding
+   * request handler. Bypasses such requests by default.
+   *
+   * @example worker.start({ onUnhandledRequest: 'warn' })
+   * @example server.listen({ onUnhandledRequest: 'error' })
+   */
   onUnhandledRequest?: OnUnhandledRequest
 }

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -75,6 +75,22 @@ export const handleRequestWith = (
       // Handle a scenario when there is no request handler
       // found for a given request.
       if (!handler) {
+        if (options.onUnhandledRequest === 'warn') {
+          // Produce a developer-friendly warning
+          return
+        }
+
+        if (options.onUnhandledRequest === 'error') {
+          // Throw an exception
+          return
+        }
+
+        if (typeof options.onUnhandledRequest === 'function') {
+          return
+        }
+
+        // options.onUnhandledRequest === 'bypass'
+
         return channel.send({ type: 'MOCK_NOT_FOUND' })
       }
 

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -77,16 +77,16 @@ export const handleRequestWith = (
       if (!handler) {
         if (options.onUnhandledRequest === 'warn') {
           // Produce a developer-friendly warning
-          return
+          return channel.send({ type: 'MOCK_NOT_FOUND' })
         }
 
         if (options.onUnhandledRequest === 'error') {
           // Throw an exception
-          return
+          return channel.send({ type: 'MOCK_NOT_FOUND' })
         }
 
         if (typeof options.onUnhandledRequest === 'function') {
-          return
+          return channel.send({ type: 'MOCK_NOT_FOUND' })
         }
 
         // options.onUnhandledRequest === 'bypass'

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -10,6 +10,7 @@ import {
   createBroadcastChannel,
 } from '../utils/createBroadcastChannel'
 import { getResponse } from '../utils/getResponse'
+import { onUnhandledRequest } from '../onUnhandledRequest'
 import { parseRequestBody } from './request/parseRequestBody'
 import { getRequestCookies } from './request/getRequestCookies'
 import { isStringEqual } from './isStringEqual'
@@ -75,27 +76,7 @@ export const handleRequestWith = (
       // Handle a scenario when there is no request handler
       // found for a given request.
       if (!handler) {
-        if (options.onUnhandledRequest === 'warn') {
-          // Produce a developer-friendly warning
-          console.warn(
-            `A request to ${req.url} was detected but not mocked because no request handler matching the URL exists.`,
-          )
-          return channel.send({ type: 'MOCK_NOT_FOUND' })
-        }
-
-        if (options.onUnhandledRequest === 'error') {
-          // Throw an exception
-
-          // throw new Error(`A request to ${req.url} was detected but not mocked because no request handler matching the URL exists.`)
-          return channel.send({ type: 'MOCK_NOT_FOUND' })
-        }
-
-        if (typeof options.onUnhandledRequest === 'function') {
-          options.onUnhandledRequest(req)
-          return channel.send({ type: 'MOCK_NOT_FOUND' })
-        }
-
-        // options.onUnhandledRequest === 'bypass'
+        onUnhandledRequest(req, options.onUnhandledRequest)
 
         return channel.send({ type: 'MOCK_NOT_FOUND' })
       }

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -77,15 +77,21 @@ export const handleRequestWith = (
       if (!handler) {
         if (options.onUnhandledRequest === 'warn') {
           // Produce a developer-friendly warning
+          console.warn(
+            `A request to ${req.url} was detected but not mocked because no request handler matching the URL exists.`,
+          )
           return channel.send({ type: 'MOCK_NOT_FOUND' })
         }
 
         if (options.onUnhandledRequest === 'error') {
           // Throw an exception
+
+          // throw new Error(`A request to ${req.url} was detected but not mocked because no request handler matching the URL exists.`)
           return channel.send({ type: 'MOCK_NOT_FOUND' })
         }
 
         if (typeof options.onUnhandledRequest === 'function') {
+          options.onUnhandledRequest(req)
           return channel.send({ type: 'MOCK_NOT_FOUND' })
         }
 

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/bypass.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/bypass.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => {
+  server.close()
+  jest.restoreAllMocks()
+})
+
+test('bypasses unhandled requests by default', async () => {
+  jest.spyOn(global.console, 'error')
+  jest.spyOn(global.console, 'warn')
+
+  const res = await fetch('https://test.mswjs.io')
+
+  // Request should be performed as-is
+  expect(res).toHaveProperty('status', 404)
+
+  // No warnings/errors should be printed
+  expect(console.error).not.toBeCalled()
+  expect(console.warn).not.toBeCalled()
+})

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/callback-throws.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/callback-throws.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest(req) {
+      throw new Error(`Custom error for ${req.method} ${req.url}`)
+    },
+  }),
+)
+afterAll(() => server.close())
+
+test('prevents a request when a custom callback throws an exception', async () => {
+  const getResponse = () => fetch('https://test.mswjs.io')
+
+  // Request should be cancelled with a fetch error, since the callback threw.
+  await expect(getResponse()).rejects.toThrow(
+    'request to https://test.mswjs.io/ failed, reason: Custom error for GET https://test.mswjs.io/',
+  )
+})

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/callback.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/callback.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { setupServer } from 'msw/node'
+import { rest, MockedRequest } from 'msw'
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+const logs = []
+
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest(req) {
+      logs.push(`${req.method} ${req.url}`)
+    },
+  }),
+)
+afterAll(() => server.close())
+
+test('executes given callback function on un unmatched request', async () => {
+  const res = await fetch('https://test.mswjs.io')
+
+  // Request should be performed as-is, since the callback didn't throw.
+  expect(res).toHaveProperty('status', 404)
+  expect(logs).toEqual(['GET https://test.mswjs.io/'])
+})

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/user', (req, res, ctx) => {
+    return res(ctx.json({ mocked: true }))
+  }),
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterAll(() => server.close())
+
+test('errors on unhandled request when using the "error" value', async () => {
+  const getResponse = () => fetch('https://test.mswjs.io')
+
+  await expect(getResponse()).rejects.toThrow(
+    'request to https://test.mswjs.io/ failed, reason: [MSW] Error: captured a GET https://test.mswjs.io/ request without a corresponding request handler.',
+  )
+})

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/warn.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/warn.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
+afterAll(() => {
+  server.close()
+  jest.restoreAllMocks()
+})
+
+test('warns on unhandled request when using the "warn" value', async () => {
+  jest.spyOn(global.console, 'warn')
+
+  const res = await fetch('https://test.mswjs.io')
+
+  expect(res).toHaveProperty('status', 404)
+  expect(console.warn).toBeCalledWith(
+    '[MSW] Warning: captured a GET https://test.mswjs.io/ request without a corresponding request handler.',
+  )
+})

--- a/test/msw-api/setup-worker/start/on-unhandled-request/bypass.mocks.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/bypass.mocks.ts
@@ -1,0 +1,11 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+// By default any unhandled requests are bypass,
+// meaning performed as-is.
+worker.start()

--- a/test/msw-api/setup-worker/start/on-unhandled-request/bypass.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/bypass.test.ts
@@ -1,0 +1,57 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../../../../support/runBrowserWith'
+
+let runtimeRef: TestAPI
+
+async function startWorker() {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'bypass.mocks.ts'),
+  )
+
+  runtime.page.on('console', (message) => {
+    const messageText = message.text()
+
+    switch (message.type()) {
+      case 'warning': {
+        if (messageText.startsWith('[MSW]')) {
+          warnings.push(messageText)
+          break
+        }
+      }
+
+      case 'error': {
+        if (messageText.startsWith('[MSW]')) {
+          errors.push(messageText)
+          break
+        }
+      }
+    }
+  })
+
+  runtimeRef = runtime
+
+  return { runtime, errors, warnings }
+}
+
+afterEach(async () => {
+  await runtimeRef.cleanup()
+})
+
+test('bypasses an unhandled request by default', async () => {
+  const { runtime, errors, warnings } = await startWorker()
+
+  const res = await runtime.request({
+    url: 'https://mswjs.io/non-existing-page',
+  })
+  const status = res.status()
+
+  // Produces no MSW warnings/errors.
+  expect(errors).toHaveLength(0)
+  expect(warnings).toHaveLength(0)
+
+  // Performs the request as-is.
+  expect(status).toBe(404)
+})

--- a/test/msw-api/setup-worker/start/on-unhandled-request/callback-throws.mocks.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/callback-throws.mocks.ts
@@ -1,0 +1,13 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start({
+  onUnhandledRequest(req) {
+    throw new Error(`Forbid unhandled ${req.method} ${req.url.href}`)
+  },
+})

--- a/test/msw-api/setup-worker/start/on-unhandled-request/callback.mocks.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/callback.mocks.ts
@@ -1,0 +1,13 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start({
+  onUnhandledRequest(req) {
+    console.log(`Oops, unhandled ${req.method} ${req.url.href}`)
+  },
+})

--- a/test/msw-api/setup-worker/start/on-unhandled-request/callback.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/callback.test.ts
@@ -1,0 +1,68 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../../../../support/runBrowserWith'
+
+let runtimeRef: TestAPI
+
+async function startWorker() {
+  const logs: string[] = []
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'callback.mocks.ts'),
+  )
+
+  runtime.page.on('console', (message) => {
+    const messageText = message.text()
+
+    switch (message.type()) {
+      case 'log': {
+        logs.push(messageText)
+        break
+      }
+
+      case 'warning': {
+        if (messageText.startsWith('[MSW]')) {
+          warnings.push(messageText)
+          break
+        }
+      }
+
+      case 'error': {
+        if (messageText.startsWith('[MSW]')) {
+          errors.push(messageText)
+          break
+        }
+      }
+    }
+  })
+
+  runtimeRef = runtime
+
+  return { runtime, logs, errors, warnings }
+}
+
+afterEach(async () => {
+  await runtimeRef.cleanup()
+})
+
+test('executes a given callback on an unhandled request', async () => {
+  const { runtime, logs, warnings, errors } = await startWorker()
+
+  const res = await runtime.request({
+    url: 'https://mswjs.io/non-existing-page',
+  })
+  const status = res.status()
+
+  // Request is performed as-is.
+  expect(status).toBe(404)
+
+  // Custom callback executed.
+  expect(logs).toContain(
+    'Oops, unhandled GET https://mswjs.io/non-existing-page',
+  )
+
+  // No warnings/errors produced by MSW.
+  expect(errors).toHaveLength(0)
+  expect(warnings).toHaveLength(0)
+})

--- a/test/msw-api/setup-worker/start/on-unhandled-request/error.mocks.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/error.mocks.ts
@@ -1,0 +1,13 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start({
+  // Produce an error and cancel a request, if it's not handled
+  // in the request handlers above.
+  onUnhandledRequest: 'error',
+})

--- a/test/msw-api/setup-worker/start/on-unhandled-request/warn.mocks.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/warn.mocks.ts
@@ -1,0 +1,13 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start({
+  // Warn on the requests that are not handled in the request handlers above.
+  // Does not cancel the request.
+  onUnhandledRequest: 'warn',
+})

--- a/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
@@ -1,0 +1,54 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../../../../support/runBrowserWith'
+
+let runtimeRef: TestAPI
+
+async function startWorker() {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  const runtime = await runBrowserWith(path.resolve(__dirname, 'warn.mocks.ts'))
+
+  runtime.page.on('console', (message) => {
+    const messageText = message.text()
+
+    switch (message.type()) {
+      case 'warning': {
+        if (messageText.startsWith('[MSW]')) {
+          warnings.push(messageText)
+          break
+        }
+      }
+
+      case 'error': {
+        if (messageText.startsWith('[MSW]')) {
+          errors.push(messageText)
+          break
+        }
+      }
+    }
+  })
+
+  runtimeRef = runtime
+
+  return { runtime, errors, warnings }
+}
+
+afterEach(async () => {
+  await runtimeRef.cleanup()
+})
+
+test('warns on an unhandled request when using the "warn" option', async () => {
+  const { runtime, warnings, errors } = await startWorker()
+
+  const res = await runtime.request({
+    url: 'https://mswjs.io/non-existing-page',
+  })
+  const status = res.status()
+
+  expect(status).toBe(404)
+  expect(errors).toHaveLength(0)
+  expect(warnings).toContain(
+    '[MSW] Warning: captured a GET https://mswjs.io/non-existing-page request without a corresponding request handler.',
+  )
+})


### PR DESCRIPTION
## GitHub

- Resolves #191

### Specification
This specification will be kept up to date as we iterate over the functionality.

An _unhandled request_ is a request that has no corresponding request handler. It's possible to configure MSW to handle such requests differently. For example, MSW could notify the user with a warning or error message when a request has no corresponding request handler.

#### onUnhandledRequest
Both worker and server instances accept the `onUnhanledRequest` configuration option. This allows the user to choose a provided functionality or provide their own through a custom function:
```ts
type OnUnhandledRequest = 'bypass' | 'warn' | 'error' | (req: MockedRequest) => void
```
**Important:** all functionality is **opt-in**. This means that the default value for `onUnhanledRequest` is `'bypass'`.

#### Usage example
```ts
const worker = setupWorker(...)
const server = setupServer(...)

worker.start({ onUnhandledRequest: 'bypass' })
server.listen({ onUnhandledRequest: 'error' })
```

### Draft
This pull request is a _work in progress_. That means large portions of functionality have _not_ been implemented yet, and the functionality and specification details are still open for debate.