### PR TITLE
test(isNodeProcess): mock global.process in react native

### DIFF
--- a/src/utils/isNodeProcess.react-native.test.ts
+++ b/src/utils/isNodeProcess.react-native.test.ts
@@ -33,11 +33,12 @@ beforeAll(() => {
    * @see https://github.com/facebook/react-native/blob/6d6c68c2c639b6473e049f7d916690b92e921c7e/Libraries/Core/setUpNavigator.js
    * @see https://github.com/facebook/react-native/blob/6d6c68c2c639b6473e049f7d916690b92e921c7e/Libraries/Core/setUpGlobals.js
    */
-  Object.defineProperty(global.process, 'env', {
-    get: () => ({
+  // @ts-ignore
+  global.process = {
+    env: {
       NODE_ENV: 'development',
-    }),
-  })
+    },
+  }
 
   global.navigator = {
     product: 'ReactNative',

--- a/src/utils/isNodeProcess.react-native.test.ts
+++ b/src/utils/isNodeProcess.react-native.test.ts
@@ -33,12 +33,11 @@ beforeAll(() => {
    * @see https://github.com/facebook/react-native/blob/6d6c68c2c639b6473e049f7d916690b92e921c7e/Libraries/Core/setUpNavigator.js
    * @see https://github.com/facebook/react-native/blob/6d6c68c2c639b6473e049f7d916690b92e921c7e/Libraries/Core/setUpGlobals.js
    */
-  // @ts-ignore
   global.process = {
     env: {
       NODE_ENV: 'development',
     },
-  }
+  } as any
 
   global.navigator = {
     product: 'ReactNative',


### PR DESCRIPTION
This is following #255, I notice if we just mock global.process like this `Object.defineProperty(global.process, 'env', { get: () => ({ NODE_ENV: 'development', }), })`, which leads `Object.prototype.toString.call(global.process)` still equals `[object process]`. It should be `[object Object]`? Would you mind to look at it again?