### PR TITLE
Updates "node-request-interceptor" to version 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "sideEffects": false,
   "dependencies": {
-    "@open-draft/until": "^1.0.0",
+    "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.3.3",
     "chalk": "^4.0.0",
     "cookie": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "graphql": "^15.0.0",
     "headers-utils": "^1.1.9",
     "node-match-path": "^0.4.2",
-    "node-request-interceptor": "^0.2.5",
+    "node-request-interceptor": "^0.3.0",
     "statuses": "^2.0.0",
     "yargs": "^15.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6118,11 +6118,12 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-node-request-interceptor@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.2.5.tgz#4578a4b005e70e6ee14d20b7a331892091079a93"
-  integrity sha512-9iRH/E+8jipPUbDsGiNdhErea81ANqaaAeXbnk0M3agDCsIMli3dcCSB8uQKKYUFu4SQjsqClIotPX2kIo9Hug==
+node-request-interceptor@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.3.0.tgz#9a0b717c5f5f4b09a4423db17d5b0bea5f7260c1"
+  integrity sha512-yrEFqAIrdDYTB+5+m6Mk/hyHLy95bhMKfhH+VWvQ90kr+ILykRcE1wDt0OhsQr2sEkfYJYE1eTSt/rpd/lN4ig==
   dependencies:
+    "@open-draft/until" "^1.0.3"
     debug "^4.1.1"
     headers-utils "^1.2.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,10 +949,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@open-draft/until@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.2.tgz#9ca97314d58ac13e343dd0516d3f1fb0a656998d"
-  integrity sha512-hMXQs2UDAugL6eBoPI1LQ8cM0Tv+Bs4/cdtLRgwGhpMIBq/YUFUOBdAT/kHyoAEAiIz4DKvAVTG4G07EFMzBqg==
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
 "@rollup/plugin-commonjs@^11.1.0":
   version "11.1.0"


### PR DESCRIPTION
> See the [Release notes](https://github.com/mswjs/node-request-interceptor/releases/tag/v0.3.0).

## Changes

- Supports imitation of network error by throwing in the request middleware.
- Improves request debugging.

## GitHub

- Pre-requisite for https://github.com/mswjs/msw/pull/257