### PR TITLE
Add `native` runtime, alongside node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __*
 .DS_*
 node_modules
 /lib
+/native/**/*.js
 /node/**/*.js
 tmp
 *-error.log

--- a/native/package.json
+++ b/native/package.json
@@ -1,0 +1,3 @@
+{
+  "types": "../lib/types/native"
+}

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
-    "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-commonjs": "^11.1.0",
+    "@rollup/plugin-inject": "^4.0.2",
     "@rollup/plugin-json": "^4.0.3",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-replace": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
+    "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-json": "^4.0.3",
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+import alias from '@rollup/plugin-alias'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import typescript from 'rollup-plugin-typescript2'
@@ -97,4 +98,32 @@ const buildNode = {
   ],
 }
 
-export default [buildNode, buildEsm, buildUdm]
+const buildNative = {
+  input: 'src/native/index.ts',
+  external: ['events', 'node-request-interceptor'],
+  output: {
+    file: 'native/index.js',
+    format: 'cjs',
+  },
+  plugins: [
+    alias({
+      entries: [{ find: 'timers', replacement: '../utils/reactNativeTimers' }],
+    }),
+    json(),
+    resolve({
+      browser: false,
+      preferBuiltins: true,
+      extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    }),
+    typescript({
+      useTsconfigDeclarationDir: true,
+      tsconfigOverride: {
+        outDir: './native',
+        declarationDir: './native',
+      },
+    }),
+    commonjs(),
+  ],
+}
+
+export default [buildNode, buildNative, buildEsm, buildUdm]

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
-import alias from '@rollup/plugin-alias'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
+import inject from '@rollup/plugin-inject'
 import typescript from 'rollup-plugin-typescript2'
 import json from '@rollup/plugin-json'
 import packageJson from './package.json'
@@ -94,6 +94,9 @@ const buildNode = {
         declarationDir: './node',
       },
     }),
+    inject({
+      setTimeout: ['timers', 'setTimeout'],
+    }),
     commonjs(),
   ],
 }
@@ -106,9 +109,6 @@ const buildNative = {
     format: 'cjs',
   },
   plugins: [
-    alias({
-      entries: [{ find: 'timers', replacement: '../utils/reactNativeTimers' }],
-    }),
     json(),
     resolve({
       browser: false,

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -1,0 +1,1 @@
+export * from '../node'

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,5 +1,5 @@
-import timers from 'timers'
 import cookieUtils from 'cookie'
+import { setTimeout } from 'timers'
 import { Headers, flattenHeadersObject } from 'headers-utils'
 import {
   RequestInterceptor,
@@ -83,7 +83,7 @@ export const setupServer = (...requestHandlers: RequestHandlersList) => {
         return new Promise<MockedInterceptedResponse>((resolve) => {
           // using the timers module to ensure @sinon/fake-timers or jest fake timers
           // don't affect this timeout.
-          timers.setTimeout(() => {
+          setTimeout(() => {
             resolve({
               status: response.status,
               statusText: response.statusText,

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,5 +1,4 @@
 import cookieUtils from 'cookie'
-import { setTimeout } from 'timers'
 import { Headers, flattenHeadersObject } from 'headers-utils'
 import {
   RequestInterceptor,
@@ -81,7 +80,7 @@ export const setupServer = (...requestHandlers: RequestHandlersList) => {
         }
 
         return new Promise<MockedInterceptedResponse>((resolve) => {
-          // using the timers module to ensure @sinon/fake-timers or jest fake timers
+          // the node build will use the timers module to ensure @sinon/fake-timers or jest fake timers
           // don't affect this timeout.
           setTimeout(() => {
             resolve({

--- a/src/utils/reactNativeTimers.ts
+++ b/src/utils/reactNativeTimers.ts
@@ -1,2 +1,0 @@
-// used as replacement of the timers's setTimeout in the native module
-export const setTimeout = global.setTimeout

--- a/src/utils/reactNativeTimers.ts
+++ b/src/utils/reactNativeTimers.ts
@@ -1,0 +1,2 @@
+// used as replacement of the timers's setTimeout in the native module
+export const setTimeout = global.setTimeout

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,6 +954,13 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@rollup/plugin-alias@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.1.tgz#bb96cf37fefeb0a953a6566c284855c7d1cd290c"
+  integrity sha512-hNcQY4bpBUIvxekd26DBPgF7BT4mKVNDF5tBG4Zi+3IgwLxGYRY0itHs9D0oLVwXM5pvJDWJlBQro+au8WaUWw==
+  dependencies:
+    slash "^3.0.0"
+
 "@rollup/plugin-commonjs@^11.1.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz#60636c7a722f54b41e419e1709df05c7234557ef"

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,13 +954,6 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@rollup/plugin-alias@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.1.tgz#bb96cf37fefeb0a953a6566c284855c7d1cd290c"
-  integrity sha512-hNcQY4bpBUIvxekd26DBPgF7BT4mKVNDF5tBG4Zi+3IgwLxGYRY0itHs9D0oLVwXM5pvJDWJlBQro+au8WaUWw==
-  dependencies:
-    slash "^3.0.0"
-
 "@rollup/plugin-commonjs@^11.1.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz#60636c7a722f54b41e419e1709df05c7234557ef"
@@ -973,6 +966,15 @@
     is-reference "^1.1.2"
     magic-string "^0.25.2"
     resolve "^1.11.0"
+
+"@rollup/plugin-inject@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz#55b21bb244a07675f7fdde577db929c82fc17395"
+  integrity sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.4"
+    estree-walker "^1.0.1"
+    magic-string "^0.25.5"
 
 "@rollup/plugin-json@^4.0.3":
   version "4.0.3"
@@ -999,6 +1001,15 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
     magic-string "^0.25.5"
+
+"@rollup/pluginutils@^3.0.4":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
 
 "@rollup/pluginutils@^3.0.8":
   version "3.0.9"
@@ -6600,7 +6611,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==


### PR DESCRIPTION
This is an attempt to support react native's runtime. https://github.com/mswjs/msw/issues/203

```
import 'react-native-url-polyfill/auto' // required polyfill
import { setupServer } from 'msw/native'

setupServer(...).listen()
```

After some thinking, I came to the conclusion that the `node` environment is just not the right place to target RN.
Currently, the main issue is that there's no practical way to conditionally import `timers`. This is not an option, as the metro packager of react native will still try to include it in the main bundle:

```
const aSetTimeout  = navigator.product !== 'ReactNative' ? require('timers').setTimeout : global.setTimeout
```
Another required change to this PR would be to import a `RequestInterceptor` from `node-request-interceptor` that doesn't attempt to import the `http` core module.

The solution of moving from `msw/node` to `msw/native` is not perfect either thought. When running your jest test suite, you may still want to use `msw/node`.

There may be some babel based alternatives worth exploring, but nothing I can think of at the moment.

Before creating a PR to `node-request-interceptor` with the change required to complete this PR, I may want to get some early feedback on the preferred direction.