### PR TITLE
Adds browser/node interception GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/not_intercepted_in_browser.md
+++ b/.github/ISSUE_TEMPLATE/not_intercepted_in_browser.md
@@ -1,0 +1,51 @@
+---
+name: Browser interception
+about: My request is not intercepted/mocked in a browser
+title: ''
+labels: bug, scope:browser
+assignees: ''
+---
+
+## Environment
+
+| Name    | Version |
+| ------- | ------- |
+| msw     | 0.0.0   |
+| browser | XXX     |
+| OS      | XXX     |
+
+## Request handlers
+
+<!-- Please provide your mocking setup and the request handlers used -->
+
+```js
+// Example of declaration. Provide your code here.
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('???', () => {...})
+)
+
+worker.start()
+```
+
+## Actual request
+
+<!-- Reference how do you perform a request (i.e. fetch/axios/etc.) -->
+
+```js
+// Example of making a request. Provide your code here.
+fetch('???').then((res) => res.json())
+```
+
+## Current behavior
+
+<!-- Describe what behavior you observe currently -->
+
+## Expected behavior
+
+<!-- Describe what do you expect to happen -->
+
+## Screenshots
+
+<!-- If applicable, attach screenshots to help explain the issue -->

--- a/.github/ISSUE_TEMPLATE/not_intercepted_in_node.md
+++ b/.github/ISSUE_TEMPLATE/not_intercepted_in_node.md
@@ -1,0 +1,52 @@
+---
+name: NodeJS interception
+about: My request is not intercepted/mocked in NodeJS (tests)
+title: ''
+labels: bug, scope:node
+assignees: ''
+---
+
+## Environment
+
+| Name | Version |
+| ---- | ------- |
+| msw  | 0.0.0   |
+| node | XXX     |
+| OS   | XXX     |
+
+## Request handlers
+
+<!-- Please provide your mocking setup and the request handlers used -->
+
+```js
+// Example of declaration. Provide your code here.
+import { setupServer } from 'msw/node'
+import { rest } from 'msw'
+
+const server = setupServer(
+  rest.get('???', () => {...})
+)
+
+server.listen()
+```
+
+## Actual request
+
+<!-- Reference how do you perform a request (i.e. fetch/axios/etc.) -->
+
+```js
+// Example of making a request. Provide your code here.
+fetch('???').then((res) => res.json())
+```
+
+## Current behavior
+
+<!-- Describe what behavior you observe currently -->
+
+## Expected behavior
+
+<!-- Describe what do you expect to happen -->
+
+## Screenshots
+
+<!-- If applicable, attach screenshots to help explain the issue -->


### PR DESCRIPTION
## Changes

- Adds two new GitHub issue templates:
  - Request not intercepted in a browser
  - Request not intercepted in NodeJS

## Motivation

People often submit issues like this, and we always ask to provide:

1. What request handlers you use.
1. How do you make an actual request.

I've embedded that into the issue template itself, so people provide that vital info before submitting an issue. This will make the reproduction and resolving process of the issue much more effective. 