### PR TITLE
Updates "node-request-interceptor" to version 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "graphql": "^15.0.0",
     "headers-utils": "^1.1.9",
     "node-match-path": "^0.4.2",
-    "node-request-interceptor": "^0.3.0",
+    "node-request-interceptor": "^0.3.1",
     "statuses": "^2.0.0",
     "yargs": "^15.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6118,10 +6118,10 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-node-request-interceptor@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.3.0.tgz#9a0b717c5f5f4b09a4423db17d5b0bea5f7260c1"
-  integrity sha512-yrEFqAIrdDYTB+5+m6Mk/hyHLy95bhMKfhH+VWvQ90kr+ILykRcE1wDt0OhsQr2sEkfYJYE1eTSt/rpd/lN4ig==
+node-request-interceptor@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.3.1.tgz#69b09ed07144814e550ba697392c9793e799b67a"
+  integrity sha512-Qvv/6noh+IHySE9bI9ijxM790xUR6oy0h8ICrjINTOgp1RSS8xOYgMLW2HacDKCk6YYABvLGcfxC13Dqu6igqQ==
   dependencies:
     "@open-draft/until" "^1.0.3"
     debug "^4.1.1"


### PR DESCRIPTION
## Changes

- Fixes an issue that resulted into event handlers added via `addEventListener` to `XMLHttpRequest` to never resolve with neither mocked nor real responses.

## GitHub

- Fixes #273 