### PR TITLE
Fix: Return the correct mock worker when registering or updating

### DIFF
--- a/src/setupWorker/start/utils/getWorkerByRegistration.ts
+++ b/src/setupWorker/start/utils/getWorkerByRegistration.ts
@@ -4,6 +4,11 @@
  */
 export const getWorkerByRegistration = (
   registration: ServiceWorkerRegistration,
+  absoluteWorkerUrl: string,
 ): ServiceWorker | null => {
-  return registration.active || registration.installing || registration.waiting
+  return (
+    [registration.active, registration.installing, registration.waiting].find(
+      (worker) => worker?.scriptURL === absoluteWorkerUrl,
+    ) || null
+  )
 }

--- a/src/setupWorker/start/utils/getWorkerByRegistration.ts
+++ b/src/setupWorker/start/utils/getWorkerByRegistration.ts
@@ -1,14 +1,20 @@
 /**
- * Attempts to resolve a Service Worker instance from any of its states:
- * active, installing, or waiting.
+ * Attempts to resolve a Service Worker instance from a given registration,
+ * regardless of its state (active, installing, waiting).
  */
 export const getWorkerByRegistration = (
   registration: ServiceWorkerRegistration,
   absoluteWorkerUrl: string,
 ): ServiceWorker | null => {
-  return (
-    [registration.active, registration.installing, registration.waiting].find(
-      (worker) => worker?.scriptURL === absoluteWorkerUrl,
-    ) || null
-  )
+  const allStates = [
+    registration.active,
+    registration.installing,
+    registration.waiting,
+  ]
+  const existingStates = allStates.filter(Boolean) as ServiceWorker[]
+  const mockWorker = existingStates.find((worker) => {
+    return worker.scriptURL === absoluteWorkerUrl
+  })
+
+  return mockWorker || null
 }

--- a/src/setupWorker/start/utils/getWorkerInstance.ts
+++ b/src/setupWorker/start/utils/getWorkerInstance.ts
@@ -16,11 +16,9 @@ export const getWorkerInstance = async (
 
   const [, mockRegistrations] = await until(async () => {
     const registrations = await navigator.serviceWorker.getRegistrations()
-    return registrations.filter((registration) => {
-      const worker = getWorkerByRegistration(registration)
-      // Filter out other workers that can be associated with this page
-      return worker?.scriptURL === absoluteWorkerUrl
-    })
+    return registrations.filter((registration) =>
+      getWorkerByRegistration(registration, absoluteWorkerUrl),
+    )
   })
 
   if (!navigator.serviceWorker.controller && mockRegistrations.length > 0) {
@@ -40,15 +38,19 @@ export const getWorkerInstance = async (
     // Update existing service worker to ensure it's up-to-date
     return existingRegistration.update().then(() => {
       return [
-        getWorkerByRegistration(existingRegistration),
+        getWorkerByRegistration(existingRegistration, absoluteWorkerUrl),
         existingRegistration,
       ]
     })
   }
+
   const [error, instance] = await until<ServiceWorkerInstanceTuple>(
     async () => {
       const registration = await navigator.serviceWorker.register(url, options)
-      return [getWorkerByRegistration(registration), registration]
+      return [
+        getWorkerByRegistration(registration, absoluteWorkerUrl),
+        registration,
+      ]
     },
   )
 

--- a/src/setupWorker/start/utils/getWorkerInstance.ts
+++ b/src/setupWorker/start/utils/getWorkerInstance.ts
@@ -33,9 +33,8 @@ export const getWorkerInstance = async (
     location.reload()
   }
 
-  const [, existingRegistration] = await until(() => {
-    return navigator.serviceWorker.getRegistration(url)
-  })
+  const existingRegistration =
+    mockRegistrations.length > 0 ? mockRegistrations[0] : undefined
 
   if (existingRegistration) {
     // Update existing service worker to ensure it's up-to-date

--- a/src/setupWorker/start/utils/getWorkerInstance.ts
+++ b/src/setupWorker/start/utils/getWorkerInstance.ts
@@ -31,8 +31,7 @@ export const getWorkerInstance = async (
     location.reload()
   }
 
-  const existingRegistration =
-    mockRegistrations.length > 0 ? mockRegistrations[0] : undefined
+  const existingRegistration = mockRegistrations[0]
 
   if (existingRegistration) {
     // Update existing service worker to ensure it's up-to-date

--- a/src/setupWorker/start/utils/getWorkerInstance.ts
+++ b/src/setupWorker/start/utils/getWorkerInstance.ts
@@ -1,5 +1,5 @@
-import { getWorkerByRegistration } from './getWorkerByRegistration'
 import { until } from '@open-draft/until'
+import { getWorkerByRegistration } from './getWorkerByRegistration'
 import { ServiceWorkerInstanceTuple } from '../../glossary'
 import { getAbsoluteWorkerUrl } from '../../../utils/getAbsoluteWorkerUrl'
 
@@ -16,9 +16,9 @@ export const getWorkerInstance = async (
 
   const [, mockRegistrations] = await until(async () => {
     const registrations = await navigator.serviceWorker.getRegistrations()
-    return registrations.filter((registration) =>
-      getWorkerByRegistration(registration, absoluteWorkerUrl),
-    )
+    return registrations.filter((registration) => {
+      return getWorkerByRegistration(registration, absoluteWorkerUrl)
+    })
   })
 
   if (!navigator.serviceWorker.controller && mockRegistrations.length > 0) {
@@ -31,7 +31,7 @@ export const getWorkerInstance = async (
     location.reload()
   }
 
-  const existingRegistration = mockRegistrations[0]
+  const [existingRegistration] = mockRegistrations
 
   if (existingRegistration) {
     // Update existing service worker to ensure it's up-to-date
@@ -47,6 +47,8 @@ export const getWorkerInstance = async (
     async () => {
       const registration = await navigator.serviceWorker.register(url, options)
       return [
+        // Compare existing worker registration by its worker URL,
+        // to prevent irrelevant workers to resolve here (such as Codesandbox worker).
         getWorkerByRegistration(registration, absoluteWorkerUrl),
         registration,
       ]


### PR DESCRIPTION
This is in regard to the comments in https://github.com/mswjs/msw/issues/73 regarding CodeSandbox behavior. `getRegistration(url)`, whether providing an absolute or relative url, was just returning the CodeSandbox service worker being that the `scope` was on the root domain like 'https://kuwlp.csb.app/' during registration. Being that we already check for `mockRegistrations` above, we can just pull the existing one from there if it exists as it's already filtered.

Additional edit:

The behavior of `.register()` is a bit unexpected in the event that there is already a service worker that made the first claim. In this case, codesandbox's worker would alway so do that, so the `ServiceWorkerRegistration` would look like:
`{ active: CSBworker, waiting: mockWorker, ... normal registration fields }` - so what was happening is that when we called `getWorkerByRegistration`, even though the registration instance was correct, the returned Worker instance was not. I've enforced the filter for `scriptURL` === `asbsoluteWorkerUrl` as a default as this is always going to be the desired behavior and cuts out any future edge cases.