### PR TITLE
Reworks "captureConsole" API for tests

### DIFF
--- a/src/utils/isNodeProcess.react-native.test.ts
+++ b/src/utils/isNodeProcess.react-native.test.ts
@@ -41,7 +41,7 @@ beforeAll(() => {
 
   global.navigator = {
     product: 'ReactNative',
-  }
+  } as any
 })
 
 afterAll(() => {

--- a/test/graphql-api/logging.test.ts
+++ b/test/graphql-api/logging.test.ts
@@ -18,9 +18,7 @@ describe('GraphQL: Logging', () => {
     let requestLog: string
 
     beforeAll(async () => {
-      const logs: string[] = []
-
-      captureConsole(test.page, logs, filterLibraryLogs)
+      const { messages } = captureConsole(test.page, filterLibraryLogs)
 
       await executeOperation(test.page, {
         query: `
@@ -33,8 +31,8 @@ describe('GraphQL: Logging', () => {
         `,
       })
 
-      requestLog = logs.find((message) => {
-        return message.includes('GetUserDetail')
+      requestLog = messages.startGroupCollapsed.find((text) => {
+        return text.includes('GetUserDetail')
       })
     })
 
@@ -57,9 +55,7 @@ describe('GraphQL: Logging', () => {
     let requestLog: string
 
     beforeAll(async () => {
-      const logs: string[] = []
-
-      captureConsole(test.page, logs, filterLibraryLogs)
+      const { messages } = captureConsole(test.page, filterLibraryLogs)
 
       await executeOperation(test.page, {
         query: `
@@ -71,8 +67,8 @@ describe('GraphQL: Logging', () => {
         `,
       })
 
-      requestLog = logs.find((message) => {
-        return message.includes('Login')
+      requestLog = messages.startGroupCollapsed.find((text) => {
+        return text.includes('Login')
       })
     })
 

--- a/test/msw-api/exception-handling.test.ts
+++ b/test/msw-api/exception-handling.test.ts
@@ -1,46 +1,36 @@
 import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+import { captureConsole } from '../support/captureConsole'
 
-describe('Exception handling', () => {
-  describe('given exception in a request handler', () => {
-    let test: TestAPI
+let runtime: TestAPI
 
-    beforeAll(async () => {
-      test = await runBrowserWith(
-        path.resolve(__dirname, 'exception-handling.mocks.ts'),
-      )
-    })
+beforeAll(async () => {
+  runtime = await runBrowserWith(
+    path.resolve(__dirname, 'exception-handling.mocks.ts'),
+  )
+})
 
-    afterAll(() => {
-      return test.cleanup()
-    })
+afterAll(() => {
+  return runtime.cleanup()
+})
 
-    it('should activate without errors', async () => {
-      const errorMessages: string[] = []
+it('should activate without errors', async () => {
+  const { messages } = captureConsole(runtime.page)
+  await runtime.reload()
 
-      test.page.on('console', function (message) {
-        if (message.type() === 'error') {
-          errorMessages.push(message.text())
-        }
-      })
+  expect(messages.error).toHaveLength(0)
+})
 
-      await test.reload()
-
-      expect(errorMessages).toHaveLength(0)
-    })
-
-    it('should transform exception into 500 response', async () => {
-      const res = await test.request({
-        url: 'https://api.github.com/users/octocat',
-      })
-      const status = res.status()
-      const headers = res.headers()
-      const body = await res.json()
-
-      expect(status).toEqual(500)
-      expect(headers).not.toHaveProperty('x-powered-by', 'msw')
-      expect(body).toHaveProperty('errorType', 'ReferenceError')
-      expect(body).toHaveProperty('message', 'nonExisting is not defined')
-    })
+it('should transform exception into 500 response', async () => {
+  const res = await runtime.request({
+    url: 'https://api.github.com/users/octocat',
   })
+  const status = res.status()
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(status).toEqual(500)
+  expect(headers).not.toHaveProperty('x-powered-by', 'msw')
+  expect(body).toHaveProperty('errorType', 'ReferenceError')
+  expect(body).toHaveProperty('message', 'nonExisting is not defined')
 })

--- a/test/msw-api/integrity-check.test.ts
+++ b/test/msw-api/integrity-check.test.ts
@@ -84,8 +84,8 @@ describe('Integrity check', () => {
       // Open the page anew to trigger the console listener
       await test.reload()
 
-      const integrityError = errors.find((message) => {
-        return message.includes('[MSW] Detected outdated Service Worker')
+      const integrityError = errors.find((text) => {
+        return text.includes('[MSW] Detected outdated Service Worker')
       })
 
       expect(integrityError).toBeTruthy()

--- a/test/msw-api/res/network-error.test.ts
+++ b/test/msw-api/res/network-error.test.ts
@@ -13,10 +13,7 @@ beforeAll(async () => {
 afterAll(() => runtime.cleanup())
 
 test('throws a network error', async () => {
-  const errors: string[] = []
-  captureConsole(runtime.page, errors, (message) => {
-    return message.type() === 'error'
-  })
+  const { messages } = captureConsole(runtime.page)
 
   // Do not use `runtime.request()`, because it always awaits a response.
   // In this case we await a network error, performing a request manually.
@@ -32,5 +29,5 @@ test('throws a network error', async () => {
 
   // Assert a network error message printed into the console
   // before `fetch` rejects.
-  expect(errors).toContain('Failed to load resource: net::ERR_FAILED')
+  expect(messages.error).toContain('Failed to load resource: net::ERR_FAILED')
 })

--- a/test/msw-api/setup-worker/start/error.test.ts
+++ b/test/msw-api/setup-worker/start/error.test.ts
@@ -11,10 +11,7 @@ beforeAll(async () => {
 afterAll(() => runtime.cleanup())
 
 test('prints a custom error message when given a non-existing worker script', async () => {
-  const errors: string[] = []
-  captureConsole(runtime.page, errors, (message) => {
-    return message.type() === 'error'
-  })
+  const { messages } = captureConsole(runtime.page)
 
   await runtime.page.evaluate(() => {
     // @ts-ignore
@@ -25,12 +22,11 @@ test('prints a custom error message when given a non-existing worker script', as
     })
   })
 
-  const workerNotFoundMessage = errors.find((message) => {
+  const workerNotFoundMessage = messages.error.find((text) => {
     return (
-      message.startsWith(
+      text.startsWith(
         `[MSW] Failed to register a Service Worker for scope ('${runtime.page.url()}')`,
-      ) &&
-      message.includes('Did you forget to run "npx msw init <PUBLIC_DIR>"?')
+      ) && text.includes('Did you forget to run "npx msw init <PUBLIC_DIR>"?')
     )
   })
 

--- a/test/msw-api/setup-worker/start/on-unhandled-request/callback.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/callback.test.ts
@@ -1,53 +1,23 @@
 import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../../../../support/runBrowserWith'
+import {
+  captureConsole,
+  filterLibraryLogs,
+} from '../../../../support/captureConsole'
 
-let runtimeRef: TestAPI
+let runtime: TestAPI
 
-async function startWorker() {
-  const logs: string[] = []
-  const errors: string[] = []
-  const warnings: string[] = []
-
-  const runtime = await runBrowserWith(
-    path.resolve(__dirname, 'callback.mocks.ts'),
-  )
-
-  runtime.page.on('console', (message) => {
-    const messageText = message.text()
-
-    switch (message.type()) {
-      case 'log': {
-        logs.push(messageText)
-        break
-      }
-
-      case 'warning': {
-        if (messageText.startsWith('[MSW]')) {
-          warnings.push(messageText)
-          break
-        }
-      }
-
-      case 'error': {
-        if (messageText.startsWith('[MSW]')) {
-          errors.push(messageText)
-          break
-        }
-      }
-    }
-  })
-
-  runtimeRef = runtime
-
-  return { runtime, logs, errors, warnings }
-}
+beforeAll(async () => {
+  runtime = await runBrowserWith(path.resolve(__dirname, 'callback.mocks.ts'))
+})
 
 afterEach(async () => {
-  await runtimeRef.cleanup()
+  await runtime.cleanup()
 })
 
 test('executes a given callback on an unhandled request', async () => {
-  const { runtime, logs, warnings, errors } = await startWorker()
+  const { messages } = captureConsole(runtime.page)
+  await runtime.reload()
 
   const res = await runtime.request({
     url: 'https://mswjs.io/non-existing-page',
@@ -58,11 +28,14 @@ test('executes a given callback on an unhandled request', async () => {
   expect(status).toBe(404)
 
   // Custom callback executed.
-  expect(logs).toContain(
+  expect(messages.log).toContain(
     'Oops, unhandled GET https://mswjs.io/non-existing-page',
   )
 
+  const libraryErrors = messages.error.filter(filterLibraryLogs)
+  const libraryWarnings = messages.warning.filter(filterLibraryLogs)
+
   // No warnings/errors produced by MSW.
-  expect(errors).toHaveLength(0)
-  expect(warnings).toHaveLength(0)
+  expect(libraryErrors).toHaveLength(0)
+  expect(libraryWarnings).toHaveLength(0)
 })

--- a/test/msw-api/setup-worker/start/quiet.test.ts
+++ b/test/msw-api/setup-worker/start/quiet.test.ts
@@ -1,67 +1,48 @@
 import * as path from 'path'
-import { Response } from 'puppeteer'
 import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
 
-describe('API: setupWorker / start / quiet', () => {
-  let test: TestAPI
-  const logs: string[] = []
+let runtime: TestAPI
 
-  beforeAll(async () => {
-    test = await runBrowserWith(path.resolve(__dirname, 'quiet.mocks.ts'))
+beforeAll(async () => {
+  runtime = await runBrowserWith(path.resolve(__dirname, 'quiet.mocks.ts'))
+})
 
-    captureConsole(test.page, logs, (message) => {
-      return message.type() === 'startGroupCollapsed'
-    })
+afterAll(() => {
+  return runtime.cleanup()
+})
+
+test('does not log the captured request when the "quiet" option is set to "true"', async () => {
+  const { messages } = captureConsole(runtime.page)
+
+  await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW_REGISTRATION__
   })
 
-  afterAll(() => {
-    return test.cleanup()
+  await runtime.reload()
+
+  const activationMessage = messages.startGroupCollapsed.find((text) => {
+    return text.includes('[MSW] Mocking enabled.')
+  })
+  expect(activationMessage).toBeFalsy()
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/user`,
   })
 
-  describe('given I start a worker with "quiet: true" option', () => {
-    beforeAll(async () => {
-      await test.page.evaluate(() => {
-        // @ts-ignore
-        return window.__MSW_REGISTRATION__
-      })
+  const headers = res.headers()
+  const body = await res.json()
 
-      await test.reload()
-    })
-
-    it('should not print any activation message into console', () => {
-      const activationMessage = logs.find((message) => {
-        return message.includes('[MSW] Mocking enabled.')
-      })
-      expect(activationMessage).toBeFalsy()
-    })
-
-    describe('and I perform a request that should be mocked', () => {
-      let res: Response
-
-      beforeAll(async () => {
-        res = await test.request({
-          url: `${test.origin}/user`,
-        })
-      })
-
-      it('should return the mocked response', async () => {
-        const headers = res.headers()
-        const body = await res.json()
-
-        expect(headers).toHaveProperty('x-powered-by', 'msw')
-        expect(body).toEqual({
-          firstName: 'John',
-          age: 32,
-        })
-      })
-
-      it('should not print request logs into console', () => {
-        const requetsLog = logs.find((message) => {
-          return message.includes('[MSW]') && message.includes('GET /user')
-        })
-        expect(requetsLog).toBeUndefined()
-      })
-    })
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(body).toEqual({
+    firstName: 'John',
+    age: 32,
   })
+
+  const requetsLog = messages.startGroupCollapsed.find((text) => {
+    return text.includes('[MSW]') && text.includes('GET /user')
+  })
+
+  expect(requetsLog).toBeUndefined()
 })

--- a/test/msw-api/setup-worker/start/start.test.ts
+++ b/test/msw-api/setup-worker/start/start.test.ts
@@ -2,51 +2,39 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
 
-describe('API: setupWorker / start', () => {
-  let test: TestAPI
+let runtime: TestAPI
 
-  beforeAll(async () => {
-    test = await runBrowserWith(path.resolve(__dirname, 'start.mocks.ts'))
+beforeAll(async () => {
+  runtime = await runBrowserWith(path.resolve(__dirname, 'start.mocks.ts'))
+})
+
+afterAll(() => {
+  return runtime.cleanup()
+})
+
+test('resolves the "start" Promise after the worker has been activated', async () => {
+  const resolvedPayload = await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW_REGISTRATION__
   })
 
-  afterAll(() => {
-    return test.cleanup()
+  expect(resolvedPayload).toBe('ServiceWorkerRegistration')
+
+  const { messages } = captureConsole(runtime.page)
+
+  await runtime.reload()
+
+  const activationMessageIndex = messages.startGroupCollapsed.findIndex(
+    (text) => {
+      return text.includes('[MSW] Mocking enabled')
+    },
+  )
+
+  const customMessageIndex = messages.log.findIndex((text) => {
+    return text.includes('Registration Promise resolved')
   })
 
-  describe('given a custom Promise chain handler to worker.start()', () => {
-    let resolvedPayload
-
-    beforeAll(async () => {
-      resolvedPayload = await test.page.evaluate(() => {
-        // @ts-ignore
-        return window.__MSW_REGISTRATION__
-      })
-    })
-
-    it('should return instance of ServiceWorkerRegistration', () => {
-      expect(resolvedPayload).toBe('ServiceWorkerRegistration')
-    })
-
-    it('should resolve after the mocking has been activated', async () => {
-      const logs: string[] = []
-
-      captureConsole(test.page, logs, (message) => {
-        return ['startGroupCollapsed', 'log'].includes(message.type())
-      })
-
-      await test.reload()
-
-      const activationMessageIndex = logs.findIndex((message) => {
-        return message.includes('[MSW] Mocking enabled')
-      })
-
-      const customMessageIndex = logs.findIndex((message) => {
-        return message.includes('Registration Promise resolved')
-      })
-
-      expect(activationMessageIndex).toBeGreaterThan(-1)
-      expect(customMessageIndex).toBeGreaterThan(-1)
-      expect(customMessageIndex).toBeGreaterThan(activationMessageIndex)
-    })
-  })
+  expect(activationMessageIndex).toBeGreaterThan(-1)
+  expect(customMessageIndex).toBeGreaterThan(-1)
+  expect(customMessageIndex).toBeGreaterThan(activationMessageIndex)
 })

--- a/test/rest-api/logging.test.ts
+++ b/test/rest-api/logging.test.ts
@@ -1,49 +1,37 @@
 import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
-import { captureConsole, filterLibraryLogs } from '../support/captureConsole'
+import { captureConsole } from '../support/captureConsole'
 
-describe('REST: Logging', () => {
-  let test: TestAPI
+let runtime: TestAPI
 
-  beforeAll(async () => {
-    test = await runBrowserWith(path.resolve(__dirname, 'basic.mocks.ts'))
+beforeAll(async () => {
+  runtime = await runBrowserWith(path.resolve(__dirname, 'basic.mocks.ts'))
+})
+
+afterAll(() => {
+  return runtime.cleanup()
+})
+
+test('prints a captured request info into browser console', async () => {
+  const { messages } = captureConsole(runtime.page)
+
+  await runtime.request({
+    url: 'https://api.github.com/users/octocat',
   })
 
-  afterAll(() => {
-    return test.cleanup()
+  const requestLog = messages.startGroupCollapsed.find((text) => {
+    // No way to assert the entire format of the log entry,
+    // because Puppeteer intercepts `console.log` calls,
+    // which contain unformatted strings (with %s, %c, styles).
+    return text.includes('https://api.github.com/users/octocat')
   })
 
-  describe('given I performed a REST API request', () => {
-    let requestLog: string
+  // Request log must include a timestamp.
+  expect(requestLog).toMatch(/\d{2}:\d{2}:\d{2}/)
 
-    beforeAll(async () => {
-      const logs: string[] = []
-      captureConsole(test.page, logs, filterLibraryLogs)
+  // Request log must include the request method.
+  expect(requestLog).toContain('GET')
 
-      await test.request({
-        url: 'https://api.github.com/users/octocat',
-      })
-
-      requestLog = logs.find((message) => {
-        // No way to assert the entire format of the log entry,
-        // because Puppeteer intercepts `console.log` calls,
-        // which contain unformatted strings (with %s, %c, styles).
-        return message.includes('https://api.github.com/users/octocat')
-      })
-    })
-
-    describe('should print an information about the request in browser console', () => {
-      it('with a timestamp', () => {
-        expect(requestLog).toMatch(/\d{2}:\d{2}:\d{2}/)
-      })
-
-      it('with the request method', () => {
-        expect(requestLog).toContain('GET')
-      })
-
-      it('with the response status code', () => {
-        expect(requestLog).toContain('200')
-      })
-    })
-  })
+  // Request log must include the response status code.
+  expect(requestLog).toContain('200')
 })

--- a/test/support/captureConsole.ts
+++ b/test/support/captureConsole.ts
@@ -1,15 +1,44 @@
-import { Page, ConsoleMessage } from 'puppeteer'
+import { Page, ConsoleMessage, ConsoleMessageType } from 'puppeteer'
+
+export type Messages = Record<ConsoleMessageType, string[]>
 
 export function captureConsole(
   page: Page,
-  logs: string[],
   predicate: (message: ConsoleMessage) => boolean = () => true,
 ) {
+  const messages: Messages = {
+    info: [],
+    log: [],
+    debug: [],
+    error: [],
+    warning: [],
+    profile: [],
+    profileEnd: [],
+    table: [],
+    trace: [],
+    timeEnd: [],
+    startGroup: [],
+    startGroupCollapsed: [],
+    endGroup: [],
+    dir: [],
+    dirxml: [],
+    clear: [],
+    count: [],
+    assert: [],
+  }
+
   page.on('console', (message) => {
     if (predicate(message)) {
-      logs.push(removeConsoleStyles(message.text()))
+      const type = message.type()
+      const text = message.text()
+
+      messages[type] = messages[type].concat(removeConsoleStyles(text))
     }
   })
+
+  return {
+    messages,
+  }
 }
 
 export function filterLibraryLogs(message: ConsoleMessage) {

--- a/test/support/captureConsole.ts
+++ b/test/support/captureConsole.ts
@@ -1,10 +1,14 @@
 import { Page, ConsoleMessage, ConsoleMessageType } from 'puppeteer'
 
 export type Messages = Record<ConsoleMessageType, string[]>
+export type ConsolePredicate = (
+  text: string,
+  type: ConsoleMessageType,
+) => boolean
 
 export function captureConsole(
   page: Page,
-  predicate: (message: ConsoleMessage) => boolean = () => true,
+  predicate: ConsolePredicate = () => true,
 ) {
   const messages: Messages = {
     info: [],
@@ -28,7 +32,7 @@ export function captureConsole(
   }
 
   page.on('console', (message) => {
-    if (predicate(message)) {
+    if (predicate(message.text(), message.type())) {
       const type = message.type()
       const text = message.text()
 
@@ -41,8 +45,8 @@ export function captureConsole(
   }
 }
 
-export function filterLibraryLogs(message: ConsoleMessage) {
-  return message.text().startsWith('[MSW]')
+export const filterLibraryLogs = (text: string) => {
+  return text.startsWith('[MSW]')
 }
 
 export function removeConsoleStyles(message: string): string {


### PR DESCRIPTION
## Motivation

- Current `captureConsole` accepts the Array argument that it later mutates.
- Also refactors certain tests to be shallow and have each test scenario as a standalone reproducible test.

## Changes

The `captureConsole` function now returns the `messages`, where all captured console messages are sorted in groups ("info", "log", "warning", etc.).

```js
const { messages } = captureConsole(runtime.page)
const neededMessage = messages.error.find(text => text.startsWith('Oops'))
```