### PR TITLE
grahpql: Annotates request "body" to be a Record

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -17,9 +17,11 @@ import { jsonParse } from './utils/jsonParse'
 
 type GraphQLRequestHandlerSelector = RegExp | string
 
-export type GraphQLMockedRequest<
-  VariablesType = Record<string, any>
-> = MockedRequest & {
+export type GraphQLMockedRequest<VariablesType = Record<string, any>> = Omit<
+  MockedRequest,
+  'body'
+> & {
+  body: (GraphQLRequestPayload<VariablesType> & Record<string, any>) | undefined
   variables: VariablesType
 }
 

--- a/test/graphql-api/operation-reference.mocks.ts
+++ b/test/graphql-api/operation-reference.mocks.ts
@@ -1,0 +1,22 @@
+import { setupWorker, graphql } from 'msw'
+
+const worker = setupWorker(
+  graphql.query('GetUser', (req, res, ctx) => {
+    return res(
+      ctx.data({
+        query: req.body.query,
+        variables: req.body.variables,
+      }),
+    )
+  }),
+  graphql.mutation('Login', (req, res, ctx) => {
+    return res(
+      ctx.data({
+        query: req.body.query,
+        variables: req.body.variables,
+      }),
+    )
+  }),
+)
+
+worker.start()

--- a/test/graphql-api/operation-reference.test.ts
+++ b/test/graphql-api/operation-reference.test.ts
@@ -1,0 +1,71 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../support/runBrowserWith'
+import { executeOperation } from './utils/executeOperation'
+
+let runtime: TestAPI
+
+beforeAll(async () => {
+  runtime = await runBrowserWith(
+    path.resolve(__dirname, 'operation-reference.mocks.ts'),
+  )
+})
+
+afterAll(() => runtime.cleanup())
+
+test('allows referencing the request body in the request handler', async () => {
+  const GET_USER_QUERY = `
+    query GetUser($id: String!) {
+      query
+      variables
+    }
+  `
+
+  const res = await executeOperation(runtime.page, {
+    query: GET_USER_QUERY,
+    variables: {
+      id: 'abc-123',
+    },
+  })
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(body).toEqual({
+    data: {
+      query: GET_USER_QUERY,
+      variables: {
+        id: 'abc-123',
+      },
+    },
+  })
+})
+
+test('allows referencing the request body in the request handler', async () => {
+  const LOGIN_MUTATION = `
+    mutation Login($username: String!, $password: String!) {
+      mutation
+      variables
+    }
+  `
+
+  const res = await executeOperation(runtime.page, {
+    query: LOGIN_MUTATION,
+    variables: {
+      username: 'john',
+      password: 'super-secret',
+    },
+  })
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(body).toEqual({
+    data: {
+      query: LOGIN_MUTATION,
+      variables: {
+        username: 'john',
+        password: 'super-secret',
+      },
+    },
+  })
+})


### PR DESCRIPTION
## GitHub

- Fixes #297 