### PR TITLE
chore: node-fetch should be installed as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "node-match-path": "^0.4.4",
     "node-request-interceptor": "^0.3.3",
     "statuses": "^2.0.0",
-    "yargs": "^15.4.1"
+    "yargs": "^15.4.1",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -98,7 +99,6 @@
     "ignore-loader": "^0.1.2",
     "jest": "^26.1.0",
     "lint-staged": "^10.2.11",
-    "node-fetch": "^2.6.0",
     "prettier": "^2.0.5",
     "puppeteer": "^5.2.1",
     "regenerator-runtime": "^0.13.7",


### PR DESCRIPTION
The released version of `msw` can't be run on `node` because it requires `node-fetch` that is installed as dev dependency, but should be installed as dependency