### PR TITLE
Adds a generic "AsyncResponseResolverReturnType"

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,5 +1,9 @@
 import { OperationTypeNode, OperationDefinitionNode, parse } from 'graphql'
-import { RequestHandler, MockedRequest } from './handlers/requestHandler'
+import {
+  RequestHandler,
+  MockedRequest,
+  AsyncResponseResolverReturnType,
+} from './handlers/requestHandler'
 import { MockedResponse, ResponseComposition } from './response'
 import { set } from './context/set'
 import { status } from './context/status'
@@ -50,7 +54,7 @@ export type GraphQLResponseResolver<QueryType, VariablesType> = (
   req: GraphQLMockedRequest<VariablesType>,
   res: ResponseComposition,
   context: GraphQLMockedContext<QueryType>,
-) => MockedResponse
+) => AsyncResponseResolverReturnType<MockedResponse>
 
 export interface GraphQLRequestPayload<VariablesType> {
   query: string

--- a/src/handlers/requestHandler.ts
+++ b/src/handlers/requestHandler.ts
@@ -40,7 +40,10 @@ export type RequestParams = {
   [paramName: string]: any
 }
 
-type ResponseResolverReturnType = MockedResponse | undefined | void
+export type ResponseResolverReturnType<R> = R | undefined | void
+export type AsyncResponseResolverReturnType<R> =
+  | Promise<ResponseResolverReturnType<R>>
+  | ResponseResolverReturnType<R>
 
 export type ResponseResolver<
   RequestType = MockedRequest,
@@ -49,7 +52,7 @@ export type ResponseResolver<
   req: RequestType,
   res: ResponseComposition,
   context: ContextType,
-) => Promise<ResponseResolverReturnType> | ResponseResolverReturnType
+) => AsyncResponseResolverReturnType<MockedResponse>
 
 export interface RequestHandler<
   RequestType = MockedRequest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export {
   RequestParams,
   RequestQuery,
   ResponseResolver,
+  ResponseResolverReturnType,
+  AsyncResponseResolverReturnType,
   defaultContext,
 } from './handlers/requestHandler'
 export { rest, restContext, RESTMethods } from './rest'


### PR DESCRIPTION
## Changes

- Adds a generic `AsyncResponseResolverReturnType` type to produce a proper return type of response resolvers for various request handlers. This way we ensure that a response resolver may return a mocked response, `undefined` or `void`, including returning aforementioned types in an asynchronous way.

## GitHub

- Fixes #296 