### PR TITLE
Do not set document.cookie on plain node

### DIFF
--- a/src/context/cookie.node.test.ts
+++ b/src/context/cookie.node.test.ts
@@ -4,19 +4,9 @@
 import { cookie } from './cookie'
 import { response } from '../response'
 
-describe('cookie (Node.js without jsdom)', () => {
-  describe('given I set a cookie', () => {
-    let result: ReturnType<typeof response>
-
-    beforeAll(() => {
-      result = response(cookie('my-cookie', 'arbitrary-value'))
-      expect(result).toBeDefined()
-    })
-
-    it('should be set on the response headers', () => {
-      expect(result.headers.get('set-cookie')).toEqual(
-        'my-cookie=arbitrary-value',
-      )
-    })
-  })
+test('sets a cookie on the response headers, node environment', () => {
+  const result: ReturnType<typeof response> = response(
+    cookie('my-cookie', 'arbitrary-value'),
+  )
+  expect(result.headers.get('set-cookie')).toEqual('my-cookie=arbitrary-value')
 })

--- a/src/context/cookie.node.test.ts
+++ b/src/context/cookie.node.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment node
+ */
+import { cookie } from './cookie'
+import { response } from '../response'
+
+describe('cookie (Node.js without jsdom)', () => {
+  describe('given I set a cookie', () => {
+    let result: ReturnType<typeof response>
+
+    beforeAll(() => {
+      result = response(cookie('my-cookie', 'arbitrary-value'))
+      expect(result).toBeDefined()
+    })
+
+    it('should be set on the response headers', () => {
+      expect(result.headers.get('set-cookie')).toEqual(
+        'my-cookie=arbitrary-value',
+      )
+    })
+  })
+})

--- a/src/context/cookie.ts
+++ b/src/context/cookie.ts
@@ -14,7 +14,9 @@ export const cookie = (
   return (res) => {
     const serializedCookie = cookieUtils.serialize(name, value, options)
     res.headers.set('Set-Cookie', serializedCookie)
-    document.cookie = serializedCookie
+    if (typeof document !== 'undefined') {
+      document.cookie = serializedCookie
+    }
     return res
   }
 }


### PR DESCRIPTION
If `document` does not exist in the environment, `ctx.cookie` should not attempt to save cookies into `document.cookie`.

Fixes #312 