### PR TITLE
Integration test for binary responses using setupServer

### DIFF
--- a/test/rest-api/body-binary.node.test.ts
+++ b/test/rest-api/body-binary.node.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest environment-node
+ */
+import * as path from 'path'
+import * as fs from 'fs'
+import fetch from 'node-fetch'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+
+function getImageBuffer() {
+  return fs.readFileSync(path.resolve(__dirname, '../fixtures/image.jpg'))
+}
+
+const server = setupServer(
+  rest.get('http://test.mswjs.io/image', (_, res, ctx) => {
+    const imageBuffer = getImageBuffer()
+
+    return res(
+      ctx.set('Content-Length', imageBuffer.byteLength.toString()),
+      ctx.set('Content-Type', 'image/jpeg'),
+      ctx.body(imageBuffer),
+    )
+  }),
+)
+
+beforeAll(() => server.listen())
+afterAll(() => server.close())
+
+test('returns given buffer in the mocked response', async () => {
+  const response = await fetch('http://test.mswjs.io/image')
+  const { status, headers } = response
+  const actualImageBuffer = await response.buffer()
+  const expectedImageBuffer = getImageBuffer()
+
+  expect(status).toBe(200)
+  expect(headers.get('x-powered-by')).toBe('msw')
+  expect(headers.get('content-length')).toBe(
+    actualImageBuffer.byteLength.toString(),
+  )
+  expect(Buffer.compare(actualImageBuffer, expectedImageBuffer)).toBe(0)
+})
+
+test('returns given blob in the mocked response', async () => {
+  const response = await fetch('http://test.mswjs.io/image')
+  const { status, headers } = response
+  const blob = await response.blob()
+
+  const [, blobBufferSymbol] = Object.getOwnPropertySymbols(blob)
+  const actualImageBuffer = blob[blobBufferSymbol] as Buffer
+  const expectedImageBuffer = getImageBuffer()
+
+  expect(status).toBe(200)
+  expect(headers.get('x-powered-by')).toBe('msw')
+  expect(blob.type).toBe('image/jpeg')
+  expect(blob.size).toBe(Number(headers.get('content-length')))
+  expect(Buffer.compare(actualImageBuffer, expectedImageBuffer)).toBe(0)
+})


### PR DESCRIPTION
This adds a (failing, for now) integration test for returning binary data using `setupServer`.

The mock:
* Reads an image from the file system using `fs.readFileSync`
* Sets the `Content-Length`, `Content-Type`, and returns the image; pretty much like the [recipe](https://mswjs.io/docs/recipes/binary-response-type) from the docs, but in node.

The test:
* Fetches the image using `fetch`
* Parses the response as a `blob`
* Tries to convert the response from blob to a base64 representation using `FileReader`'s `readAsDataURL` (like you would do on the browser)

The tests fail with a: `TypeError: Failed to execute 'readAsDataURL' on 'FileReader': parameter 1 is not of type 'Blob'`, probably because `FileReader` it's a browser API and the response from `node-fetch` does not conform to what's expected by the `readAsDataURL` method. Use cases for this kind of test could be code that is meant to fetch images browser-side (React custom hooks for example, which is my use case).