### PR TITLE
Adds a "graphql.link" API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,4 @@ export {
   GraphQLRequestPayload,
   GraphQLResponseResolver,
 } from './graphql'
+export { matchRequestUrl } from './utils/matching/matchRequest'

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -5,6 +5,7 @@ import { SharedOptions } from '../sharedOptions'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
 
 export type Mask = RegExp | string
+export type ResolvedMask = Mask | URL
 
 export interface SetupWorkerInternalContext {
   worker: ServiceWorker | null

--- a/src/utils/matching/getCleanMask.node.test.ts
+++ b/src/utils/matching/getCleanMask.node.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment node
+ */
+import { getCleanMask } from './getCleanMask'
+
+test('returns clean URL given a URL mask', () => {
+  const mask = new URL('https://test.mswjs.io/path?query=123#some')
+  expect(getCleanMask(mask)).toBe('https://test.mswjs.io/path')
+})
+
+test('returns a relative URL as-is given a string mask', () => {
+  const mask = '/relative/url'
+  expect(getCleanMask(mask)).toBe('/relative/url')
+})
+
+test('returns RegExp mask as-is', () => {
+  const mask = /\/user\/(.+?)\//
+  expect(getCleanMask(mask)).toEqual(mask)
+})

--- a/src/utils/matching/getCleanMask.test.ts
+++ b/src/utils/matching/getCleanMask.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getCleanMask } from './getCleanMask'
+
+test('returns clean URL given a URL mask', () => {
+  const mask = new URL('https://test.mswjs.io/path?query=123#some')
+  expect(getCleanMask(mask)).toBe('https://test.mswjs.io/path')
+})
+
+test('returns an abslute URL given a string mask', () => {
+  const mask = '/relative/url'
+  expect(getCleanMask(mask)).toBe(`${location.origin}/relative/url`)
+})
+
+test('returns RegExp mask as-is', () => {
+  const mask = /\/user\/(.+?)\//
+  expect(getCleanMask(mask)).toEqual(mask)
+})

--- a/src/utils/matching/getCleanMask.ts
+++ b/src/utils/matching/getCleanMask.ts
@@ -1,0 +1,11 @@
+import { getCleanUrl } from 'node-request-interceptor/lib/utils/getCleanUrl'
+import { Mask, ResolvedMask } from '../../setupWorker/glossary'
+import { resolveRelativeUrl } from '../resolveRelativeUrl'
+
+export function getCleanMask(resolvedMask: ResolvedMask): Mask {
+  return resolvedMask instanceof URL
+    ? getCleanUrl(resolvedMask)
+    : resolvedMask instanceof RegExp
+    ? resolvedMask
+    : resolveRelativeUrl(resolvedMask)
+}

--- a/src/utils/matching/matchRequest.test.ts
+++ b/src/utils/matching/matchRequest.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import { matchRequestUrl } from './matchRequest'
+
+test('returns true when matched against a wildcard', () => {
+  const match = matchRequestUrl(new URL('https://test.mswjs.io'), '*')
+  expect(match).toHaveProperty('matches', true)
+  expect(match).toHaveProperty('params', null)
+})
+
+test('returns true when matches against an exact URL', () => {
+  const match = matchRequestUrl(
+    new URL('https://test.mswjs.io'),
+    'https://test.mswjs.io',
+  )
+  expect(match).toHaveProperty('matches', true)
+  expect(match).toHaveProperty('params', null)
+})
+
+test('returns true when matched against a RegExp', () => {
+  const match = matchRequestUrl(
+    new URL('https://test.mswjs.io'),
+    /test\.mswjs\.io/,
+  )
+  expect(match).toHaveProperty('matches', true)
+  expect(match).toHaveProperty('params', null)
+})
+
+test('returns request parameters when matched', () => {
+  const match = matchRequestUrl(
+    new URL('https://test.mswjs.io/user/abc-123'),
+    'https://test.mswjs.io/user/:userId',
+  )
+  expect(match).toHaveProperty('matches', true)
+  expect(match).toHaveProperty('params', {
+    userId: 'abc-123',
+  })
+})
+
+test('returns false when does not match against the request URL', () => {
+  const match = matchRequestUrl(
+    new URL('https://test.mswjs.io'),
+    'https://google.com',
+  )
+  expect(match).toHaveProperty('matches', false)
+  expect(match).toHaveProperty('params', null)
+})

--- a/src/utils/matching/matchRequest.ts
+++ b/src/utils/matching/matchRequest.ts
@@ -1,0 +1,20 @@
+import { match } from 'node-match-path'
+import { getCleanUrl } from 'node-request-interceptor/lib/utils/getCleanUrl'
+import { Mask } from '../../setupWorker/glossary'
+import { resolveMask } from '../resolveMask'
+import { getCleanMask } from './getCleanMask'
+
+/**
+ * Returns the result of matching given request URL
+ * against a mask.
+ */
+export function matchRequestUrl(
+  url: URL,
+  mask: Mask,
+): ReturnType<typeof match> {
+  const resolvedMask = resolveMask(mask)
+  const cleanMask = getCleanMask(resolvedMask)
+  const cleanRequestUrl = getCleanUrl(url)
+
+  return match(cleanMask, cleanRequestUrl)
+}

--- a/test/graphql-api/link.mocks.ts
+++ b/test/graphql-api/link.mocks.ts
@@ -1,0 +1,39 @@
+import { setupWorker, graphql } from 'msw'
+
+const github = graphql.link('https://api.github.com/graphql')
+const stripe = graphql.link('https://api.stripe.com/graphql')
+
+const worker = setupWorker(
+  github.query('GetUser', (req, res, ctx) => {
+    return res(
+      ctx.data({
+        user: {
+          id: '46cfe8ff-a79b-42af-9699-b56e2239d1bb',
+          username: req.variables.username,
+        },
+      }),
+    )
+  }),
+  stripe.mutation('Payment', (req, res, ctx) => {
+    return res(
+      ctx.data({
+        bankAccount: {
+          totalFunds: 100 + req.variables.amount,
+        },
+      }),
+    )
+  }),
+  graphql.query('GetUser', (req, res, ctx) => {
+    return res(
+      ctx.set('x-request-handler', 'fallback'),
+      ctx.data({
+        user: {
+          id: '46cfe8ff-a79b-42af-9699-b56e2239d1bb',
+          username: req.variables.username,
+        },
+      }),
+    )
+  }),
+)
+
+worker.start()

--- a/test/graphql-api/link.test.ts
+++ b/test/graphql-api/link.test.ts
@@ -1,0 +1,153 @@
+import * as path from 'path'
+import { executeOperation } from './utils/executeOperation'
+import { runBrowserWith } from '../support/runBrowserWith'
+
+function createRuntime() {
+  return runBrowserWith(path.resolve(__dirname, 'link.mocks.ts'), {
+    withRoutes(app) {
+      app.post('/graphql', (req, res) => {
+        res.status(500).end()
+      })
+    },
+  })
+}
+
+test('mocks a GraphQL query to the GitHub GraphQL API', async () => {
+  const runtime = await createRuntime()
+
+  const res = await executeOperation(
+    runtime.page,
+    {
+      query: `
+      query GetUser($username: String!) {
+        user(username: $username) {
+          id
+          username
+        }
+      }
+    `,
+      variables: {
+        username: 'john',
+      },
+    },
+    {
+      uri: 'https://api.github.com/graphql',
+    },
+  )
+
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(res.status()).toEqual(200)
+  expect(headers).toHaveProperty('content-type', 'application/json')
+  expect(body).toEqual({
+    data: {
+      user: {
+        id: '46cfe8ff-a79b-42af-9699-b56e2239d1bb',
+        username: 'john',
+      },
+    },
+  })
+
+  await runtime.cleanup()
+})
+
+test('mocks a GraphQL mutation to the Stripe GraphQL API', async () => {
+  const runtime = await createRuntime()
+
+  const res = await executeOperation(
+    runtime.page,
+    {
+      query: `
+      mutation Payment($amount: Int!) {
+        bankAccount {
+          totalFunds
+        }
+      }
+    `,
+      variables: {
+        amount: 350,
+      },
+    },
+    {
+      uri: 'https://api.stripe.com/graphql',
+    },
+  )
+
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(res.status()).toEqual(200)
+  expect(headers).toHaveProperty('content-type', 'application/json')
+  expect(body).toEqual({
+    data: {
+      bankAccount: {
+        totalFunds: 450,
+      },
+    },
+  })
+
+  await runtime.cleanup()
+})
+
+test('falls through to the matching GraphQL operation to an unknown endpoint', async () => {
+  const runtime = await createRuntime()
+
+  const res = await executeOperation(runtime.page, {
+    query: `
+      query GetUser($username: String!) {
+        user(username: $username) {
+          id
+          username
+        }
+      }
+    `,
+    variables: {
+      username: 'john',
+    },
+  })
+
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-request-handler', 'fallback')
+
+  expect(body).toEqual({
+    data: {
+      user: {
+        id: '46cfe8ff-a79b-42af-9699-b56e2239d1bb',
+        username: 'john',
+      },
+    },
+  })
+
+  await runtime.cleanup()
+})
+
+test('bypasses a GraphQL operation to an unknown endpoint', async () => {
+  const runtime = await createRuntime()
+
+  const res = await executeOperation(
+    runtime.page,
+    {
+      query: `
+      mutation Payment($amount: Int!) {
+        bankAccount {
+          totalFunds
+        }
+      }
+    `,
+      variables: {
+        amount: 350,
+      },
+    },
+    {
+      uri: `${runtime.origin}/graphql`,
+    },
+  )
+
+  const status = res.status()
+  expect(status).toBe(500)
+
+  await runtime.cleanup()
+})

--- a/test/graphql-api/query.test.ts
+++ b/test/graphql-api/query.test.ts
@@ -19,7 +19,9 @@ test('mocks a GraphQL query issued with a GET request', async () => {
       }
     `,
     },
-    'GET',
+    {
+      method: 'GET',
+    },
   )
 
   const headers = res.headers()


### PR DESCRIPTION
## Changes

- Isolates request matching logic (resolved/clean mask, `match`) into its own utility.
- Exposes `matchRequestUrl` in the public API:

```js
import { matchRequestUrl } from 'msw'

matchRequestUrl(req.url, '*/your/mask')
```

> This would allow developers to create custom request handlers (#290) with the native MSW request matching logic embedded. 

- Request matching is now performed in the "parse" phase for `rest`. This allows us to match request URL against a mask once, so we don't have to do this again to get request params later on.
- Reuses the request matching utility for `rest` and `graphql` API.
- Adds `graphql.link` API that allows to define per-endpoint GraphQL operations mocking.

```js
import { graphql } from 'msw'

const github = graphql.link('https://api.github.com/graphql')
const stripe = graphql.link('https://api.stripe.com/graphql')

github.query('GetUser', resolver)
stripe.mutation('Payment', resolver)
```

## GitHub

- Fixes #315