### PR TITLE
Sets "allowSyntheticDefaultImports" to false

### DIFF
--- a/src/context/cookie.test.ts
+++ b/src/context/cookie.test.ts
@@ -1,4 +1,4 @@
-import cookieUtils from 'cookie'
+import * as cookieUtils from 'cookie'
 import { cookie } from './cookie'
 import { response } from '../response'
 

--- a/src/context/cookie.ts
+++ b/src/context/cookie.ts
@@ -1,4 +1,4 @@
-import cookieUtils, { CookieSerializeOptions } from 'cookie'
+import * as cookieUtils from 'cookie'
 import { ResponseTransformer } from '../response'
 
 /**
@@ -9,14 +9,16 @@ import { ResponseTransformer } from '../response'
 export const cookie = (
   name: string,
   value: string,
-  options?: CookieSerializeOptions,
+  options?: cookieUtils.CookieSerializeOptions,
 ): ResponseTransformer => {
   return (res) => {
     const serializedCookie = cookieUtils.serialize(name, value, options)
     res.headers.set('Set-Cookie', serializedCookie)
+
     if (typeof document !== 'undefined') {
       document.cookie = serializedCookie
     }
+
     return res
   }
 }

--- a/src/context/status.ts
+++ b/src/context/status.ts
@@ -1,4 +1,4 @@
-import statuses from 'statuses/codes.json'
+import * as statuses from 'statuses/codes.json'
 import { ResponseTransformer } from '../response'
 
 export const status = (

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,4 +1,4 @@
-import cookieUtils from 'cookie'
+import * as cookieUtils from 'cookie'
 import { Headers, flattenHeadersObject } from 'headers-utils'
 import {
   RequestInterceptor,

--- a/src/utils/request/getRequestCookies.ts
+++ b/src/utils/request/getRequestCookies.ts
@@ -1,4 +1,4 @@
-import cookieUtils from 'cookie'
+import * as cookieUtils from 'cookie'
 import { MockedRequest } from '../../handlers/requestHandler'
 
 function getAllCookies() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es6",
     "module": "ESNext",
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports": false,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "declaration": true,


### PR DESCRIPTION
## Changes

- Builds the library with the `allowSyntheticDefaultImports` TypeScript option set to `false. This ensures more strict compilation rules, granting that developers with strict TypeScript configuration may use MSW without issues. More permissive TypeScript configurations should not be affected.

## GitHub

- Fixes #321