### PR TITLE
Update ParsedRestRequest to be exported

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export {
   AsyncResponseResolverReturnType,
   defaultContext,
 } from './handlers/requestHandler'
-export { rest, restContext, RESTMethods } from './rest'
+export { rest, restContext, RESTMethods, ParsedRestRequest } from './rest'
 export {
   graphql,
   graphqlContext,

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -45,7 +45,7 @@ export const restContext = {
   fetch,
 }
 
-interface ParsedRestRequest {
+export interface ParsedRestRequest {
   match: ReturnType<typeof matchRequestUrl>
 }
 


### PR DESCRIPTION
When building with declaration: true in ts config for a library re-exporting a bunch of rest mocks, an error can arise due to the return type of rest[method] being a generic, where one of the types of the generic is not exported (and therefor not accessible to the compiler when building, directly). 

A fix is to export that interface `ParsedRestRequest` from src/rest.
This alone seems to allow the compiler to access this interface and work effectively, however, it seems as though a user might also want to explicitly type these options at some point, and doing so would require a re-export of that from the main package (to match the re-exports of MockedRequest, restContext)

fixes #325 