### PR TITLE
Add matchFilenameOnly start option

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "cross-env NODE_ENV=development rollup -c rollup.config.ts -w",
     "clean": "rimraf lib node/**/*.js",
-    "lint": "eslint '{cli,config,src,test}/**/*.ts'",
+    "lint": "eslint \"{cli,config,src,test}/**/*.ts\"",
     "build": "yarn clean && cross-env NODE_ENV=production rollup -c rollup.config.ts",
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "cross-env BABEL_ENV=test jest --runInBand",

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -54,6 +54,14 @@ export type StartOptions = SharedOptions & {
    * instance is ready. Defaults to `true`.
    */
   waitUntilReady?: boolean
+
+  /**
+   * A boolean that allows you to override the default strict matching behavior. If set to false, the first worker
+   * based on a matching filename only (ex: mockServiceWorker.js) will be returned. This is primarily useful in the scenario that
+   * you are using proxies and having difficulty to get the origin and `scriptURL` to match due to port differences.
+   * Defaults to `false`.
+   */
+  matchFilenameOnly?: boolean
 }
 
 export type RequestHandlersList = RequestHandler<any, any>[]

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -56,7 +56,7 @@ export type StartOptions = SharedOptions & {
   waitUntilReady?: boolean
 
   /**
-   * A boolean that allows you to override the default strict matching behavior. If set to false, the first worker
+   * A boolean that allows you to override the default strict matching behavior. If set to `true`, the first worker
    * based on a matching filename only (ex: mockServiceWorker.js) will be returned. This is primarily useful in the scenario that
    * you are using proxies and having difficulty to get the origin and `scriptURL` to match due to port differences.
    * Defaults to `false`.

--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -18,6 +18,7 @@ const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
   quiet: false,
   waitUntilReady: true,
   onUnhandledRequest: 'bypass',
+  matchFilenameOnly: false,
 }
 
 export const createStart = (context: SetupWorkerInternalContext) => {
@@ -50,6 +51,7 @@ export const createStart = (context: SetupWorkerInternalContext) => {
         getWorkerInstance(
           resolvedOptions.serviceWorker.url,
           resolvedOptions.serviceWorker.options,
+          resolvedOptions.matchFilenameOnly,
         ),
       )
 

--- a/src/setupWorker/start/utils/getWorkerByRegistration.ts
+++ b/src/setupWorker/start/utils/getWorkerByRegistration.ts
@@ -16,9 +16,7 @@ export const getWorkerByRegistration = (
   const mockWorker = existingStates.find((worker) => {
     if (matchFilenameOnly) {
       const workerFileName = absoluteWorkerUrl.split('/').pop()
-      if (workerFileName) {
-        return worker.scriptURL.includes(workerFileName)
-      }
+      return workerFileName ? worker.scriptURL.includes(workerFileName) : false
     }
     return worker.scriptURL === absoluteWorkerUrl
   })

--- a/src/setupWorker/start/utils/getWorkerByRegistration.ts
+++ b/src/setupWorker/start/utils/getWorkerByRegistration.ts
@@ -5,6 +5,7 @@
 export const getWorkerByRegistration = (
   registration: ServiceWorkerRegistration,
   absoluteWorkerUrl: string,
+  matchFilenameOnly = false,
 ): ServiceWorker | null => {
   const allStates = [
     registration.active,
@@ -13,6 +14,12 @@ export const getWorkerByRegistration = (
   ]
   const existingStates = allStates.filter(Boolean) as ServiceWorker[]
   const mockWorker = existingStates.find((worker) => {
+    if (matchFilenameOnly) {
+      const workerFileName = absoluteWorkerUrl.split('/').pop()
+      if (workerFileName) {
+        return worker.scriptURL.includes(workerFileName)
+      }
+    }
     return worker.scriptURL === absoluteWorkerUrl
   })
 

--- a/src/setupWorker/start/utils/getWorkerInstance.ts
+++ b/src/setupWorker/start/utils/getWorkerInstance.ts
@@ -1,6 +1,6 @@
 import { until } from '@open-draft/until'
 import { getWorkerByRegistration } from './getWorkerByRegistration'
-import { ServiceWorkerInstanceTuple } from '../../glossary'
+import { ServiceWorkerInstanceTuple, StartOptions } from '../../glossary'
 import { getAbsoluteWorkerUrl } from '../../../utils/getAbsoluteWorkerUrl'
 
 /**
@@ -10,6 +10,7 @@ import { getAbsoluteWorkerUrl } from '../../../utils/getAbsoluteWorkerUrl'
 export const getWorkerInstance = async (
   url: string,
   options?: RegistrationOptions,
+  matchFilenameOnly?: StartOptions['matchFilenameOnly'],
 ): Promise<ServiceWorkerInstanceTuple | null> => {
   // Resolve the absolute Service Worker URL
   const absoluteWorkerUrl = getAbsoluteWorkerUrl(url)
@@ -17,7 +18,11 @@ export const getWorkerInstance = async (
   const [, mockRegistrations] = await until(async () => {
     const registrations = await navigator.serviceWorker.getRegistrations()
     return registrations.filter((registration) => {
-      return getWorkerByRegistration(registration, absoluteWorkerUrl)
+      return getWorkerByRegistration(
+        registration,
+        absoluteWorkerUrl,
+        matchFilenameOnly,
+      )
     })
   })
 
@@ -37,7 +42,11 @@ export const getWorkerInstance = async (
     // Update existing service worker to ensure it's up-to-date
     return existingRegistration.update().then(() => {
       return [
-        getWorkerByRegistration(existingRegistration, absoluteWorkerUrl),
+        getWorkerByRegistration(
+          existingRegistration,
+          absoluteWorkerUrl,
+          matchFilenameOnly,
+        ),
         existingRegistration,
       ]
     })
@@ -49,7 +58,11 @@ export const getWorkerInstance = async (
       return [
         // Compare existing worker registration by its worker URL,
         // to prevent irrelevant workers to resolve here (such as Codesandbox worker).
-        getWorkerByRegistration(registration, absoluteWorkerUrl),
+        getWorkerByRegistration(
+          registration,
+          absoluteWorkerUrl,
+          matchFilenameOnly,
+        ),
         registration,
       ]
     },


### PR DESCRIPTION
- Addresses the conversation in #335 by introducing an escape hatch that allows a `serviceWorker` to be matched on the filename only, disregarding the strict `origin/filename` match.