### PR TITLE
onUnhandledRequest: Adds request handler declaration suggestion

### DIFF
--- a/src/onUnhandledRequest.ts
+++ b/src/onUnhandledRequest.ts
@@ -1,4 +1,5 @@
 import { MockedRequest } from './handlers/requestHandler'
+import { getPublicUrlFromRequest } from './utils/getPublicUrlFromRequest'
 
 type UnhandledRequestCallback = (req: MockedRequest) => void
 
@@ -17,7 +18,17 @@ export function onUnhandledRequest(
     return
   }
 
-  const message = `captured a ${request.method} ${request.url} request without a corresponding request handler.`
+  const publicUrl = getPublicUrlFromRequest(request)
+
+  const message = `captured a ${request.method} ${
+    request.url
+  } request without a corresponding request handler.
+
+  If you wish to intercept this request, consider creating a request handler for it:
+
+  rest.${request.method.toLowerCase()}('${publicUrl}', (req, res, ctx) => {
+    return res(ctx.text('body'))
+  })`
 
   switch (onUnhandledRequest) {
     case 'error': {

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,4 +1,3 @@
-import { format } from 'url'
 import {
   RequestHandler,
   ResponseResolver,
@@ -18,6 +17,7 @@ import { fetch } from './context/fetch'
 /* Logging */
 import { prepareRequest } from './utils/logger/prepareRequest'
 import { prepareResponse } from './utils/logger/prepareResponse'
+import { getPublicUrlFromRequest } from './utils/getPublicUrlFromRequest'
 import { getTimestamp } from './utils/logger/getTimestamp'
 import { getStatusCodeColor } from './utils/logger/getStatusCodeColor'
 import { isStringEqual } from './utils/isStringEqual'
@@ -110,14 +110,7 @@ ${queryParams
           )
         }
 
-        const isRelativeRequest = req.referrer.startsWith(req.url.origin)
-        const publicUrl = isRelativeRequest
-          ? req.url.pathname
-          : format({
-              protocol: req.url.protocol,
-              host: req.url.host,
-              pathname: req.url.pathname,
-            })
+        const publicUrl = getPublicUrlFromRequest(req)
 
         const loggedRequest = prepareRequest(req)
         const loggedResponse = prepareResponse(res)

--- a/src/utils/getPublicUrlFromRequest.test.ts
+++ b/src/utils/getPublicUrlFromRequest.test.ts
@@ -1,0 +1,18 @@
+import { getPublicUrlFromRequest } from './getPublicUrlFromRequest'
+import { MockedRequest } from '../handlers/requestHandler'
+
+test('returns an absolute URL string given its origin differs from the referrer', () => {
+  const request = {
+    url: new URL('https://test.mswjs.io/path'),
+    referrer: 'http://localhost',
+  } as MockedRequest
+  expect(getPublicUrlFromRequest(request)).toBe('https://test.mswjs.io/path')
+})
+
+test('returns a relative URL string given its origin matches the referrer', () => {
+  const request = {
+    url: new URL('http://localhost/path'),
+    referrer: 'http://localhost',
+  } as MockedRequest
+  expect(getPublicUrlFromRequest(request)).toBe('/path')
+})

--- a/src/utils/getPublicUrlFromRequest.ts
+++ b/src/utils/getPublicUrlFromRequest.ts
@@ -1,0 +1,15 @@
+import { format } from 'url'
+import { MockedRequest } from '../handlers/requestHandler'
+
+/**
+ * Returns an absolute or relative URL string based on the URL's origin.
+ */
+export const getPublicUrlFromRequest = (request: MockedRequest) => {
+  return request.referrer.startsWith(request.url.origin)
+    ? request.url.pathname
+    : format({
+        protocol: request.url.protocol,
+        host: request.url.host,
+        pathname: request.url.pathname,
+      })
+}

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
@@ -11,13 +11,23 @@ const server = setupServer(
   }),
 )
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-afterAll(() => server.close())
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' })
+})
+
+afterAll(() => {
+  server.close()
+})
 
 test('errors on unhandled request when using the "error" value', async () => {
   const getResponse = () => fetch('https://test.mswjs.io')
 
-  await expect(getResponse()).rejects.toThrow(
-    'request to https://test.mswjs.io/ failed, reason: [MSW] Error: captured a GET https://test.mswjs.io/ request without a corresponding request handler.',
-  )
+  await expect(getResponse()).rejects.toThrow(`\
+request to https://test.mswjs.io/ failed, reason: [MSW] Error: captured a GET https://test.mswjs.io/ request without a corresponding request handler.
+
+  If you wish to intercept this request, consider creating a request handler for it:
+
+  rest.get('https://test.mswjs.io/', (req, res, ctx) => {
+    return res(ctx.text('body'))
+  })`)
 })

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/warn.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/warn.test.ts
@@ -11,7 +11,10 @@ const server = setupServer(
   }),
 )
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'warn' })
+})
+
 afterAll(() => {
   server.close()
   jest.restoreAllMocks()
@@ -23,7 +26,12 @@ test('warns on unhandled request when using the "warn" value', async () => {
   const res = await fetch('https://test.mswjs.io')
 
   expect(res).toHaveProperty('status', 404)
-  expect(console.warn).toBeCalledWith(
-    '[MSW] Warning: captured a GET https://test.mswjs.io/ request without a corresponding request handler.',
-  )
+  expect(console.warn).toBeCalledWith(`\
+[MSW] Warning: captured a GET https://test.mswjs.io/ request without a corresponding request handler.
+
+  If you wish to intercept this request, consider creating a request handler for it:
+
+  rest.get('https://test.mswjs.io/', (req, res, ctx) => {
+    return res(ctx.text('body'))
+  })`)
 })

--- a/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
@@ -7,7 +7,7 @@ import {
 
 let runtime: TestAPI
 
-beforeAll(async () => {
+beforeEach(async () => {
   runtime = await runBrowserWith(path.resolve(__dirname, 'warn.mocks.ts'))
 })
 
@@ -15,7 +15,7 @@ afterEach(async () => {
   await runtime.cleanup()
 })
 
-test('warns on an unhandled request when using the "warn" option', async () => {
+test('warns on an absolute unhandled request', async () => {
   const { messages } = captureConsole(runtime.page)
 
   const res = await runtime.request({
@@ -29,7 +29,43 @@ test('warns on an unhandled request when using the "warn" option', async () => {
   const libraryWarnings = messages.warning.filter(filterLibraryLogs)
 
   expect(libraryErrors).toHaveLength(0)
-  expect(libraryWarnings).toContain(
-    '[MSW] Warning: captured a GET https://mswjs.io/non-existing-page request without a corresponding request handler.',
-  )
+  expect(libraryWarnings).toContain(`\
+[MSW] Warning: captured a GET https://mswjs.io/non-existing-page request without a corresponding request handler.
+
+  If you wish to intercept this request, consider creating a request handler for it:
+
+  rest.get('https://mswjs.io/non-existing-page', (req, res, ctx) => {
+    return res(ctx.text('body'))
+  })`)
+})
+
+test('warns on a relative unhandled request', async () => {
+  const { messages } = captureConsole(runtime.page)
+
+  const url = `${runtime.origin}/user-details`
+  const res = await runtime.request({
+    url,
+  })
+  const status = res.status()
+
+  expect(status).toBe(404)
+
+  const libraryErrors = messages.error.filter(filterLibraryLogs)
+  const libraryWarnings = messages.warning.filter(filterLibraryLogs)
+  const requestHandlerWarning = libraryWarnings.find((text) => {
+    return /\[MSW\] Warning: captured a GET .+? request without a corresponding request handler/.test(
+      text,
+    )
+  })
+
+  expect(libraryErrors).toHaveLength(0)
+  expect(requestHandlerWarning).toBeTruthy()
+  expect(requestHandlerWarning).toMatch(`\
+[MSW] Warning: captured a GET ${url} request without a corresponding request handler.
+
+  If you wish to intercept this request, consider creating a request handler for it:
+
+  rest.get('/user-details', (req, res, ctx) => {
+    return res(ctx.text('body'))
+  })`)
 })


### PR DESCRIPTION
Fixes #336 

- Updates the error message as requested
- Updates relevant tests to use `toMatchInlineSnapshot`