### PR TITLE
setupWorker: Deeply merges default and custom options

### DIFF
--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -9,6 +9,7 @@ import {
 import { handleRequestWith } from '../../utils/handleRequestWith'
 import { requestIntegrityCheck } from '../../utils/internal/requestIntegrityCheck'
 import { deferNetworkRequestsUntil } from '../../utils/deferNetworkRequestsUntil'
+import { mergeRight } from '../../utils/internal/mergeRight'
 
 const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
   serviceWorker: {
@@ -25,7 +26,7 @@ export const createStart = (context: SetupWorkerInternalContext) => {
    * Registers and activates the mock Service Worker.
    */
   return function start(options?: StartOptions) {
-    const resolvedOptions = Object.assign({}, DEFAULT_START_OPTIONS, options)
+    const resolvedOptions = mergeRight(DEFAULT_START_OPTIONS, options || {})
 
     const startWorkerInstance = async () => {
       if (!('serviceWorker' in navigator)) {

--- a/src/utils/internal/mergeRight.test.ts
+++ b/src/utils/internal/mergeRight.test.ts
@@ -1,0 +1,43 @@
+import { mergeRight } from './mergeRight'
+
+test('shallowly merges two given objects', () => {
+  expect(mergeRight({ a: 1, b: 2 }, { b: 3, c: 4 })).toEqual({
+    a: 1,
+    b: 3,
+    c: 4,
+  })
+})
+
+test('deeply merges two given objects', () => {
+  expect(
+    mergeRight(
+      {
+        a: 'string',
+        b: [1, 2],
+        c: {
+          d: 2,
+        },
+      },
+      {
+        a: 'another-string',
+        b: [3],
+        c: {
+          e: 'five',
+          f: {
+            g: true,
+          },
+        },
+      },
+    ),
+  ).toEqual({
+    a: 'another-string',
+    b: [1, 2, 3],
+    c: {
+      d: 2,
+      e: 'five',
+      f: {
+        g: true,
+      },
+    },
+  })
+})

--- a/src/utils/internal/mergeRight.ts
+++ b/src/utils/internal/mergeRight.ts
@@ -1,0 +1,32 @@
+function isObject(obj: Record<string, any>): boolean {
+  return typeof obj === 'object'
+}
+
+/**
+ * Deeply merges two given objects with the right one
+ * having a priority during property assignment.
+ */
+export function mergeRight(
+  a: Record<string, any>,
+  b: Record<string, any>,
+): Record<string, any> {
+  const result = Object.assign({}, a)
+
+  Object.entries(b).forEach(([key, value]) => {
+    const existingValue = result[key]
+
+    if (Array.isArray(existingValue) && Array.isArray(value)) {
+      result[key] = existingValue.concat(value)
+      return
+    }
+
+    if (isObject(existingValue) && isObject(value)) {
+      result[key] = mergeRight(existingValue, value)
+      return
+    }
+
+    result[key] = value
+  })
+
+  return result
+}

--- a/test/msw-api/setup-worker/start/options-sw-scope.mocks.ts
+++ b/test/msw-api/setup-worker/start/options-sw-scope.mocks.ts
@@ -1,0 +1,17 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start({
+  serviceWorker: {
+    options: {
+      // Service Worker would control the network traffic
+      // outgoing only from the "/profile/*" pages.
+      scope: '/profile',
+    },
+  },
+})

--- a/test/msw-api/setup-worker/start/options-sw-scope.test.ts
+++ b/test/msw-api/setup-worker/start/options-sw-scope.test.ts
@@ -1,0 +1,40 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
+import { captureConsole } from '../../../support/captureConsole'
+
+let runtime: TestAPI
+
+beforeAll(async () => {
+  runtime = await runBrowserWith(
+    path.resolve(__dirname, 'options-sw-scope.mocks.ts'),
+  )
+})
+
+afterAll(() => {
+  return runtime.cleanup()
+})
+
+test('respects a custom "scope" Service Worker option', async () => {
+  const { messages } = captureConsole(runtime.page)
+
+  await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW_REGISTRATION__
+  })
+
+  await runtime.reload()
+
+  const activationMessage = messages.startGroupCollapsed.find((text) => {
+    return text.includes('[MSW] Mocking enabled.')
+  })
+  expect(activationMessage).toBeTruthy()
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/user`,
+  })
+  const status = res.status()
+
+  // Since the root "/" page lies outside of the custom worker scope,
+  // it won't be able to intercept an otherwise matching request.
+  expect(status).toBe(404)
+})


### PR DESCRIPTION
## Changes

- Adds `mergeRight` custom utility function that deeply merges two objects, given the right one a priority.
- Uses `mergeRight` utility in `worker.start()` to merge default and custom options (objects can be deep).
- Adds an integration test for `worker.start()` with custom `serviceWorker.options.scope` option.

## GitHub

- Fixes #347 