### PR TITLE
Add support for more types passed to `context.json` helper

### DIFF
--- a/src/context/json.test.ts
+++ b/src/context/json.test.ts
@@ -10,21 +10,31 @@ describe('json', () => {
     })
 
     it('should have body set to the given JSON', () => {
-      const object = response(json({ firstName: 'John' }))
+      const object = json({ firstName: 'John' })
 
-      expect(object).toHaveProperty('body', `{"firstName":"John"}`)
+      expect(response(object)).toHaveProperty('body', `{"firstName":"John"}`)
 
-      const array = response(json([1, '2', true, { ok: true }, '']))
+      const array = json([1, '2', true, { ok: true }, ''])
 
-      expect(array).toHaveProperty('body', '[1,"2",true,{"ok":true},""]')
+      expect(response(array)).toHaveProperty(
+        'body',
+        '[1,"2",true,{"ok":true},""]',
+      )
 
-      const string = response(json('Some string'))
+      const string = json('Some string')
 
-      expect(string).toHaveProperty('body', '"Some string"')
+      expect(response(string)).toHaveProperty('body', '"Some string"')
 
-      const bool = response(json(true))
+      const bool = json(true)
 
-      expect(bool).toHaveProperty('body', 'true')
+      expect(response(bool)).toHaveProperty('body', 'true')
+
+      const date = json(new Date(Date.UTC(2020, 0, 1)))
+
+      expect(response(date)).toHaveProperty(
+        'body',
+        '"2020-01-01T00:00:00.000Z"',
+      )
     })
   })
 })

--- a/src/context/json.test.ts
+++ b/src/context/json.test.ts
@@ -3,18 +3,28 @@ import { response } from '../response'
 
 describe('json', () => {
   describe('given a JSON body', () => {
-    let result: ReturnType<typeof response>
-
-    beforeAll(() => {
-      result = response(json({ firstName: 'John' }))
-    })
-
     it('should have "Content-Type" as "application/json"', () => {
+      const result = response(json({ firstName: 'John' }))
+
       expect(result.headers.get('content-type')).toEqual('application/json')
     })
 
     it('should have body set to the given JSON', () => {
-      expect(result).toHaveProperty('body', `{"firstName":"John"}`)
+      const object = response(json({ firstName: 'John' }))
+
+      expect(object).toHaveProperty('body', `{"firstName":"John"}`)
+
+      const array = response(json([1, '2', true, { ok: true }, '']))
+
+      expect(array).toHaveProperty('body', '[1,"2",true,{"ok":true},""]')
+
+      const string = response(json('Some string'))
+
+      expect(string).toHaveProperty('body', '"Some string"')
+
+      const bool = response(json(true))
+
+      expect(bool).toHaveProperty('body', 'true')
     })
   })
 })

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -1,17 +1,13 @@
 import { ResponseTransformer } from '../response'
 
-type JsonArray = (JsonValue | JsonRecord)[]
-type JsonRecord = Record<string, unknown>
-type JsonValue = string | boolean | number | JsonRecord | JsonArray | null
-
 /**
- * Sets the given Object as the JSON body of the response.
+ * Sets the given value as the JSON body of the response.
  * @example
  * res(json({ foo: 'bar' }))
  * res(json('Some string'))
  * res(json([1, '2', false, { ok: true }]))
  */
-export const json = (body: JsonValue): ResponseTransformer => {
+export const json = (body: any): ResponseTransformer => {
   return (res) => {
     res.headers.set('Content-Type', 'application/json')
     res.body = JSON.stringify(body)

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -1,11 +1,17 @@
 import { ResponseTransformer } from '../response'
 
+type JsonArray = (JsonValue | JsonRecord)[]
+type JsonRecord = Record<string, unknown>
+type JsonValue = string | boolean | number | JsonRecord | JsonArray | null
+
 /**
  * Sets the given Object as the JSON body of the response.
  * @example
  * res(json({ foo: 'bar' }))
+ * res(json('Some string'))
+ * res(json([1, '2', false, { ok: true }]))
  */
-export const json = (body: Record<string, any>): ResponseTransformer => {
+export const json = (body: JsonValue): ResponseTransformer => {
   return (res) => {
     res.headers.set('Content-Type', 'application/json')
     res.body = JSON.stringify(body)


### PR DESCRIPTION
Close #349

Expand the types the `context.json` helper accepts for the `body` argument so it is not just `Record<string, any>`. It should accept any type that would result in a successful `JSON.stringify` call.