### PR TITLE
rest: Supports RequestBodyType, ResponseBodyType generics

### DIFF
--- a/src/context/body.ts
+++ b/src/context/body.ts
@@ -1,11 +1,15 @@
-import { ResponseTransformer } from '../response'
+import { ResponseTransformer, MockedResponse } from '../response'
 
 /**
  * Sets the body of the response without any `Content-Type` header.
  * @example
- * res(body('foo'))
+ * res(body('message'))
  */
-export const body = <T>(value: T): ResponseTransformer => {
+export const body = <
+  BodyType extends string | Blob | BufferSource | ReadableStream | FormData
+>(
+  value: BodyType,
+): ResponseTransformer<BodyType> => {
   return (res) => {
     res.body = value
     return res

--- a/src/context/body.ts
+++ b/src/context/body.ts
@@ -1,4 +1,4 @@
-import { ResponseTransformer, MockedResponse } from '../response'
+import { ResponseTransformer } from '../response'
 
 /**
  * Sets the body of the response without any `Content-Type` header.

--- a/src/context/errors.ts
+++ b/src/context/errors.ts
@@ -7,6 +7,6 @@ import { json } from './json'
  */
 export const errors = (
   errorsList: Partial<GraphQLError>[],
-): ResponseTransformer => {
+): ResponseTransformer<{ errors: typeof errorsList }> => {
   return json({ errors: errorsList })
 }

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -1,4 +1,4 @@
-import { ResponseTransformer, MockedResponse } from '../response'
+import { ResponseTransformer } from '../response'
 
 /**
  * Sets the given value as the JSON body of the response.

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -1,16 +1,18 @@
-import { ResponseTransformer } from '../response'
+import { ResponseTransformer, MockedResponse } from '../response'
 
 /**
  * Sets the given value as the JSON body of the response.
  * @example
- * res(json({ foo: 'bar' }))
+ * res(json({ key: 'value' }))
  * res(json('Some string'))
  * res(json([1, '2', false, { ok: true }]))
  */
-export const json = (body: any): ResponseTransformer => {
+export const json = <BodyType>(
+  body: BodyType,
+): ResponseTransformer<BodyType> => {
   return (res) => {
     res.headers.set('Content-Type', 'application/json')
-    res.body = JSON.stringify(body)
+    res.body = JSON.stringify(body) as any
     return res
   }
 }

--- a/src/context/text.ts
+++ b/src/context/text.ts
@@ -1,11 +1,13 @@
-import { ResponseTransformer } from '../response'
+import { ResponseTransformer, MockedResponse } from '../response'
 
 /**
  * Sets a given text as a "Cotent-Type: text/plain" body of the response.
  * @example
- * res(text('Message'))
+ * res(text('message'))
  */
-export const text = (body: string): ResponseTransformer => {
+export const text = <BodyType extends string>(
+  body: BodyType,
+): ResponseTransformer<BodyType> => {
   return (res) => {
     res.headers.set('Content-Type', 'text/plain')
     res.body = body

--- a/src/context/text.ts
+++ b/src/context/text.ts
@@ -1,4 +1,4 @@
-import { ResponseTransformer, MockedResponse } from '../response'
+import { ResponseTransformer } from '../response'
 
 /**
  * Sets a given text as a "Cotent-Type: text/plain" body of the response.

--- a/src/context/xml.ts
+++ b/src/context/xml.ts
@@ -3,9 +3,11 @@ import { ResponseTransformer } from '../response'
 /**
  * Sets the given XML as the body of the response.
  * @example
- * res(xml('<message>Foo</message>'))
+ * res(xml('<key>value</key>'))
  */
-export const xml = (body: string): ResponseTransformer => {
+export const xml = <BodyType extends string>(
+  body: BodyType,
+): ResponseTransformer<BodyType> => {
   return (res) => {
     res.headers.set('Content-Type', 'text/xml')
     res.body = body

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -96,7 +96,7 @@ export const setupServer = (...requestHandlers: RequestHandlersList) => {
               status: response.status,
               statusText: response.statusText,
               headers: response.headers.getAllHeaders(),
-              body: response.body,
+              body: response.body as string,
             })
           }, response.delay ?? 0)
         })

--- a/src/response.ts
+++ b/src/response.ts
@@ -2,7 +2,7 @@ import { Headers } from 'headers-utils'
 import { compose } from './utils/internal/compose'
 import { NetworkError } from './utils/NetworkError'
 
-export interface MockedResponse<BodyType = any> {
+export interface MockedResponse<BodyType = unknown> {
   body: BodyType
   status: number
   statusText: string
@@ -11,13 +11,15 @@ export interface MockedResponse<BodyType = any> {
   delay?: number
 }
 
-export type ResponseTransformer<BodyType = any> = (
+export type ResponseTransformer<BodyType = unknown> = (
   res: MockedResponse<BodyType>,
 ) => MockedResponse<BodyType>
 type ResponseFunction<BodyType = any> = (
   ...transformers: ResponseTransformer<BodyType>[]
 ) => MockedResponse<BodyType>
-export type ResponseComposition<BodyType = any> = ResponseFunction<BodyType> & {
+export type ResponseComposition<BodyType = unknown> = ResponseFunction<
+  BodyType
+> & {
   /**
    * Respond using a given mocked response to the first captured request.
    * Does not affect any subsequent captured requests.

--- a/src/response.ts
+++ b/src/response.ts
@@ -2,8 +2,8 @@ import { Headers } from 'headers-utils'
 import { compose } from './utils/internal/compose'
 import { NetworkError } from './utils/NetworkError'
 
-export interface MockedResponse {
-  body: any
+export interface MockedResponse<BodyType = any> {
+  body: BodyType
   status: number
   statusText: string
   headers: Headers
@@ -11,16 +11,18 @@ export interface MockedResponse {
   delay?: number
 }
 
-export type ResponseTransformer = (res: MockedResponse) => MockedResponse
-type ResponseFunction = (
-  ...transformers: ResponseTransformer[]
-) => MockedResponse
-export type ResponseComposition = ResponseFunction & {
+export type ResponseTransformer<BodyType = any> = (
+  res: MockedResponse<BodyType>,
+) => MockedResponse<BodyType>
+type ResponseFunction<BodyType = any> = (
+  ...transformers: ResponseTransformer<BodyType>[]
+) => MockedResponse<BodyType>
+export type ResponseComposition<BodyType = any> = ResponseFunction<BodyType> & {
   /**
    * Respond using a given mocked response to the first captured request.
    * Does not affect any subsequent captured requests.
    */
-  once: ResponseFunction
+  once: ResponseFunction<BodyType>
   networkError: (message: string) => void
 }
 
@@ -55,12 +57,9 @@ function createResponseComposition(
   }
 }
 
-export const response: ResponseComposition = Object.assign(
-  createResponseComposition(),
-  {
-    once: createResponseComposition({ once: true }),
-    networkError(message: string) {
-      throw new NetworkError(message)
-    },
+export const response = Object.assign(createResponseComposition(), {
+  once: createResponseComposition({ once: true }),
+  networkError(message: string) {
+    throw new NetworkError(message)
   },
-)
+})

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -51,7 +51,7 @@ export interface ParsedRestRequest {
 }
 
 const createRestHandler = (method: RESTMethods) => {
-  return <RequestBodyType = DefaultRequestBodyType, ResponseBodyType = any>(
+  return <RequestBodyType = DefaultRequestBodyType, ResponseBodyType = unknown>(
     mask: Mask,
     resolver: ResponseResolver<
       MockedRequest<RequestBodyType>,

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -2,6 +2,7 @@ import {
   RequestHandler,
   ResponseResolver,
   MockedRequest,
+  DefaultRequestBodyType,
 } from './utils/handlers/requestHandler'
 import { Mask } from './setupWorker/glossary'
 import { set } from './context/set'
@@ -50,10 +51,20 @@ export interface ParsedRestRequest {
 }
 
 const createRestHandler = (method: RESTMethods) => {
-  return (
+  return <RequestBodyType = DefaultRequestBodyType, ResponseBodyType = any>(
     mask: Mask,
-    resolver: ResponseResolver<MockedRequest, typeof restContext>,
-  ): RequestHandler<MockedRequest, typeof restContext, ParsedRestRequest> => {
+    resolver: ResponseResolver<
+      MockedRequest<RequestBodyType>,
+      typeof restContext,
+      ResponseBodyType
+    >,
+  ): RequestHandler<
+    MockedRequest<RequestBodyType>,
+    typeof restContext,
+    ParsedRestRequest,
+    MockedRequest<RequestBodyType>,
+    ResponseBodyType
+  > => {
     const resolvedMask = getUrlByMask(mask)
 
     return {

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -58,6 +58,9 @@ export type StartOptions = SharedOptions & {
 
 export type RequestHandlersList = RequestHandler<any, any>[]
 
-export type ResponseWithSerializedHeaders = Omit<MockedResponse, 'headers'> & {
+export type ResponseWithSerializedHeaders<BodyType = unknown> = Omit<
+  MockedResponse<BodyType>,
+  'headers'
+> & {
   headers: HeadersList
 }

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -50,7 +50,7 @@ export type AsyncResponseResolverReturnType<R> =
 export type ResponseResolver<
   RequestType = MockedRequest,
   ContextType = typeof defaultContext,
-  BodyType = any
+  BodyType = unknown
 > = (
   req: RequestType,
   res: ResponseComposition<BodyType>,
@@ -60,9 +60,9 @@ export type ResponseResolver<
 export interface RequestHandler<
   RequestType = MockedRequest,
   ContextType = typeof defaultContext,
-  ParsedRequest = any,
+  ParsedRequest = unknown,
   PublicRequest = RequestType,
-  ResponseBodyType = any
+  ResponseBodyType = unknown
 > {
   /**
    * Parses a captured request to retrieve additional

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -13,7 +13,9 @@ export const defaultContext = {
   fetch,
 }
 
-export interface MockedRequest {
+export type DefaultRequestBodyType = Record<string, any> | string | undefined
+
+export interface MockedRequest<BodyType = DefaultRequestBodyType> {
   url: URL
   method: Request['method']
   headers: Headers
@@ -27,7 +29,7 @@ export interface MockedRequest {
   redirect: Request['redirect']
   referrer: Request['referrer']
   referrerPolicy: Request['referrerPolicy']
-  body: Record<string, any> | string | undefined
+  body: BodyType
   bodyUsed: Request['bodyUsed']
   params: RequestParams
 }
@@ -47,18 +49,20 @@ export type AsyncResponseResolverReturnType<R> =
 
 export type ResponseResolver<
   RequestType = MockedRequest,
-  ContextType = typeof defaultContext
+  ContextType = typeof defaultContext,
+  BodyType = any
 > = (
   req: RequestType,
-  res: ResponseComposition,
+  res: ResponseComposition<BodyType>,
   context: ContextType,
-) => AsyncResponseResolverReturnType<MockedResponse>
+) => AsyncResponseResolverReturnType<MockedResponse<BodyType>>
 
 export interface RequestHandler<
   RequestType = MockedRequest,
   ContextType = typeof defaultContext,
   ParsedRequest = any,
-  PublicRequest = RequestType
+  PublicRequest = RequestType,
+  ResponseBodyType = any
 > {
   /**
    * Parses a captured request to retrieve additional
@@ -82,7 +86,7 @@ export interface RequestHandler<
   /**
    * Returns a mocked response object to the captured request.
    */
-  resolver: ResponseResolver<RequestType, ContextType>
+  resolver: ResponseResolver<RequestType, ContextType, ResponseBodyType>
 
   /**
    * Returns a map of context utility functions available
@@ -97,7 +101,13 @@ export interface RequestHandler<
   log: (
     req: PublicRequest,
     res: ResponseWithSerializedHeaders,
-    handler: RequestHandler<RequestType, ContextType>,
+    handler: RequestHandler<
+      RequestType,
+      ContextType,
+      ParsedRequest,
+      PublicRequest,
+      ResponseBodyType
+    >,
     parsedRequest: ParsedRequest,
   ) => void
 

--- a/src/utils/logging/prepareResponse.ts
+++ b/src/utils/logging/prepareResponse.ts
@@ -5,7 +5,7 @@ import { parseBody } from '../request/parseBody'
 /**
  * Formats a mocked response for introspection in browser's console.
  */
-export function prepareResponse(res: ResponseWithSerializedHeaders) {
+export function prepareResponse(res: ResponseWithSerializedHeaders<any>) {
   const responseHeaders = listToHeaders(res.headers)
 
   return {


### PR DESCRIPTION
## Changes

- Extends the `rest` request handler to accept `RequestBodyType` and `ResponseBodyType` generics.
- Extends request handler, response composition, and context utilities to inherit the given `ResponseBodyType` to provide proper type checking during response composition.

## Usage

```ts
import { rest } from 'msw'

interface LoginRequestBodyType {
  username: string
}

interface LoginResponseBodyType {
  accessToken: string
}

rest.post<LoginRequestBodyType, LoginResponseBodyType>('/login', (req, res, ctx) => {
  const { username } = req.body // "username" is type of "string"
  // req.body.foo // ERROR, "foo" doesn't exist on LoginRequestBodyType

  return res(ctx.json({ accessToken: 'abc-123' })) // OK
  // return res(ctx.json({ foo: 'bar' })) // ERROR, unknown property "foo"
  // return res(ctx.text('foo')) // ERROR, text not assignable to LoginResponseBodyType
})
```

## GitHub

- Fixes #345

## Roadmap

- [x] ~~`rest.get` should not have the `RequestBodyType`, only the response body type.~~
- [x] Use `unknown` instead of `any`