### PR TITLE
getUrlByMask: Returns URL-like path string as-is

### DIFF
--- a/src/utils/url/getUrlByMask.test.ts
+++ b/src/utils/url/getUrlByMask.test.ts
@@ -22,6 +22,14 @@ test('creates a URL instance given a path with parameters', () => {
   expect(url.toString()).toBe('http://localhost/user/:userId')
 })
 
+test('returns a URL-like path string as-is', () => {
+  const url = getUrlByMask('http://*.mswjs.io/:resourceName')
+  expect(typeof url).toBe('string')
+  expect(url).toBe('http://*.mswjs.io/:resourceName')
+})
+
 test('returns a path string as-is', () => {
-  expect(getUrlByMask('*')).toBe('*')
+  const url = getUrlByMask('*')
+  expect(typeof url).toBe('string')
+  expect(url).toBe('*')
 })

--- a/src/utils/url/getUrlByMask.ts
+++ b/src/utils/url/getUrlByMask.ts
@@ -5,7 +5,12 @@ import { getAbsoluteUrl } from './getAbsoluteUrl'
  * Converts a given request handler mask into a URL, if given a valid URL string.
  */
 export function getUrlByMask(mask: Mask): URL | Mask {
-  if (mask instanceof RegExp) {
+  /**
+   * If a string mask contains an asterisk (wildcard), return it as-is.
+   * Converting a URL-like path string into an actual URL is misleading.
+   * @see https://github.com/mswjs/msw/issues/357
+   */
+  if (mask instanceof RegExp || mask.includes('*')) {
     return mask
   }
 


### PR DESCRIPTION
## Changes

- In `getUrlByMask` short-circuit when given a path string (i.e. a string with wildcard) being a valid URL. This prevents such string to be converted into a `URL` instance, escaping the wildcard character (`*` -> `%2A`) and resulting into URL mismatch.
- Adds a new unit test for `getUrlByMask` to test URL-like path strings.

## GitHub

- Fixes #357 