### PR TITLE
Windows development environment support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -118,7 +118,7 @@ $ yarn test:integration test/rest-api/basic.mock.ts
 When working on a feature or a bug fix it's useful to interact with your usage example. There's a dedicated command that can run a given usage scenario in a local server for you to work with:
 
 ```bash
-$ yarn test:focused test/rest-api/basic.mock.ts
+$ yarn test:focused test/rest-api/basic.mocks.ts
 ```
 
 > Navigate to the URL in the terminal to preview and interact with the usage scenario.

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "scripts": {
     "start": "cross-env NODE_ENV=development rollup -c rollup.config.ts -w",
     "clean": "rimraf lib node/**/*.js",
-    "lint": "eslint '{cli,config,src,test}/**/*.ts'",
+    "lint": "eslint \"{cli,config,src,test}/**/*.ts\"",
     "build": "yarn clean && cross-env NODE_ENV=production rollup -c rollup.config.ts",
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "cross-env BABEL_ENV=test jest --runInBand",
-    "test:integration": "node --max_old_space_size=8000 node_modules/.bin/jest --config=test/jest.config.js --runInBand",
+    "test:integration": "node --max_old_space_size=8000 node_modules/jest/bin/jest.js --config=test/jest.config.js --runInBand",
     "test:smoke": "config/scripts/smoke.sh",
     "test:focused": "node_modules/.bin/ts-node --project=test/tsconfig.json test/focusedTest.ts",
     "prepublishOnly": "yarn lint && yarn test:unit && yarn build && yarn test:integration"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit": "cross-env BABEL_ENV=test jest --runInBand",
     "test:integration": "node --max_old_space_size=8000 node_modules/jest/bin/jest.js --config=test/jest.config.js --runInBand",
     "test:smoke": "config/scripts/smoke.sh",
-    "test:focused": "node_modules/.bin/ts-node --project=test/tsconfig.json test/focusedTest.ts",
+    "test:focused": "node node_modules/ts-node/dist/bin.js --project=test/tsconfig.json test/focusedTest.ts",
     "prepublishOnly": "yarn lint && yarn test:unit && yarn build && yarn test:integration"
   },
   "husky": {

--- a/test/msw-api/cli/init.test.ts
+++ b/test/msw-api/cli/init.test.ts
@@ -27,7 +27,7 @@ describe('init', () => {
 
       // Run the CLI command
       exec(
-        'cli/index.js init ./tmp/cli/init/public',
+        'node cli/index.js init ./tmp/cli/init/public',
         {
           cwd: PROJECT_ROOT,
         },
@@ -61,7 +61,7 @@ describe('init', () => {
 
     beforeAll((done) => {
       exec(
-        'cli/index.js init ./tmp/cli/init/missing-public',
+        'node cli/index.js init ./tmp/cli/init/missing-public',
         {
           cwd: PROJECT_ROOT,
         },


### PR DESCRIPTION
- Addresses #363

- Update failing `test/msw-api/cli/init.test.ts` test on windows
- Update package config for cross env compatibility
   - Windows can't use the bin files, so instead, we use the js file it would resolve