### PR TITLE
Set body to null for GET & HEAD requests

### DIFF
--- a/src/context/fetch.test.ts
+++ b/src/context/fetch.test.ts
@@ -1,6 +1,4 @@
-import { augmentRequestInit, createFetchRequestParameters } from './fetch'
-import { MockedRequest } from '../utils/handlers/requestHandler'
-import { Headers } from 'headers-utils/lib'
+import { augmentRequestInit } from './fetch'
 
 describe('augmentRequestInit', () => {
   describe('given provided custom headers', () => {
@@ -70,60 +68,6 @@ describe('augmentRequestInit', () => {
       it('should preserve custom headers', () => {
         expect(headers.get('authorization')).toEqual('token')
       })
-    })
-  })
-})
-
-describe('createFetchRequestParameters', () => {
-  let mockedRequest: MockedRequest
-
-  beforeAll(() => {
-    mockedRequest = {
-      url: new URL('http://www.mswjs.io'),
-      method: 'GET',
-      headers: new Headers(),
-      cookies: {},
-      mode: 'same-origin',
-      keepalive: true,
-      cache: 'default',
-      destination: '',
-      integrity: '',
-      credentials: 'same-origin',
-      redirect: 'follow',
-      referrer: '',
-      referrerPolicy: 'origin',
-      body: {},
-      bodyUsed: true,
-      params: {},
-    }
-  })
-
-  describe('given a GET request', () => {
-    it('should set the body to null', () => {
-      const result = createFetchRequestParameters(mockedRequest)
-      expect(result.body).toEqual(null)
-    })
-  })
-
-  describe('given a HEAD request', () => {
-    it('should set the body to null', () => {
-      mockedRequest.method = 'HEAD'
-
-      const result = createFetchRequestParameters(mockedRequest)
-      expect(result.body).toEqual(null)
-    })
-  })
-
-  describe('given a POST request', () => {
-    it('should keep the body', () => {
-      const body = {
-        foo: 'bar',
-      }
-      mockedRequest.method = 'POST'
-      mockedRequest.body = body
-
-      const result = createFetchRequestParameters(mockedRequest)
-      expect(result.body).toEqual(JSON.stringify(body))
     })
   })
 })

--- a/src/context/fetch.test.ts
+++ b/src/context/fetch.test.ts
@@ -1,4 +1,6 @@
-import { augmentRequestInit } from './fetch'
+import { augmentRequestInit, createFetchRequestParameters } from './fetch'
+import { MockedRequest } from '../utils/handlers/requestHandler'
+import { Headers } from 'headers-utils/lib'
 
 describe('augmentRequestInit', () => {
   describe('given provided custom headers', () => {
@@ -68,6 +70,60 @@ describe('augmentRequestInit', () => {
       it('should preserve custom headers', () => {
         expect(headers.get('authorization')).toEqual('token')
       })
+    })
+  })
+})
+
+describe('createFetchRequestParameters', () => {
+  let mockedRequest: MockedRequest
+
+  beforeAll(() => {
+    mockedRequest = {
+      url: new URL('http://www.mswjs.io'),
+      method: 'GET',
+      headers: new Headers(),
+      cookies: {},
+      mode: 'same-origin',
+      keepalive: true,
+      cache: 'default',
+      destination: '',
+      integrity: '',
+      credentials: 'same-origin',
+      redirect: 'follow',
+      referrer: '',
+      referrerPolicy: 'origin',
+      body: {},
+      bodyUsed: true,
+      params: {},
+    }
+  })
+
+  describe('given a GET request', () => {
+    it('should set the body to null', () => {
+      const result = createFetchRequestParameters(mockedRequest)
+      expect(result.body).toEqual(null)
+    })
+  })
+
+  describe('given a HEAD request', () => {
+    it('should set the body to null', () => {
+      mockedRequest.method = 'HEAD'
+
+      const result = createFetchRequestParameters(mockedRequest)
+      expect(result.body).toEqual(null)
+    })
+  })
+
+  describe('given a POST request', () => {
+    it('should keep the body', () => {
+      const body = {
+        foo: 'bar',
+      }
+      mockedRequest.method = 'POST'
+      mockedRequest.body = body
+
+      const result = createFetchRequestParameters(mockedRequest)
+      expect(result.body).toEqual(JSON.stringify(body))
     })
   })
 })

--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -26,7 +26,7 @@ export const augmentRequestInit = (requestInit: RequestInit): RequestInit => {
   }
 }
 
-export const createFetchRequestParameters = (input: MockedRequest) => {
+const createFetchRequestParameters = (input: MockedRequest) => {
   const { body } = input
   const requestParameters: RequestInit = {
     ...input,

--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -27,16 +27,18 @@ export const augmentRequestInit = (requestInit: RequestInit): RequestInit => {
 }
 
 const createFetchRequestParameters = (input: MockedRequest) => {
-  const { body } = input
+  const { body, method } = input
   const requestParameters: RequestInit = {
     ...input,
-    body: null,
+    body: undefined,
   }
 
-  if (input.method !== 'GET' && input.method !== 'HEAD') {
-    requestParameters.body =
-      typeof body === 'object' ? JSON.stringify(body) : body
+  if (['GET', 'HEAD'].includes(method)) {
+    return requestParameters
   }
+
+  requestParameters.body =
+    typeof body === 'object' ? JSON.stringify(body) : body
 
   return requestParameters
 }
@@ -59,7 +61,7 @@ export const fetch = <ResponseType = any>(
 
   const requestParameters: RequestInit = createFetchRequestParameters(input)
 
-  const compliantReq: RequestInit = augmentRequestInit(requestParameters)
+  const compliantRequest: RequestInit = augmentRequestInit(requestParameters)
 
-  return gracefully<ResponseType>(useFetch(input.url.href, compliantReq))
+  return gracefully<ResponseType>(useFetch(input.url.href, compliantRequest))
 }

--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -26,6 +26,21 @@ export const augmentRequestInit = (requestInit: RequestInit): RequestInit => {
   }
 }
 
+export const createFetchRequestParameters = (input: MockedRequest) => {
+  const { body } = input
+  const requestParameters: RequestInit = {
+    ...input,
+    body: null,
+  }
+
+  if (input.method !== 'GET' && input.method !== 'HEAD') {
+    requestParameters.body =
+      typeof body === 'object' ? JSON.stringify(body) : body
+  }
+
+  return requestParameters
+}
+
 /**
  * Wrapper around the native `window.fetch()` function that performs
  * a request bypassing MSW. Requests performed using
@@ -42,11 +57,9 @@ export const fetch = <ResponseType = any>(
     )
   }
 
-  const { body } = input
-  const compliantReq: RequestInit = augmentRequestInit({
-    ...input,
-    body: typeof body === 'object' ? JSON.stringify(body) : body,
-  })
+  const requestParameters: RequestInit = createFetchRequestParameters(input)
+
+  const compliantReq: RequestInit = augmentRequestInit(requestParameters)
 
   return gracefully<ResponseType>(useFetch(input.url.href, compliantReq))
 }

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -59,6 +59,10 @@ const worker = setupWorker(
       }),
     )
   }),
+
+  rest.head('/headtest', async (req, res, ctx) => {
+    return res(ctx.json(null))
+  }),
 )
 
 worker.start()

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -61,7 +61,11 @@ const worker = setupWorker(
   }),
 
   rest.head('/posts', async (req, res, ctx) => {
-    return res(ctx.json(null))
+    return res(
+      ctx.json({
+        mocked: true,
+      }),
+    )
   }),
 )
 

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -48,6 +48,28 @@ const worker = setupWorker(
       }),
     )
   }),
+
+  rest.get('/posts', async (req, res, ctx) => {
+    const originalResponse = await ctx.fetch(req)
+
+    return res(
+      ctx.json({
+        ...originalResponse,
+        mocked: true,
+      }),
+    )
+  }),
+
+  rest.head('/posts', async (req, res, ctx) => {
+    const originalResponse = await ctx.fetch(req)
+
+    return res(
+      ctx.json({
+        ...originalResponse,
+        mocked: true,
+      }),
+    )
+  }),
 )
 
 worker.start()

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -59,17 +59,6 @@ const worker = setupWorker(
       }),
     )
   }),
-
-  rest.head('/posts', async (req, res, ctx) => {
-    const originalResponse = await ctx.fetch(req)
-
-    return res(
-      ctx.json({
-        ...originalResponse,
-        mocked: true,
-      }),
-    )
-  }),
 )
 
 worker.start()

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -60,7 +60,7 @@ const worker = setupWorker(
     )
   }),
 
-  rest.head('/headtest', async (req, res, ctx) => {
+  rest.head('/posts', async (req, res, ctx) => {
     return res(ctx.json(null))
   }),
 )

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -27,10 +27,6 @@ describe('REST: Response patching', () => {
           app.get('/posts', (req, res) => {
             res.status(200).json({ id: 101 }).end()
           })
-
-          app.head('/posts', (req, res) => {
-            res.status(200).json({ id: 101 }).end()
-          })
         },
       },
     )
@@ -161,34 +157,7 @@ describe('REST: Response patching', () => {
 
       expect(status).toBe(200)
       expect(headers).toHaveProperty('x-powered-by', 'msw')
-      expect(body).toEqual(null)
-    })
-  })
-
-  describe('given a HEAD request to be patched', () => {
-    it('should be able to properly request and patch the response', async () => {
-      const res = await test.request({
-        url: '/posts',
-        fetchOptions: {
-          method: 'HEAD',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        },
-        responsePredicate(res, url) {
-          return (
-            match(test.origin + url, res.url()).matches &&
-            res.headers()['x-powered-by'] === 'msw'
-          )
-        },
-      })
-      const status = res.status()
-      const headers = res.headers()
-      const body = await res.json()
-
-      expect(status).toBe(200)
-      expect(headers).toHaveProperty('x-powered-by', 'msw')
-      expect(body).toEqual(null)
+      expect(body).toEqual({ id: 101, mocked: true })
     })
   })
 })

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -186,7 +186,7 @@ describe('REST: Response patching', () => {
 
       expect(status).toBe(200)
       expect(headers).toHaveProperty('x-powered-by', 'msw')
-      expect(body).toEqual(null)
+      expect(body).toEqual({ mocked: true })
     })
   })
 })

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -23,6 +23,14 @@ describe('REST: Response patching', () => {
           app.post('/posts', (req, res) => {
             res.status(200).json({ id: 101 }).end()
           })
+
+          app.get('/posts', (req, res) => {
+            res.status(200).json({ id: 101 }).end()
+          })
+
+          app.head('/posts', (req, res) => {
+            res.status(200).json({ id: 101 }).end()
+          })
         },
       },
     )
@@ -127,6 +135,60 @@ describe('REST: Response patching', () => {
         id: 101,
         mocked: true,
       })
+    })
+  })
+
+  describe('given a GET request to be patched', () => {
+    it('should be able to properly request and patch the response', async () => {
+      const res = await test.request({
+        url: '/posts',
+        fetchOptions: {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+        responsePredicate(res, url) {
+          return (
+            match(test.origin + url, res.url()).matches &&
+            res.headers()['x-powered-by'] === 'msw'
+          )
+        },
+      })
+      const status = res.status()
+      const headers = res.headers()
+      const body = await res.json()
+
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(body).toEqual(null)
+    })
+  })
+
+  describe('given a HEAD request to be patched', () => {
+    it('should be able to properly request and patch the response', async () => {
+      const res = await test.request({
+        url: '/posts',
+        fetchOptions: {
+          method: 'HEAD',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+        responsePredicate(res, url) {
+          return (
+            match(test.origin + url, res.url()).matches &&
+            res.headers()['x-powered-by'] === 'msw'
+          )
+        },
+      })
+      const status = res.status()
+      const headers = res.headers()
+      const body = await res.json()
+
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(body).toEqual(null)
     })
   })
 })

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -28,7 +28,7 @@ describe('REST: Response patching', () => {
             res.status(200).json({ id: 101 }).end()
           })
 
-          app.head('/headtest', (req, res) => {
+          app.head('/posts', (req, res) => {
             res.status(200).end()
           })
         },
@@ -168,7 +168,7 @@ describe('REST: Response patching', () => {
   describe('given a HEAD request to be patched', () => {
     it('should be able to properly request and patch the response', async () => {
       const res = await test.request({
-        url: '/headtest',
+        url: '/posts',
         fetchOptions: {
           method: 'HEAD',
         },

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -27,6 +27,10 @@ describe('REST: Response patching', () => {
           app.get('/posts', (req, res) => {
             res.status(200).json({ id: 101 }).end()
           })
+
+          app.head('/headtest', (req, res) => {
+            res.status(200).end()
+          })
         },
       },
     )
@@ -158,6 +162,31 @@ describe('REST: Response patching', () => {
       expect(status).toBe(200)
       expect(headers).toHaveProperty('x-powered-by', 'msw')
       expect(body).toEqual({ id: 101, mocked: true })
+    })
+  })
+
+  describe('given a HEAD request to be patched', () => {
+    it('should be able to properly request and patch the response', async () => {
+      const res = await test.request({
+        url: '/headtest',
+        fetchOptions: {
+          method: 'HEAD',
+        },
+        responsePredicate(res, url) {
+          return (
+            match(test.origin + url, res.url()).matches &&
+            res.headers()['x-powered-by'] === 'msw'
+          )
+        },
+      })
+
+      const status = res.status()
+      const headers = res.headers()
+      const body = await res.json()
+
+      expect(status).toBe(200)
+      expect(headers).toHaveProperty('x-powered-by', 'msw')
+      expect(body).toEqual(null)
     })
   })
 })


### PR DESCRIPTION
Hey,

this should fix the bug #361.

I added a check for `GET` & `HEAD` requests and set the body to`null` in this case.