### PR TITLE
Start option to share a client across all other client requests

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -37,7 +37,7 @@ self.addEventListener('message', async function (event) {
   const allClients = await self.clients.matchAll()
   const allClientIds = allClients.map((client) => client.id)
 
-  switch (event.data) {
+  switch (event.data.type) {
     case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
         type: 'KEEPALIVE_RESPONSE',
@@ -57,20 +57,12 @@ self.addEventListener('message', async function (event) {
       clients = ensureKeys(allClientIds, clients)
       clients[clientId] = true
 
+      if (event.data.shared) {
+        sharedClientId = clientId
+      }
+
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
-        payload: true,
-      })
-      break
-    }
-
-    case 'SHARED_MOCK_ACTIVATE': {
-      clients = ensureKeys(allClientIds, clients)
-      clients[clientId] = true
-      sharedClientId = clientId
-
-      sendToClient(client, {
-        type: 'SHARED_MOCKING_ENABLED',
         payload: true,
       })
       break
@@ -101,7 +93,7 @@ self.addEventListener('message', async function (event) {
   }
 })
 
-self.addEventListener('fetch', async function (event) {
+self.addEventListener('fetch', function (event) {
   const { request } = event
   const requestId = uuidv4()
   const requestClone = request.clone()

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -87,6 +87,10 @@ self.addEventListener('message', async function (event) {
         return client.id !== clientId
       })
 
+      if (sharedClientId === clientId) {
+        sharedClientId = null
+      }
+
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
         self.registration.unregister()

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -154,6 +154,7 @@ export type StartOptions = SharedOptions & {
    */
   serviceWorker?: {
     url?: string
+    shared?: boolean
     options?: RegistrationOptions
   }
 

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -52,7 +52,6 @@ export type ServiceWorkerIncomingResponse = Pick<
  */
 export interface ServiceWorkerIncomingEventsMap {
   MOCKING_ENABLED: boolean
-  SHARED_MOCKING_ENABLED: boolean
   INTEGRITY_CHECK_RESPONSE: string
   KEEPALIVE_RESPONSE: never
   REQUEST: ServiceWorkerIncomingRequest
@@ -65,7 +64,6 @@ export interface ServiceWorkerIncomingEventsMap {
  */
 export type ServiceWorkerOutgoingEventTypes =
   | 'MOCK_ACTIVATE'
-  | 'SHARED_MOCK_ACTIVATE'
   | 'MOCK_DEACTIVATE'
   | 'INTEGRITY_CHECK_REQUEST'
   | 'KEEPALIVE_REQUEST'
@@ -113,6 +111,7 @@ export interface SetupWorkerInternalContext {
     ): void
     send<EventType extends ServiceWorkerOutgoingEventTypes>(
       eventType: EventType,
+      data?: Record<string, any>,
     ): void
   }
   events: {
@@ -156,9 +155,13 @@ export type StartOptions = SharedOptions & {
    */
   serviceWorker?: {
     url?: string
-    shared?: boolean
     options?: RegistrationOptions
   }
+
+  /**
+   * Shares the mocks with all clients connected
+   */
+  shared?: boolean
 
   /**
    * Disables the logging of captured requests

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -52,6 +52,7 @@ export type ServiceWorkerIncomingResponse = Pick<
  */
 export interface ServiceWorkerIncomingEventsMap {
   MOCKING_ENABLED: boolean
+  SHARED_MOCKING_ENABLED: boolean
   INTEGRITY_CHECK_RESPONSE: string
   KEEPALIVE_RESPONSE: never
   REQUEST: ServiceWorkerIncomingRequest
@@ -64,6 +65,7 @@ export interface ServiceWorkerIncomingEventsMap {
  */
 export type ServiceWorkerOutgoingEventTypes =
   | 'MOCK_ACTIVATE'
+  | 'SHARED_MOCK_ACTIVATE'
   | 'MOCK_DEACTIVATE'
   | 'INTEGRITY_CHECK_REQUEST'
   | 'KEEPALIVE_REQUEST'

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -68,8 +68,8 @@ export function setupWorker(
           },
         )
       },
-      send(type) {
-        context.worker?.postMessage(type)
+      send(type, payload = {}) {
+        context.worker?.postMessage({ type, ...payload })
       },
     },
     events: {

--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -15,9 +15,9 @@ import { createResponseListener } from '../../utils/worker/createResponseListene
 const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
   serviceWorker: {
     url: '/mockServiceWorker.js',
-    shared: false,
     options: null as any,
   },
+  shared: false,
   quiet: false,
   waitUntilReady: true,
   onUnhandledRequest: 'bypass',
@@ -127,7 +127,7 @@ If this message still persists after updating, please report an issue: https://g
 
       // Signal the Service Worker to enable requests interception
       const [activationError] = await until(() =>
-        activateMocking(context, options, resolvedOptions.serviceWorker.shared),
+        activateMocking(context, options),
       )
 
       if (activationError) {

--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -15,6 +15,7 @@ import { createResponseListener } from '../../utils/worker/createResponseListene
 const DEFAULT_START_OPTIONS: DeepRequired<StartOptions> = {
   serviceWorker: {
     url: '/mockServiceWorker.js',
+    shared: false,
     options: null as any,
   },
   quiet: false,
@@ -126,7 +127,7 @@ If this message still persists after updating, please report an issue: https://g
 
       // Signal the Service Worker to enable requests interception
       const [activationError] = await until(() =>
-        activateMocking(context, options),
+        activateMocking(context, options, resolvedOptions.serviceWorker.shared),
       )
 
       if (activationError) {

--- a/src/setupWorker/start/utils/activateMocking.ts
+++ b/src/setupWorker/start/utils/activateMocking.ts
@@ -3,19 +3,16 @@ import { StartOptions, SetupWorkerInternalContext } from '../../glossary'
 export const activateMocking = async (
   context: SetupWorkerInternalContext,
   options?: StartOptions,
-  shared = false,
 ) => {
-  const message = shared ? 'SHARED_MOCK_ACTIVATE' : 'MOCK_ACTIVATE'
-  const event = shared ? 'SHARED_MOCKING_ENABLED' : 'MOCKING_ENABLED'
-  context.worker?.postMessage(message)
+  context.workerChannel.send('MOCK_ACTIVATE', { shared: options?.shared })
 
-  return context.events.once(event).then(() => {
+  return context.events.once('MOCKING_ENABLED').then(() => {
     if (!options?.quiet) {
       console.groupCollapsed(
-        `%c[MSW] ${shared ? 'Shared ' : ''}Mocking enabled.`,
+        `%c[MSW] ${options?.shared ? 'Shared ' : ''}Mocking enabled.`,
         'color:orangered;font-weight:bold;',
       )
-      if (shared) {
+      if (options?.shared) {
         console.log('All connected clients will be served these mocks')
       }
       console.log(

--- a/src/setupWorker/start/utils/activateMocking.ts
+++ b/src/setupWorker/start/utils/activateMocking.ts
@@ -3,15 +3,21 @@ import { StartOptions, SetupWorkerInternalContext } from '../../glossary'
 export const activateMocking = async (
   context: SetupWorkerInternalContext,
   options?: StartOptions,
+  shared = false,
 ) => {
-  context.workerChannel.send('MOCK_ACTIVATE')
+  const message = shared ? 'SHARED_MOCK_ACTIVATE' : 'MOCK_ACTIVATE'
+  const event = shared ? 'SHARED_MOCKING_ENABLED' : 'MOCKING_ENABLED'
+  context.worker?.postMessage(message)
 
-  return context.events.once('MOCKING_ENABLED').then(() => {
+  return context.events.once(event).then(() => {
     if (!options?.quiet) {
       console.groupCollapsed(
-        '%c[MSW] Mocking enabled.',
+        `%c[MSW] ${shared ? 'Shared ' : ''}Mocking enabled.`,
         'color:orangered;font-weight:bold;',
       )
+      if (shared) {
+        console.log('All connected clients will be served these mocks')
+      }
       console.log(
         '%cDocumentation: %chttps://mswjs.io/docs',
         'font-weight:bold',

--- a/test/msw-api/setup-worker/start/shared.mocks.ts
+++ b/test/msw-api/setup-worker/start/shared.mocks.ts
@@ -12,7 +12,5 @@ const worker = setupWorker(
 )
 
 worker.start({
-  serviceWorker: {
-    shared: true,
-  },
+  shared: true,
 })

--- a/test/msw-api/setup-worker/start/shared.mocks.ts
+++ b/test/msw-api/setup-worker/start/shared.mocks.ts
@@ -11,8 +11,7 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.__MSW_REGISTRATION__ = worker.start({
+worker.start({
   serviceWorker: {
     shared: true,
   },

--- a/test/msw-api/setup-worker/start/shared.mocks.ts
+++ b/test/msw-api/setup-worker/start/shared.mocks.ts
@@ -1,0 +1,19 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        firstName: 'John',
+        age: 32,
+      }),
+    )
+  }),
+)
+
+// @ts-ignore
+window.__MSW_REGISTRATION__ = worker.start({
+  serviceWorker: {
+    shared: true,
+  },
+})

--- a/test/msw-api/setup-worker/start/shared.test.ts
+++ b/test/msw-api/setup-worker/start/shared.test.ts
@@ -14,35 +14,41 @@ afterAll(() => {
 
 test('shares the client registration for all other clients when "shared" option is set to "true"', async () => {
   const { messages } = captureConsole(runtime.page)
-
-  await runtime.page.evaluate(() => {
-    // @ts-ignore
-    return window.__MSW_REGISTRATION__
-  })
+  const iframeUrl = `${runtime.origin}/test/support/template/iframe.html`
 
   await runtime.reload()
+
+  await runtime.page.evaluate((url) => {
+    const iframe = document.createElement('iframe')
+    iframe.src = url
+    document.body.appendChild(iframe)
+
+    return iframe
+  }, iframeUrl)
+
+  await runtime.page.waitForSelector('iframe')
+  const element = await runtime.page.$(`iframe[src="${iframeUrl}"]`)
+  const frame = await element.contentFrame()
+
+  const response = await frame.evaluate(() => {
+    return fetch(`${window.location.origin}/user`).then((response) =>
+      response.json(),
+    )
+  })
+
+  expect(response).toEqual({
+    firstName: 'John',
+    age: 32,
+  })
 
   const activationMessage = messages.startGroupCollapsed.find((text) => {
     return text.includes('[MSW] Shared Mocking enabled.')
   })
   expect(activationMessage).toBeTruthy()
 
-  const res = await runtime.request({
-    url: `${runtime.origin}/user`,
-  })
-
-  const headers = res.headers()
-  const body = await res.json()
-
-  expect(headers).toHaveProperty('x-powered-by', 'msw')
-  expect(body).toEqual({
-    firstName: 'John',
-    age: 32,
-  })
-
-  const requetsLog = messages.startGroupCollapsed.find((text) => {
+  const requestsLog = messages.startGroupCollapsed.find((text) => {
     return text.includes('[MSW]') && text.includes('GET /user')
   })
 
-  expect(requetsLog).toMatch(/\[MSW\] \d{2}:\d{2}:\d{2} GET \/user 200/)
+  expect(requestsLog).toMatch(/\[MSW\] \d{2}:\d{2}:\d{2} GET \/user 200/)
 })

--- a/test/msw-api/setup-worker/start/shared.test.ts
+++ b/test/msw-api/setup-worker/start/shared.test.ts
@@ -1,0 +1,48 @@
+import * as path from 'path'
+import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
+import { captureConsole } from '../../../support/captureConsole'
+
+let runtime: TestAPI
+
+beforeAll(async () => {
+  runtime = await runBrowserWith(path.resolve(__dirname, 'shared.mocks.ts'))
+})
+
+afterAll(() => {
+  return runtime.cleanup()
+})
+
+test('shares the client registration for all other clients when "shared" option is set to "true"', async () => {
+  const { messages } = captureConsole(runtime.page)
+
+  await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW_REGISTRATION__
+  })
+
+  await runtime.reload()
+
+  const activationMessage = messages.startGroupCollapsed.find((text) => {
+    return text.includes('[MSW] Shared Mocking enabled.')
+  })
+  expect(activationMessage).toBeTruthy()
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/user`,
+  })
+
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(body).toEqual({
+    firstName: 'John',
+    age: 32,
+  })
+
+  const requetsLog = messages.startGroupCollapsed.find((text) => {
+    return text.includes('[MSW]') && text.includes('GET /user')
+  })
+
+  expect(requetsLog).toMatch(/\[MSW\] \d{2}:\d{2}:\d{2} GET \/user 200/)
+})

--- a/test/msw-api/setup-worker/start/shared.test.ts
+++ b/test/msw-api/setup-worker/start/shared.test.ts
@@ -2,17 +2,11 @@ import * as path from 'path'
 import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
 
-let runtime: TestAPI
 
-beforeAll(async () => {
-  runtime = await runBrowserWith(path.resolve(__dirname, 'shared.mocks.ts'))
-})
 
-afterAll(() => {
-  return runtime.cleanup()
-})
 
 test('shares the client registration for all other clients when "shared" option is set to "true"', async () => {
+  const runtime = await runBrowserWith(path.resolve(__dirname, 'shared.mocks.ts'))
   const { messages } = captureConsole(runtime.page)
   const iframeUrl = `${runtime.origin}/test/support/template/iframe.html`
 
@@ -51,4 +45,6 @@ test('shares the client registration for all other clients when "shared" option 
   })
 
   expect(requestsLog).toMatch(/\[MSW\] \d{2}:\d{2}:\d{2} GET \/user 200/)
+  
+  return runtime.cleanup()
 })

--- a/test/msw-api/setup-worker/start/shared.test.ts
+++ b/test/msw-api/setup-worker/start/shared.test.ts
@@ -1,12 +1,11 @@
 import * as path from 'path'
-import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
+import { runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
 
-
-
-
 test('shares the client registration for all other clients when "shared" option is set to "true"', async () => {
-  const runtime = await runBrowserWith(path.resolve(__dirname, 'shared.mocks.ts'))
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'shared.mocks.ts'),
+  )
   const { messages } = captureConsole(runtime.page)
   const iframeUrl = `${runtime.origin}/test/support/template/iframe.html`
 
@@ -45,6 +44,6 @@ test('shares the client registration for all other clients when "shared" option 
   })
 
   expect(requestsLog).toMatch(/\[MSW\] \d{2}:\d{2}:\d{2} GET \/user 200/)
-  
+
   return runtime.cleanup()
 })

--- a/test/msw-api/setup-worker/stop/removes-shared.mocks.ts
+++ b/test/msw-api/setup-worker/stop/removes-shared.mocks.ts
@@ -7,9 +7,7 @@ const worker = setupWorker(
 )
 
 worker.start({
-  serviceWorker: {
-    shared: true,
-  },
+  shared: true,
 })
 
 // @ts-ignore

--- a/test/msw-api/setup-worker/stop/removes-shared.mocks.ts
+++ b/test/msw-api/setup-worker/stop/removes-shared.mocks.ts
@@ -1,0 +1,16 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('https://api.github.com', (req, res, ctx) => {
+    return res(ctx.json({ mocked: true }))
+  }),
+)
+
+worker.start({
+  serviceWorker: {
+    shared: true,
+  },
+})
+
+// @ts-ignore
+window.__mswStop = worker.stop

--- a/test/msw-api/setup-worker/stop/removes-shared.test.ts
+++ b/test/msw-api/setup-worker/stop/removes-shared.test.ts
@@ -2,7 +2,6 @@ import * as path from 'path'
 import { Page } from 'puppeteer'
 import { runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
-import { response } from 'msw/lib/types'
 
 const stopWorkerOn = async (page: Page) => {
   await page.evaluate(() => {

--- a/test/msw-api/setup-worker/stop/removes-shared.test.ts
+++ b/test/msw-api/setup-worker/stop/removes-shared.test.ts
@@ -1,0 +1,63 @@
+import * as path from 'path'
+import { Page } from 'puppeteer'
+import { runBrowserWith } from '../../../support/runBrowserWith'
+import { captureConsole } from '../../../support/captureConsole'
+import { response } from 'msw/lib/types'
+
+const stopWorkerOn = async (page: Page) => {
+  await page.evaluate(() => {
+    // @ts-ignore
+    return window.__mswStop()
+  })
+
+  return new Promise((resolve) => {
+    setTimeout(resolve, 1000)
+  })
+}
+
+test('shares the client registration for all other clients when "shared" option is set to "true"', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'removes-shared.mocks.ts'),
+  )
+  const { messages } = captureConsole(runtime.page)
+  const iframeUrl = `${runtime.origin}/test/support/template/iframe.html`
+
+  await runtime.reload()
+
+  const activationMessage = messages.startGroupCollapsed.find((text) => {
+    return text.includes('[MSW] Shared Mocking enabled.')
+  })
+  expect(activationMessage).toBeTruthy()
+
+  await runtime.page.evaluate((url) => {
+    const iframe = document.createElement('iframe')
+    iframe.src = url
+    document.body.appendChild(iframe)
+
+    return iframe
+  }, iframeUrl)
+
+  await runtime.page.waitForSelector('iframe')
+  const element = await runtime.page.$(`iframe[src="${iframeUrl}"]`)
+  const frame = await element.contentFrame()
+
+  const before = await frame.evaluate(() => {
+    return fetch('https://api.github.com').then((response) => response.json())
+  })
+
+  expect(before).toEqual({
+    mocked: true,
+  })
+
+  await stopWorkerOn(runtime.page)
+
+  const after = await frame.evaluate(() => {
+    return fetch('https://api.github.com').then((response) => response.json())
+  })
+
+  expect(after).not.toEqual({
+    mocked: true,
+  })
+
+  return runtime.cleanup()
+})

--- a/test/support/template/iframe.html
+++ b/test/support/template/iframe.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <style>
+      html {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        padding: 0 5rem;
+      }
+      pre {
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Test Iframe</h2>
+  </body>
+</html>


### PR DESCRIPTION
This is in relation to #374 . The terminology might not be correct, there might be a better way to describe this other than `shared`.

The use case is that some one would be able to load `msw` as part of a Cypress test suite rather than as part of the application itself. This can be done by:

```javascript
// cypress/support/index.js

let worker

before(() => {
  worker = setupWorker()
  cy.wrap(worker.start())
})

Cypress.on('window:before:load', win => {
  if (!worker) return

  worker.resetHandlers()

  win.msw = { worker, rest }
})

Cypress.Commands.add('mock', (method, route, fn) => {
  worker.use(rest[method.toLowerCase()](route, fn))
})
```

Then in a test, the user can:

```javascript
  cy.mock(
      'GET',
      'https://jsonplaceholder.typicode.com/todos/1',
      (req, res, ctx) => {
        return res(
          ctx.json({
            userId: 1,
            id: 1,
            title: 'Lord of the rings',
            completed: false,
          }),
        )
      },
    )
```

This currently doesn't work because the application that Cypress is testing has a different `clientId` than the one that started the worker and so the mocks aren't intercepted.

What I thought could be an option is to set an option of `{ serviceWorker: { shared: true } }` to `worker.start` so that the `mockServiceWorker` can capture that `sharedClientId` and use that when intercepting the requests.

~The other thing I'm not quite sure of is, how I can create a request from another `clientId` in the integration test.~ I have added tests for this.

I'd love to hear your thoughts.

**Note:** Some info on how this will be used: https://github.com/deshiknaves/cypress-msw-interceptor