### PR TITLE
Support process.env.PUBLIC_URL in create-react-app

### DIFF
--- a/src/utils/url/getAbsoluteWorkerUrl.ts
+++ b/src/utils/url/getAbsoluteWorkerUrl.ts
@@ -3,5 +3,9 @@
  * relative URL (known during the registration).
  */
 export function getAbsoluteWorkerUrl(relativeUrl: string): string {
-  return new URL(relativeUrl, location.origin).href
+  let origin = location.origin
+  if (process.env.PUBLIC_URL) {
+    origin = origin + process.env.PUBLIC_URL
+  }
+  return new URL(relativeUrl, origin).href
 }


### PR DESCRIPTION
When CRA is set to render in a subfolder, the worker was not found. This fixes the matter for CRA apps, not sure how other frameworks handle the same use case.