### PR TITLE
feat: add support for composing data and errors in graphql

### DIFF
--- a/src/context/data.test.ts
+++ b/src/context/data.test.ts
@@ -3,19 +3,39 @@ import { errors } from './errors'
 import { response } from '../response'
 
 describe('data', () => {
-  describe('given a JSON data', () => {
-    let result: ReturnType<typeof response>
+  describe('given JSON data', () => {
+    describe('with specifying data once', () => {
+      let result: ReturnType<typeof response>
 
-    beforeAll(() => {
-      result = response(data({ name: 'msw' }))
+      beforeAll(() => {
+        result = response(data({ name: 'msw' }))
+      })
+
+      it('should have "Content-Type" as "application/json"', () => {
+        expect(result.headers.get('content-type')).toEqual('application/json')
+      })
+
+      it('should have body set to the given JSON nested in the "data" property', () => {
+        expect(result).toHaveProperty('body', `{"data":{"name":"msw"}}`)
+      })
     })
+    describe('with specifying data multiple times', () => {
+      let result: ReturnType<typeof response>
 
-    it('should have "Content-Type" as "application/json"', () => {
-      expect(result.headers.get('content-type')).toEqual('application/json')
-    })
+      beforeAll(() => {
+        result = response(data({ name: 'msw' }), data({ is: 'great' }))
+      })
 
-    it('should have body set to the given JSON nested in the "data" property', () => {
-      expect(result).toHaveProperty('body', `{"data":{"name":"msw"}}`)
+      it('should have "Content-Type" as "application/json"', () => {
+        expect(result.headers.get('content-type')).toEqual('application/json')
+      })
+
+      it('should have body set to the given JSON nested in the "data" property merging each "data" call', () => {
+        expect(result).toHaveProperty(
+          'body',
+          `{\"data\":{\"name\":\"msw\",\"is\":\"great\"}}`,
+        )
+      })
     })
   })
   describe('given composed with error', () => {

--- a/src/context/data.test.ts
+++ b/src/context/data.test.ts
@@ -2,57 +2,60 @@ import { data } from './data'
 import { errors } from './errors'
 import { response } from '../response'
 
-describe('data', () => {
-  describe('given JSON data', () => {
-    describe('with specifying data once', () => {
-      let result: ReturnType<typeof response>
+test('sets a single data on the response JSON body', () => {
+  const result = response(data({ name: 'msw' }))
 
-      beforeAll(() => {
-        result = response(data({ name: 'msw' }))
-      })
+  expect(result.headers.get('content-type')).toBe('application/json')
+  expect(result).toHaveProperty(
+    'body',
+    JSON.stringify({
+      data: {
+        name: 'msw',
+      },
+    }),
+  )
+})
 
-      it('should have "Content-Type" as "application/json"', () => {
-        expect(result.headers.get('content-type')).toEqual('application/json')
-      })
+test('sets multiple data on the response JSON body', () => {
+  const result = response(
+    data({ name: 'msw' }),
+    data({ description: 'API mocking library' }),
+  )
 
-      it('should have body set to the given JSON nested in the "data" property', () => {
-        expect(result).toHaveProperty('body', `{"data":{"name":"msw"}}`)
-      })
-    })
-    describe('with specifying data multiple times', () => {
-      let result: ReturnType<typeof response>
+  expect(result.headers.get('content-type')).toBe('application/json')
+  expect(result).toHaveProperty(
+    'body',
+    JSON.stringify({
+      data: {
+        description: 'API mocking library',
+        name: 'msw',
+      },
+    }),
+  )
+})
 
-      beforeAll(() => {
-        result = response(data({ name: 'msw' }), data({ is: 'great' }))
-      })
+test('combines with error in the response JSON body', () => {
+  const result = response(
+    data({ name: 'msw' }),
+    errors([
+      {
+        message: 'exceeds the limit of awesomeness',
+      },
+    ]),
+  )
 
-      it('should have "Content-Type" as "application/json"', () => {
-        expect(result.headers.get('content-type')).toEqual('application/json')
-      })
-
-      it('should have body set to the given JSON nested in the "data" property merging each "data" call', () => {
-        expect(result).toHaveProperty(
-          'body',
-          `{\"data\":{\"name\":\"msw\",\"is\":\"great\"}}`,
-        )
-      })
-    })
-  })
-  describe('given composed with error', () => {
-    let result: ReturnType<typeof response>
-
-    beforeAll(() => {
-      result = response(
-        data({ name: 'msw' }),
-        errors([{ message: 'is great' }]),
-      )
-    })
-
-    it('should have body set to the given JSON nested in the "data" property', () => {
-      expect(result).toHaveProperty(
-        'body',
-        `{\"data\":{\"name\":\"msw\"},\"errors\":[{\"message\":\"is great\"}]}`,
-      )
-    })
-  })
+  expect(result.headers.get('content-type')).toBe('application/json')
+  expect(result).toHaveProperty(
+    'body',
+    JSON.stringify({
+      errors: [
+        {
+          message: 'exceeds the limit of awesomeness',
+        },
+      ],
+      data: {
+        name: 'msw',
+      },
+    }),
+  )
 })

--- a/src/context/data.test.ts
+++ b/src/context/data.test.ts
@@ -1,4 +1,5 @@
 import { data } from './data'
+import { errors } from './errors'
 import { response } from '../response'
 
 describe('data', () => {
@@ -15,6 +16,23 @@ describe('data', () => {
 
     it('should have body set to the given JSON nested in the "data" property', () => {
       expect(result).toHaveProperty('body', `{"data":{"name":"msw"}}`)
+    })
+  })
+  describe('given composed with error', () => {
+    let result: ReturnType<typeof response>
+
+    beforeAll(() => {
+      result = response(
+        data({ name: 'msw' }),
+        errors([{ message: 'is great' }]),
+      )
+    })
+
+    it('should have body set to the given JSON nested in the "data" property', () => {
+      expect(result).toHaveProperty(
+        'body',
+        `{\"errors\":[{\"message\":\"is great\"}],\"data\":{\"name\":\"msw\"}}`,
+      )
     })
   })
 })

--- a/src/context/data.test.ts
+++ b/src/context/data.test.ts
@@ -31,7 +31,7 @@ describe('data', () => {
     it('should have body set to the given JSON nested in the "data" property', () => {
       expect(result).toHaveProperty(
         'body',
-        `{\"errors\":[{\"message\":\"is great\"}],\"data\":{\"name\":\"msw\"}}`,
+        `{\"data\":{\"name\":\"msw\"},\"errors\":[{\"message\":\"is great\"}]}`,
       )
     })
   })

--- a/src/context/data.ts
+++ b/src/context/data.ts
@@ -1,4 +1,5 @@
 import { ResponseTransformer } from '../response'
+import { json } from './json'
 
 export type DataContext<T> = (payload: T) => ResponseTransformer
 
@@ -6,9 +7,5 @@ export type DataContext<T> = (payload: T) => ResponseTransformer
  * Returns a GraphQL body payload.
  */
 export const data: DataContext<Record<string, any>> = (payload) => {
-  return (res) => {
-    res.headers.set('Content-Type', 'application/json')
-    res.body = JSON.stringify({ data: payload })
-    return res
-  }
+  return json({ data: payload }, { merge: true })
 }

--- a/src/context/errors.test.ts
+++ b/src/context/errors.test.ts
@@ -2,76 +2,61 @@ import { errors } from './errors'
 import { data } from './data'
 import { response } from '../response'
 
-describe('errors', () => {
-  describe('given at list of errors', () => {
-    let result: ReturnType<typeof response>
+test('sets a given error on the response JSON body', () => {
+  const result = response(errors([{ message: 'Error message' }]))
 
-    beforeAll(() => {
-      result = response(errors([{ message: 'Error message' }]))
-    })
+  expect(result.headers.get('content-type')).toEqual('application/json')
+  expect(result).toHaveProperty(
+    'body',
+    JSON.stringify({
+      errors: [
+        {
+          message: 'Error message',
+        },
+      ],
+    }),
+  )
+})
 
-    it('should have "Content-Type" as "application/json"', () => {
-      expect(result.headers.get('content-type')).toEqual('application/json')
-    })
+test('sets given errors on the response JSON body', () => {
+  const result = response(
+    errors([{ message: 'Error message' }, { message: 'Second error' }]),
+  )
 
-    it('should have body set to the given JSON nested in the "errors" property', () => {
-      expect(result).toHaveProperty(
-        'body',
-        JSON.stringify({
-          errors: [
-            {
-              message: 'Error message',
-            },
-          ],
-        }),
-      )
-    })
-  })
-  describe('given specifying errors multiple times', () => {
-    let result: ReturnType<typeof response>
+  expect(result.headers.get('content-type')).toEqual('application/json')
+  expect(result).toHaveProperty(
+    'body',
+    JSON.stringify({
+      errors: [
+        {
+          message: 'Error message',
+        },
+        {
+          message: 'Second error',
+        },
+      ],
+    }),
+  )
+})
 
-    beforeAll(() => {
-      result = response(
-        errors([{ message: 'First error message' }]),
-        errors([{ message: 'Second error message' }]),
-      )
-    })
+test('combines with data in the response JSON body', () => {
+  const result = response(
+    data({ name: 'msw' }),
+    errors([{ message: 'exceeds the limit of awesomeness' }]),
+  )
 
-    it('should have "Content-Type" as "application/json"', () => {
-      expect(result.headers.get('content-type')).toEqual('application/json')
-    })
-
-    it('should have body set to the given JSON nested in the "errors" property merging each "errors" call', () => {
-      expect(result).toHaveProperty(
-        'body',
-        JSON.stringify({
-          errors: [
-            {
-              message: 'First error message',
-            },
-            {
-              message: 'Second error message',
-            },
-          ],
-        }),
-      )
-    })
-  })
-  describe('given composed with data', () => {
-    let result: ReturnType<typeof response>
-
-    beforeAll(() => {
-      result = response(
-        data({ name: 'msw' }),
-        errors([{ message: 'is great' }]),
-      )
-    })
-
-    it('should have body set to the given JSON nested in the "data" property', () => {
-      expect(result).toHaveProperty(
-        'body',
-        `{\"data\":{\"name\":\"msw\"},\"errors\":[{\"message\":\"is great\"}]}`,
-      )
-    })
-  })
+  expect(result.headers.get('content-type')).toEqual('application/json')
+  expect(result).toHaveProperty(
+    'body',
+    JSON.stringify({
+      errors: [
+        {
+          message: 'exceeds the limit of awesomeness',
+        },
+      ],
+      data: {
+        name: 'msw',
+      },
+    }),
+  )
 })

--- a/src/context/errors.test.ts
+++ b/src/context/errors.test.ts
@@ -1,4 +1,5 @@
 import { errors } from './errors'
+import { data } from './data'
 import { response } from '../response'
 
 describe('errors', () => {
@@ -23,6 +24,23 @@ describe('errors', () => {
             },
           ],
         }),
+      )
+    })
+  })
+  describe('given composed with data', () => {
+    let result: ReturnType<typeof response>
+
+    beforeAll(() => {
+      result = response(
+        data({ name: 'msw' }),
+        errors([{ message: 'is great' }]),
+      )
+    })
+
+    it('should have body set to the given JSON nested in the "data" property', () => {
+      expect(result).toHaveProperty(
+        'body',
+        `{\"errors\":[{\"message\":\"is great\"}],\"data\":{\"name\":\"msw\"}}`,
       )
     })
   })

--- a/src/context/errors.test.ts
+++ b/src/context/errors.test.ts
@@ -27,6 +27,36 @@ describe('errors', () => {
       )
     })
   })
+  describe('given specifying errors multiple times', () => {
+    let result: ReturnType<typeof response>
+
+    beforeAll(() => {
+      result = response(
+        errors([{ message: 'First error message' }]),
+        errors([{ message: 'Second error message' }]),
+      )
+    })
+
+    it('should have "Content-Type" as "application/json"', () => {
+      expect(result.headers.get('content-type')).toEqual('application/json')
+    })
+
+    it('should have body set to the given JSON nested in the "errors" property merging each "errors" call', () => {
+      expect(result).toHaveProperty(
+        'body',
+        JSON.stringify({
+          errors: [
+            {
+              message: 'First error message',
+            },
+            {
+              message: 'Second error message',
+            },
+          ],
+        }),
+      )
+    })
+  })
   describe('given composed with data', () => {
     let result: ReturnType<typeof response>
 

--- a/src/context/errors.test.ts
+++ b/src/context/errors.test.ts
@@ -40,7 +40,7 @@ describe('errors', () => {
     it('should have body set to the given JSON nested in the "data" property', () => {
       expect(result).toHaveProperty(
         'body',
-        `{\"errors\":[{\"message\":\"is great\"}],\"data\":{\"name\":\"msw\"}}`,
+        `{\"data\":{\"name\":\"msw\"},\"errors\":[{\"message\":\"is great\"}]}`,
       )
     })
   })

--- a/src/context/errors.ts
+++ b/src/context/errors.ts
@@ -5,6 +5,8 @@ import { json } from './json'
 /**
  * Returns a list of GraphQL errors.
  */
-export const errors = (errorsList: Partial<GraphQLError>[]) => {
+export const errors = (
+  errorsList: Partial<GraphQLError>[],
+): ResponseTransformer<{ errors: typeof errorsList }> => {
   return json({ errors: errorsList }, { merge: true })
 }

--- a/src/context/errors.ts
+++ b/src/context/errors.ts
@@ -5,8 +5,6 @@ import { json } from './json'
 /**
  * Returns a list of GraphQL errors.
  */
-export const errors = (
-  errorsList: Partial<GraphQLError>[],
-): ResponseTransformer<{ errors: typeof errorsList }> => {
+export const errors = (errorsList: Partial<GraphQLError>[]) => {
   return json({ errors: errorsList }, { merge: true })
 }

--- a/src/context/errors.ts
+++ b/src/context/errors.ts
@@ -8,5 +8,5 @@ import { json } from './json'
 export const errors = (
   errorsList: Partial<GraphQLError>[],
 ): ResponseTransformer<{ errors: typeof errorsList }> => {
-  return json({ errors: errorsList })
+  return json({ errors: errorsList }, { merge: true })
 }

--- a/src/context/json.test.ts
+++ b/src/context/json.test.ts
@@ -36,5 +36,28 @@ describe('json', () => {
         '"2020-01-01T00:00:00.000Z"',
       )
     })
+
+    it('should allow merging with a prior body', () => {
+      const firstNonNestedObject = json({ firstName: 'John' }, { merge: true })
+      const secondNonNestedObject = json({ lastName: 'Doe' }, { merge: true })
+
+      expect(
+        response(firstNonNestedObject, secondNonNestedObject),
+      ).toHaveProperty('body', '{"lastName":"Doe","firstName":"John"}')
+
+      const firstNestedObject = json(
+        { john: { street: 'Doe street' } },
+        { merge: true },
+      )
+      const secondNestedObject = json(
+        { john: { street: 'Doe street', number: 74 } },
+        { merge: true },
+      )
+
+      expect(response(firstNestedObject, secondNestedObject)).toHaveProperty(
+        'body',
+        '{"john":{"street":"Doe street"}}',
+      )
+    })
   })
 })

--- a/src/context/json.test.ts
+++ b/src/context/json.test.ts
@@ -40,15 +40,10 @@ describe('json', () => {
     it('should allow merging with a prior body', () => {
       const firstNonNestedObject = json({ firstName: 'John' }, { merge: true })
       const secondNonNestedObject = json({ lastName: 'Santa' }, { merge: true })
-      const thirdNonNestedObject = json({ lastName: 'Doe' }, { merge: true })
 
       expect(
-        response(
-          firstNonNestedObject,
-          secondNonNestedObject,
-          thirdNonNestedObject,
-        ),
-      ).toHaveProperty('body', '{"firstName":"John","lastName":"Doe"}')
+        response(firstNonNestedObject, secondNonNestedObject),
+      ).toHaveProperty('body', '{"firstName":"John","lastName":"Santa"}')
 
       const firstNestedObject = json(
         { john: { street: 'Doe street', number: 74 } },

--- a/src/context/json.test.ts
+++ b/src/context/json.test.ts
@@ -61,7 +61,7 @@ describe('json', () => {
 
       expect(response(firstNestedObject, secondNestedObject)).toHaveProperty(
         'body',
-        '{"john":{"street":"Doe street"}}',
+        '{"john":{"street":"Doe street","number":74}}',
       )
     })
   })

--- a/src/context/json.test.ts
+++ b/src/context/json.test.ts
@@ -39,18 +39,23 @@ describe('json', () => {
 
     it('should allow merging with a prior body', () => {
       const firstNonNestedObject = json({ firstName: 'John' }, { merge: true })
-      const secondNonNestedObject = json({ lastName: 'Doe' }, { merge: true })
+      const secondNonNestedObject = json({ lastName: 'Santa' }, { merge: true })
+      const thirdNonNestedObject = json({ lastName: 'Doe' }, { merge: true })
 
       expect(
-        response(firstNonNestedObject, secondNonNestedObject),
-      ).toHaveProperty('body', '{"lastName":"Doe","firstName":"John"}')
+        response(
+          firstNonNestedObject,
+          secondNonNestedObject,
+          thirdNonNestedObject,
+        ),
+      ).toHaveProperty('body', '{"firstName":"John","lastName":"Doe"}')
 
       const firstNestedObject = json(
-        { john: { street: 'Doe street' } },
+        { john: { street: 'Doe street', number: 74 } },
         { merge: true },
       )
       const secondNestedObject = json(
-        { john: { street: 'Doe street', number: 74 } },
+        { john: { street: 'Doe street' } },
         { merge: true },
       )
 

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -1,4 +1,5 @@
 import { ResponseTransformer } from '../response'
+import { mergeRight } from '../utils/internal/mergeRight'
 
 type JSONContextOptions = {
   merge?: boolean
@@ -27,7 +28,7 @@ export const json = <BodyType>(
     if (merge) {
       try {
         const nextBody = JSON.parse(res.body as string)
-        res.body = JSON.stringify({ ...body, ...nextBody }) as any
+        res.body = JSON.stringify(mergeRight(body, nextBody)) as any
       } catch (e) {
         res.body = JSON.stringify(body) as any
       }

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -1,5 +1,13 @@
 import { ResponseTransformer } from '../response'
 
+type JSONContextOptions = {
+  merge?: boolean
+}
+
+const defaultJSONContextOptions: JSONContextOptions = {
+  merge: false,
+}
+
 /**
  * Sets the given value as the JSON body of the response.
  * @example
@@ -9,10 +17,23 @@ import { ResponseTransformer } from '../response'
  */
 export const json = <BodyType>(
   body: BodyType,
+  {
+    merge = defaultJSONContextOptions.merge,
+  }: JSONContextOptions = defaultJSONContextOptions,
 ): ResponseTransformer<BodyType> => {
   return (res) => {
     res.headers.set('Content-Type', 'application/json')
-    res.body = JSON.stringify(body) as any
+
+    if (merge) {
+      try {
+        const previousBody = JSON.parse(res.body as string)
+        res.body = JSON.stringify({ ...previousBody, ...body }) as any
+      } catch (e) {
+        res.body = JSON.stringify(body) as any
+      }
+    } else {
+      res.body = JSON.stringify(body) as any
+    }
     return res
   }
 }

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -19,11 +19,7 @@ export const json = <BodyTypeJSON>(
   return (res) => {
     res.headers.set('Content-Type', 'application/json')
 
-    if (merge) {
-      res.body = mergeRight(body, res.body || {})
-    } else {
-      res.body = body
-    }
+    res.body = merge ? mergeRight(body, res.body || {}) : body
 
     return res
   }

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -16,25 +16,27 @@ const defaultJSONContextOptions: JSONContextOptions = {
  * res(json('Some string'))
  * res(json([1, '2', false, { ok: true }]))
  */
-export const json = <BodyType>(
-  body: BodyType,
+export const json = <BodyTypeJSON, BodyTypeString extends string>(
+  body: BodyTypeJSON,
   {
     merge = defaultJSONContextOptions.merge,
   }: JSONContextOptions = defaultJSONContextOptions,
-): ResponseTransformer<BodyType> => {
+): ResponseTransformer<BodyTypeString> => {
   return (res) => {
     res.headers.set('Content-Type', 'application/json')
 
     if (merge) {
       try {
-        const nextBody = JSON.parse(res.body as string)
-        res.body = JSON.stringify(mergeRight(body, nextBody)) as any
+        const nextBody = JSON.parse(res.body)
+
+        res.body = JSON.stringify(mergeRight(body, nextBody)) as BodyTypeString
       } catch (e) {
-        res.body = JSON.stringify(body) as any
+        res.body = JSON.stringify(body) as BodyTypeString
       }
     } else {
-      res.body = JSON.stringify(body) as any
+      res.body = JSON.stringify(body) as BodyTypeString
     }
+
     return res
   }
 }

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -5,10 +5,6 @@ type JSONContextOptions = {
   merge?: boolean
 }
 
-const defaultJSONContextOptions: JSONContextOptions = {
-  merge: false,
-}
-
 /**
  * Sets the given value as the JSON body of the response.
  * @example
@@ -18,9 +14,7 @@ const defaultJSONContextOptions: JSONContextOptions = {
  */
 export const json = <BodyTypeJSON, BodyTypeString extends string>(
   body: BodyTypeJSON,
-  {
-    merge = defaultJSONContextOptions.merge,
-  }: JSONContextOptions = defaultJSONContextOptions,
+  { merge = false }: JSONContextOptions = {},
 ): ResponseTransformer<BodyTypeString> => {
   return (res) => {
     res.headers.set('Content-Type', 'application/json')

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -18,8 +18,7 @@ export const json = <BodyTypeJSON>(
 ): ResponseTransformer<BodyTypeJSON> => {
   return (res) => {
     res.headers.set('Content-Type', 'application/json')
-
-    res.body = merge ? mergeRight(body, res.body || {}) : body
+    res.body = merge ? (mergeRight(res.body || {}, body) as BodyTypeJSON) : body
 
     return res
   }

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -12,23 +12,17 @@ type JSONContextOptions = {
  * res(json('Some string'))
  * res(json([1, '2', false, { ok: true }]))
  */
-export const json = <BodyTypeJSON, BodyTypeString extends string>(
+export const json = <BodyTypeJSON>(
   body: BodyTypeJSON,
   { merge = false }: JSONContextOptions = {},
-): ResponseTransformer<BodyTypeString> => {
+): ResponseTransformer<BodyTypeJSON> => {
   return (res) => {
     res.headers.set('Content-Type', 'application/json')
 
     if (merge) {
-      try {
-        const nextBody = JSON.parse(res.body)
-
-        res.body = JSON.stringify(mergeRight(body, nextBody)) as BodyTypeString
-      } catch (e) {
-        res.body = JSON.stringify(body) as BodyTypeString
-      }
+      res.body = mergeRight(body, res.body || {})
     } else {
-      res.body = JSON.stringify(body) as BodyTypeString
+      res.body = body
     }
 
     return res

--- a/src/context/json.ts
+++ b/src/context/json.ts
@@ -26,8 +26,8 @@ export const json = <BodyType>(
 
     if (merge) {
       try {
-        const previousBody = JSON.parse(res.body as string)
-        res.body = JSON.stringify({ ...previousBody, ...body }) as any
+        const nextBody = JSON.parse(res.body as string)
+        res.body = JSON.stringify({ ...body, ...nextBody }) as any
       } catch (e) {
         res.body = JSON.stringify(body) as any
       }

--- a/src/response.ts
+++ b/src/response.ts
@@ -34,13 +34,15 @@ export const defaultResponse: Omit<MockedResponse, 'headers'> = {
   once: false,
 }
 
-const postProcessJSONBody = <T = Partial<MockedResponse>>(response: T): T => {
-  if (response.headers.get('content-type')?.endsWith('json')) {
-    response.body = JSON.stringify(response.body)
+const JSONBodyResponseTransformer = (res: MockedResponse): MockedResponse => {
+  if (res.body && res.headers.get('content-type')?.endsWith('json')) {
+    res.body = JSON.stringify(res.body)
   }
 
-  return response
+  return res
 }
+
+const postProcessTransformers = [JSONBodyResponseTransformer]
 
 function createResponseComposition(
   overrides: Partial<MockedResponse> = {},
@@ -58,7 +60,9 @@ function createResponseComposition(
     )
 
     if (transformers.length > 0) {
-      return postProcessJSONBody(compose(...transformers)(resolvedResponse))
+      return compose(...postProcessTransformers.concat(transformers))(
+        resolvedResponse,
+      )
     }
 
     return resolvedResponse

--- a/src/response.ts
+++ b/src/response.ts
@@ -34,6 +34,14 @@ export const defaultResponse: Omit<MockedResponse, 'headers'> = {
   once: false,
 }
 
+const postProcessJSONBody = <T = Partial<MockedResponse>>(response: T): T => {
+  if (response.headers.get('content-type')?.endsWith('json')) {
+    response.body = JSON.stringify(response.body)
+  }
+
+  return response
+}
+
 function createResponseComposition(
   overrides: Partial<MockedResponse> = {},
 ): ResponseFunction {
@@ -50,7 +58,7 @@ function createResponseComposition(
     )
 
     if (transformers.length > 0) {
-      return compose(...transformers)(resolvedResponse)
+      return postProcessJSONBody(compose(...transformers)(resolvedResponse))
     }
 
     return resolvedResponse

--- a/src/response.ts
+++ b/src/response.ts
@@ -34,15 +34,13 @@ export const defaultResponse: Omit<MockedResponse, 'headers'> = {
   once: false,
 }
 
-const JSONBodyResponseTransformer = (res: MockedResponse): MockedResponse => {
-  if (res.body && res.headers.get('content-type')?.endsWith('json')) {
+const JSONBodyResponseTransformer = (res: Partial<MockedResponse>) => {
+  if (res.body && res.headers?.get('content-type')?.endsWith('json')) {
     res.body = JSON.stringify(res.body)
   }
 
   return res
 }
-
-const postProcessTransformers = [JSONBodyResponseTransformer]
 
 function createResponseComposition(
   overrides: Partial<MockedResponse> = {},
@@ -60,8 +58,8 @@ function createResponseComposition(
     )
 
     if (transformers.length > 0) {
-      return compose(...postProcessTransformers.concat(transformers))(
-        resolvedResponse,
+      return JSONBodyResponseTransformer(
+        compose(...transformers)(resolvedResponse),
       )
     }
 

--- a/src/utils/internal/isObject.test.ts
+++ b/src/utils/internal/isObject.test.ts
@@ -1,0 +1,20 @@
+import { isObject } from './isObject'
+
+test('returns true given an object', () => {
+  expect(isObject({})).toBe(true)
+  expect(isObject({ a: 1 })).toBe(true)
+})
+
+test('returns false given a non-object value', () => {
+  expect(isObject(1)).toBe(false)
+  expect(isObject('string')).toBe(false)
+  expect(isObject([])).toBe(false)
+  expect(
+    isObject(function () {
+      return 2
+    }),
+  ).toBe(false)
+  expect(isObject(false)).toBe(false)
+  expect(isObject(undefined)).toBe(false)
+  expect(isObject(null)).toBe(false)
+})

--- a/src/utils/internal/isObject.ts
+++ b/src/utils/internal/isObject.ts
@@ -1,0 +1,6 @@
+/**
+ * Determines if the given value is an object.
+ */
+export function isObject(value: any): boolean {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}

--- a/src/utils/internal/mergeRight.ts
+++ b/src/utils/internal/mergeRight.ts
@@ -1,32 +1,27 @@
-function isObject(obj: Record<string, any>): boolean {
-  return typeof obj === 'object'
-}
+import { isObject } from './isObject'
 
 /**
  * Deeply merges two given objects with the right one
  * having a priority during property assignment.
  */
 export function mergeRight(
-  a: Record<string, any>,
-  b: Record<string, any>,
-): Record<string, any> {
-  const result = Object.assign({}, a)
+  left: Record<string, any>,
+  right: Record<string, any>,
+) {
+  return Object.entries(right).reduce((result, [key, rightValue]) => {
+    const leftValue = result[key]
 
-  Object.entries(b).forEach(([key, value]) => {
-    const existingValue = result[key]
-
-    if (Array.isArray(existingValue) && Array.isArray(value)) {
-      result[key] = existingValue.concat(value)
-      return
+    if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
+      result[key] = leftValue.concat(rightValue)
+      return result
     }
 
-    if (isObject(existingValue) && isObject(value)) {
-      result[key] = mergeRight(existingValue, value)
-      return
+    if (isObject(leftValue) && isObject(rightValue)) {
+      result[key] = mergeRight(leftValue, rightValue)
+      return result
     }
 
-    result[key] = value
-  })
-
-  return result
+    result[key] = rightValue
+    return result
+  }, Object.assign({}, left))
 }

--- a/src/utils/request/parseBody.test.ts
+++ b/src/utils/request/parseBody.test.ts
@@ -1,10 +1,21 @@
 import { parseBody } from './parseBody'
 
-test('parses a given body string if the "Content-Type:*/json" header is set', () => {
+test('parses a body if the "Content-Type:application/json" header is set', () => {
   expect(
     parseBody(
       `{"property":2}`,
       new Headers({ 'Content-Type': 'application/json' }),
+    ),
+  ).toEqual({
+    property: 2,
+  })
+})
+
+test('parses a body if the "Content-Type*/json" header is set', () => {
+  expect(
+    parseBody(
+      `{"property":2}`,
+      new Headers({ 'Content-Type': 'application/hal+json' }),
     ),
   ).toEqual({
     property: 2,

--- a/src/utils/request/parseBody.ts
+++ b/src/utils/request/parseBody.ts
@@ -8,7 +8,7 @@ export function parseBody(body?: MockedRequest['body'], headers?: Headers) {
   if (body) {
     // If the intercepted request's body has a JSON Content-Type
     // parse it into an object, otherwise leave as-is.
-    const hasJsonContent = headers?.get('content-type')?.includes('json')
+    const hasJsonContent = headers?.get('content-type')?.endsWith('json')
 
     if (hasJsonContent && typeof body !== 'object') {
       return jsonParse(body) || body

--- a/test/focusedTest.ts
+++ b/test/focusedTest.ts
@@ -2,4 +2,13 @@ import { spawnServer } from './support/spawnServer'
 
 const mockDefs = process.argv[2]
 
+if (!mockDefs.endsWith('.mocks.ts')) {
+  throw new Error(`\
+The mock definition file you provide doesn't seem to be a valid mock definition:
+${mockDefs}
+
+Please make sure you provide the "*.mocks.ts" file to this command.\
+`)
+}
+
 spawnServer(mockDefs)


### PR DESCRIPTION
This pull request implements one suggestion (without recommending it specifically discussed here https://github.com/mswjs/msw/issues/401.

It thereby implements  allowing `json` to use a `json({}, { merge: true })` option which `data` and `errors` of the `graphql` context can use. Internally it parses the prior `res.body` and shallowly merges the new `BodyType` in.

This internally is used by `data` and `errors` to support composing both with each other.