### PR TITLE
mockServiceWorker: Short-circuits the fetch event on bypass state

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -74,10 +74,21 @@ self.addEventListener('message', async function (event) {
   }
 })
 
-self.addEventListener('fetch', async function (event) {
+self.addEventListener('fetch', function (event) {
   const { clientId, request } = event
   const requestClone = request.clone()
   const getOriginalResponse = () => fetch(requestClone)
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Bypass mocking if the current client isn't present in the internal clients map
+  // (i.e. has the mocking disabled).
+  if (!clients[clientId]) {
+    return
+  }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
@@ -89,20 +100,15 @@ self.addEventListener('fetch', async function (event) {
     new Promise(async (resolve, reject) => {
       const client = await event.target.clients.get(clientId)
 
-      if (
-        // Bypass mocking when no clients active
-        !client ||
-        // Bypass mocking if the current client has mocking disabled
-        !clients[clientId] ||
-        // Bypass mocking for navigation requests
-        request.mode === 'navigate'
-      ) {
+      // Bypass mocking when the request client is not active.
+      if (!client) {
         return resolve(getOriginalResponse())
       }
 
       // Bypass requests with the explicit bypass header
       if (requestClone.headers.get(bypassHeaderName) === 'true') {
         const modifiedHeaders = serializeHeaders(requestClone.headers)
+
         // Remove the bypass header to comply with the CORS preflight check
         delete modifiedHeaders[bypassHeaderName]
 

--- a/test/msw-api/unregister.test.ts
+++ b/test/msw-api/unregister.test.ts
@@ -35,10 +35,7 @@ test('unregisters itself when not prompted to be activated again', async () => {
   })
   const secondBody = await secondResponse.json()
 
-  // Although the Service Worker unregisters itself upon refreshing the page,
-  // it still remains "active and running" with the "deleted" status.
-  // This results into requests go through the Service Worker until the next reload.
-  expect(secondResponse.fromServiceWorker()).toBe(true)
+  expect(secondResponse.fromServiceWorker()).toBe(false)
   expect(secondBody).not.toEqual({
     mocked: true,
   })


### PR DESCRIPTION
> This requires to update the worker script.

## GitHub

- Closes #412 

## Changes

~~Instead of requesting a bypasses request once more, short circuit the `fetch` handler in the worker for it to bypass that request. This will get rid of requests duplications and won't list static assets in the XHR tab of a browser's DevTools.~~

- Short circuits on the navigation requests outside of the `respondWith` scope.
- Short circuits on the `!clients[clientId]` requests outside of the `respondWith` scope.
- Fixes an issue that some requests are still marked as "from ServiceWorker" after the worker has been unregistered.