### PR TITLE
TypeScript typing for REST path parameters

### DIFF
--- a/src/rest.ts
+++ b/src/rest.ts
@@ -3,6 +3,7 @@ import {
   ResponseResolver,
   MockedRequest,
   DefaultRequestBodyType,
+  RequestParams,
 } from './utils/handlers/requestHandler'
 import { Mask } from './setupWorker/glossary'
 import { set } from './context/set'
@@ -52,15 +53,19 @@ export interface ParsedRestRequest {
 }
 
 const createRestHandler = (method: RESTMethods) => {
-  return <RequestBodyType = DefaultRequestBodyType, ResponseBodyType = any>(
+  return <
+    RequestBodyType = DefaultRequestBodyType,
+    ResponseBodyType = any,
+    RequestParamsType extends RequestParams = RequestParams
+  >(
     mask: Mask,
     resolver: ResponseResolver<
-      MockedRequest<RequestBodyType>,
+      MockedRequest<RequestBodyType, RequestParamsType>,
       typeof restContext,
       ResponseBodyType
     >,
   ): RequestHandler<
-    MockedRequest<RequestBodyType>,
+    MockedRequest<RequestBodyType, RequestParamsType>,
     typeof restContext,
     ParsedRestRequest,
     MockedRequest<RequestBodyType>,

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -15,7 +15,10 @@ export const defaultContext = {
 
 export type DefaultRequestBodyType = Record<string, any> | string | undefined
 
-export interface MockedRequest<BodyType = DefaultRequestBodyType> {
+export interface MockedRequest<
+  BodyType = DefaultRequestBodyType,
+  RequestParamsType = RequestParams
+> {
   url: URL
   method: Request['method']
   headers: Headers
@@ -31,7 +34,7 @@ export interface MockedRequest<BodyType = DefaultRequestBodyType> {
   referrerPolicy: Request['referrerPolicy']
   body: BodyType
   bodyUsed: Request['bodyUsed']
-  params: RequestParams
+  params: RequestParamsType
 }
 
 export type RequestQuery = {

--- a/test/rest-api/params.mocks.ts
+++ b/test/rest-api/params.mocks.ts
@@ -1,7 +1,17 @@
 import { setupWorker, rest } from 'msw'
 
+interface ResponseType {
+  username: string
+  messageId: string
+}
+
+interface RequestParams {
+  username: string
+  messageId: string
+}
+
 const worker = setupWorker(
-  rest.get(
+  rest.get<any, ResponseType, RequestParams>(
     'https://api.github.com/users/:username/messages/:messageId',
     (req, res, ctx) => {
       const { username, messageId } = req.params


### PR DESCRIPTION
I'm not 100% sure about this one in terms of design. It seems kinda off that the 3rd type parameter is for something related to the request while the second one is related to the response.

Maybe we can use overloading here?

The typings would work as proposed in the issue.

Closes #393 