### PR TITLE
Export GraphQLRequestParsedResult interface to fix TypeScript error

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -65,7 +65,7 @@ export interface GraphQLRequestPayload<VariablesType> {
   variables?: VariablesType
 }
 
-interface GraphQLRequestParsedResult<VariablesType> {
+export interface GraphQLRequestParsedResult<VariablesType> {
   operationType: OperationTypeNode
   operationName: string | undefined
   variables: VariablesType | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,5 +23,6 @@ export {
   GraphQLMockedContext,
   GraphQLRequestPayload,
   GraphQLResponseResolver,
+  GraphQLRequestParsedResult,
 } from './graphql'
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'


### PR DESCRIPTION
When using `msw` with TypeScript I get an error when assigning `graphql.query` to a variable.

#### Example code:

```
const addTestQueryResolver = () => graphql.query('TestQuery', genericResolver);
```

#### Error
```
Exported variable 'addTestQueryResolver' has or is using name 'GraphQLRequestParsedResult' from external module "....../node_modules/msw/lib/types/graphql" but cannot be named.
```

Exporting the interface `GraphQLRequestParsedResult` fixes this error.