### PR TITLE
GraphQL: support undefined errors with "ctx.errors"

### DIFF
--- a/src/context/errors.test.ts
+++ b/src/context/errors.test.ts
@@ -60,3 +60,10 @@ test('combines with data in the response JSON body', () => {
     }),
   )
 })
+
+test('bypasses undefined errors', () => {
+  const result = response(errors(undefined), errors(null))
+
+  expect(result.headers.get('content-type')).not.toEqual('application/json')
+  expect(result).toHaveProperty('body', null)
+})

--- a/src/context/errors.ts
+++ b/src/context/errors.ts
@@ -3,10 +3,16 @@ import { ResponseTransformer } from '../response'
 import { json } from './json'
 
 /**
- * Returns a list of GraphQL errors.
+ * Sets a given list of GraphQL errors on the mocked response.
  */
-export const errors = (
-  errorsList: Partial<GraphQLError>[],
-): ResponseTransformer<{ errors: typeof errorsList }> => {
+export const errors = <
+  ErrorsType extends Partial<GraphQLError>[] | null | undefined
+>(
+  errorsList: ErrorsType,
+): ResponseTransformer<{ errors: ErrorsType }> => {
+  if (errorsList == null) {
+    return (res) => res
+  }
+
   return json({ errors: errorsList }, { merge: true })
 }


### PR DESCRIPTION
This PR make graphql `errors` able to be undefined, as the proposed docs are the following:

```
graphql.operation(async (req, res, ctx) => {
  const payload = await graphqlRequest(
    schema,
    req.body.query,
    root,
    null,
    req.variables,
  )
  return res(ctx.data(payload.data), ctx.errors(payload.errors))
})
```

Where errors are passed straight away to the response.
If errors are undefined, there won't be any errors property added to the response.

Reference to the docs PR: https://github.com/mswjs/mswjs.io/pull/88