### PR TITLE
docs: add build note to integration tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,6 +92,8 @@ $ yarn test:unit path/to/suite.test.ts
 - [Jest][jest-url], a test runner.
 - [Puppeteer][puppeteer-url], a Chromium automation tool.
 
+> Note: make sure that you [build](#build) MSW before you run the integration tests
+
 #### Writing an integration test
 
 Each integration test consists of two parts:


### PR DESCRIPTION
I tried to run the tests but the integration tests were failing.
I think this note can help future devs that encounter the same problem.
