### PR TITLE
ctx.status: Fixes synthetic default import of the "statuses" package

### DIFF
--- a/src/context/status.test.ts
+++ b/src/context/status.test.ts
@@ -1,36 +1,14 @@
 import { status } from './status'
 import { response } from '../response'
 
-describe('status', () => {
-  describe('given a status code', () => {
-    let result: ReturnType<typeof response>
+test('sets given status code on the response', () => {
+  const result = response(status(403))
+  expect(result).toHaveProperty('status', 403)
+  expect(result).toHaveProperty('statusText', 'Forbidden')
+})
 
-    beforeAll(() => {
-      result = response(status(403))
-    })
-
-    it('should set status code on the response', () => {
-      expect(result).toHaveProperty('status', 403)
-    })
-
-    it('should have the status text associated with the status code', () => {
-      expect(result).toHaveProperty('statusText', 'Forbidden')
-    })
-  })
-
-  describe('given a status code and a status text', () => {
-    let result: ReturnType<typeof response>
-
-    beforeAll(() => {
-      result = response(status(301, 'Custom text'))
-    })
-
-    it('should set status code on the response', () => {
-      expect(result).toHaveProperty('status', 301)
-    })
-
-    it('should have the custom status text', () => {
-      expect(result).toHaveProperty('statusText', 'Custom text')
-    })
-  })
+test('supports custom status text', () => {
+  const result = response(status(301, 'Custom text'))
+  expect(result).toHaveProperty('status', 301)
+  expect(result).toHaveProperty('statusText', 'Custom text')
 })

--- a/src/context/status.ts
+++ b/src/context/status.ts
@@ -1,4 +1,4 @@
-import * as statuses from 'statuses/codes.json'
+import statuses from 'statuses/codes.json'
 import { ResponseTransformer } from '../response'
 
 export const status = (

--- a/test/rest-api/status.mocks.ts
+++ b/test/rest-api/status.mocks.ts
@@ -1,0 +1,16 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/posts', (req, res, ctx) => {
+    // Setting response status code without status text
+    // implicitly sets the correct status text.
+    return res(ctx.status(403))
+  }),
+  rest.get('/user', (req, res, ctx) => {
+    // Response status text can be overridden
+    // to an arbitrary string value.
+    return res(ctx.status(401, 'Custom text'))
+  }),
+)
+
+worker.start()

--- a/test/rest-api/status.test.ts
+++ b/test/rest-api/status.test.ts
@@ -1,0 +1,36 @@
+import * as path from 'path'
+import { runBrowserWith } from '../support/runBrowserWith'
+
+function prepareRuntime() {
+  return runBrowserWith(path.resolve(__dirname, 'status.mocks.ts'))
+}
+
+test('sets given status code on the mocked response', async () => {
+  const runtime = await prepareRuntime()
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/posts`,
+  })
+  const status = res.status()
+  const statusText = res.statusText()
+
+  expect(status).toBe(403)
+  expect(statusText).toBe('Forbidden')
+
+  return runtime.cleanup()
+})
+
+test('supports custom status text on the mocked response', async () => {
+  const runtime = await prepareRuntime()
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/user`,
+  })
+  const status = res.status()
+  const statusText = res.statusText()
+
+  expect(status).toBe(401)
+  expect(statusText).toBe('Custom text')
+
+  return runtime.cleanup()
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es6",
     "module": "ESNext",
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "declaration": true,


### PR DESCRIPTION
## GitHub

- Regression of #70

## Changes

- Sets `allowSyntheticDefaultImports: true` in `tsconfig.json` to enable imports of non-JS modules (i.e. `statuses`).
- Fixes the issue that `ctx.status` did not set the status text based on the status code implicitly.
- Flattens unit tests for `ctx.status`.
- Adds integration test that asserts in-browser usage (the issue surfaced here, unit tests passed in NodeJS).