### PR TITLE
fix: .json() must be awaited

### DIFF
--- a/test/msw-api/setup-worker/stop.test.ts
+++ b/test/msw-api/setup-worker/stop.test.ts
@@ -28,7 +28,7 @@ test('disables the mocking when the worker is stopped', async () => {
     url: 'https://api.github.com',
   })
   const headers = res.headers()
-  const body = res.json()
+  const body = await res.json()
 
   expect(headers).not.toHaveProperty('x-powered-by', 'msw')
   expect(body).not.toEqual({


### PR DESCRIPTION
should fix the issue in CI. `res.json()` was not awaited 

![image](https://user-images.githubusercontent.com/5365582/97430396-20cb4000-1919-11eb-8876-379b41cbce49.png)
