### PR TITLE
Supports listing current request handlers

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -224,6 +224,7 @@ function graphQLRequestHandler<QueryType, VariablesType = Record<string, any>>(
 
       return {
         header,
+        mask,
         callFrame,
       }
     },

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -20,6 +20,7 @@ import { getTimestamp } from './utils/logging/getTimestamp'
 import { getStatusCodeColor } from './utils/logging/getStatusCodeColor'
 import { jsonParse } from './utils/internal/jsonParse'
 import { matchRequestUrl } from './utils/matching/matchRequestUrl'
+import { getCallFrame } from './utils/internal/getCallFrame'
 
 type ExpectedOperationTypeNode = OperationTypeNode | 'all'
 
@@ -105,6 +106,8 @@ function graphQLRequestHandler<QueryType, VariablesType = Record<string, any>>(
   GraphQLMockedContext<QueryType>,
   GraphQLRequestParsedResult<VariablesType>
 > {
+  const callFrame = getCallFrame()
+
   return {
     resolver,
 
@@ -211,6 +214,18 @@ function graphQLRequestHandler<QueryType, VariablesType = Record<string, any>>(
       })
       console.log('Response:', loggedResponse)
       console.groupEnd()
+    },
+
+    getMetaInfo() {
+      const header =
+        expectedOperationType === 'all'
+          ? `[graphql] ${expectedOperationType} (origin: ${mask.toString()})`
+          : `[graphql] ${expectedOperationType} ${expectedOperationName} (origin: ${mask.toString()})`
+
+      return {
+        header,
+        callFrame,
+      }
     },
   }
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -223,6 +223,7 @@ function graphQLRequestHandler<QueryType, VariablesType = Record<string, any>>(
           : `[graphql] ${expectedOperationType} ${expectedOperationName} (origin: ${mask.toString()})`
 
       return {
+        type: 'graphql',
         header,
         mask,
         callFrame,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,14 +16,15 @@ export { context }
 
 /* Request handlers */
 export {
+  defaultContext,
   MockedRequest,
   RequestHandler,
+  RequestHandlerMetaInfo,
   RequestParams,
   RequestQuery,
   ResponseResolver,
   ResponseResolverReturnType,
   AsyncResponseResolverReturnType,
-  defaultContext,
 } from './utils/handlers/requestHandler'
 export { rest, restContext, RESTMethods, ParsedRestRequest } from './rest'
 export {

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -136,7 +136,10 @@ export function createSetupServer(...interceptors: Interceptor[]) {
         )
       },
 
-      list() {
+      /**
+       * Prints the list of currently active request handlers.
+       */
+      printHandlers() {
         currentHandlers.forEach((handler) => {
           const meta = handler.getMetaInfo()
 

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -1,4 +1,5 @@
 import * as cookieUtils from 'cookie'
+import { bold } from 'chalk'
 import { Headers, flattenHeadersObject } from 'headers-utils'
 import {
   RequestInterceptor,
@@ -135,6 +136,20 @@ export function createSetupServer(...interceptors: Interceptor[]) {
         )
       },
 
+      list() {
+        currentHandlers.forEach((handler) => {
+          const meta = handler.getMetaInfo()
+
+          console.log(`\
+${bold(meta.header)}
+  Declaration: ${meta.callFrame}
+`)
+        })
+      },
+
+      /**
+       * Stops requests interception by restoring all augmented modules.
+       */
       close() {
         interceptor.restore()
       },

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -25,7 +25,7 @@ export interface SetupServerApi {
   /**
    * Lists all active request handlers.
    */
-  list: () => void
+  printHandlers: () => void
 
   /**
    * Stops requests interception by restoring all augmented modules.

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -23,6 +23,11 @@ export interface SetupServerApi {
   resetHandlers: (...nextHandlers: RequestHandlersList) => void
 
   /**
+   * Lists all active request handlers.
+   */
+  list: () => void
+
+  /**
    * Stops requests interception by restoring all augmented modules.
    */
   close: () => void

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -154,6 +154,7 @@ ${queryParams
 
       getMetaInfo() {
         return {
+          type: 'rest',
           header: `[rest] ${method} ${mask.toString()}`,
           mask,
           callFrame,

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -155,6 +155,8 @@ ${queryParams
       getMetaInfo() {
         return {
           header: `[rest] ${method} ${mask.toString()}`,
+          mask,
+          method,
           callFrame,
         }
       },

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -25,6 +25,7 @@ import { getStatusCodeColor } from './utils/logging/getStatusCodeColor'
 import { isStringEqual } from './utils/internal/isStringEqual'
 import { matchRequestUrl } from './utils/matching/matchRequestUrl'
 import { getUrlByMask } from './utils/url/getUrlByMask'
+import { getCallFrame } from './utils/internal/getCallFrame'
 
 export enum RESTMethods {
   HEAD = 'HEAD',
@@ -72,6 +73,7 @@ const createRestHandler = (method: RESTMethods) => {
     ResponseBodyType
   > => {
     const resolvedMask = getUrlByMask(mask)
+    const callFrame = getCallFrame()
 
     return {
       parse(req) {
@@ -148,6 +150,13 @@ ${queryParams
         })
         console.log('Response', loggedResponse)
         console.groupEnd()
+      },
+
+      getMetaInfo() {
+        return {
+          header: `[rest] ${method} ${mask.toString()}`,
+          callFrame,
+        }
       },
     }
   }

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -156,7 +156,6 @@ ${queryParams
         return {
           header: `[rest] ${method} ${mask.toString()}`,
           mask,
-          method,
           callFrame,
         }
       },

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -101,5 +101,5 @@ export interface SetupWorkerApi {
   /**
    * Lists all active request handlers.
    */
-  list: () => void
+  printHandlers: () => void
 }

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -97,4 +97,9 @@ export interface SetupWorkerApi {
    * Resets request handlers to the initial list given to the `setupWorker` call, or to the explicit next request handlers list, if given.
    */
   resetHandlers: (...nextHandlers: RequestHandlersList) => void
+
+  /**
+   * Lists all active request handlers.
+   */
+  list: () => void
 }

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -108,7 +108,7 @@ export function setupWorker(
       )
     },
 
-    list() {
+    printHandlers() {
       context.requestHandlers.forEach((handler) => {
         const meta = handler.getMetaInfo()
 

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -9,10 +9,6 @@ import * as requestHandlerUtils from '../utils/handlers/requestHandlerUtils'
 import { isNodeProcess } from '../utils/internal/isNodeProcess'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
 
-/**
- * Configures a Service Worker with the given request handler functions.
- */
-
 interface Listener {
   target: EventTarget
   event: string
@@ -110,6 +106,17 @@ export function setupWorker(
         requestHandlers,
         ...nextHandlers,
       )
+    },
+
+    list() {
+      context.requestHandlers.forEach((handler) => {
+        const meta = handler.getMetaInfo()
+
+        console.groupCollapsed(meta.header)
+        console.log(`Declaration: ${meta.callFrame}`)
+        console.log('Resolver: %s', handler.resolver)
+        console.groupEnd()
+      })
     },
   }
 }

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -115,7 +115,9 @@ export function setupWorker(
         console.groupCollapsed(meta.header)
         console.log(`Declaration: ${meta.callFrame}`)
         console.log('Resolver: %s', handler.resolver)
-        console.log('Match:', `https://mswjs.io/repl?path=${meta.mask}`)
+        if (['rest'].includes(meta.type)) {
+          console.log('Match:', `https://mswjs.io/repl?path=${meta.mask}`)
+        }
         console.groupEnd()
       })
     },

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -115,6 +115,7 @@ export function setupWorker(
         console.groupCollapsed(meta.header)
         console.log(`Declaration: ${meta.callFrame}`)
         console.log('Resolver: %s', handler.resolver)
+        console.log('Match:', `https://mswjs.io/repl?path=${meta.mask}`)
         console.groupEnd()
       })
     },

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -60,6 +60,11 @@ export type ResponseResolver<
   context: ContextType,
 ) => AsyncResponseResolverReturnType<MockedResponse<BodyType>>
 
+export interface RequestHandlerMetaInfo {
+  header: string
+  callFrame: string | undefined
+}
+
 export interface RequestHandler<
   RequestType = MockedRequest,
   ContextType = typeof defaultContext,
@@ -119,6 +124,12 @@ export interface RequestHandler<
    * when dealing with any subsequent matching requests.
    */
   shouldSkip?: boolean
+
+  /**
+   * Returns request handler's meta information used
+   * when listing each current request handler.
+   */
+  getMetaInfo: () => RequestHandlerMetaInfo
 }
 
 export default null

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -1,5 +1,5 @@
 import { Headers } from 'headers-utils'
-import { ResponseWithSerializedHeaders } from '../../setupWorker/glossary'
+import { Mask, ResponseWithSerializedHeaders } from '../../setupWorker/glossary'
 import { ResponseComposition, MockedResponse } from '../../response'
 import { status } from '../../context/status'
 import { set } from '../../context/set'
@@ -62,6 +62,7 @@ export type ResponseResolver<
 
 export interface RequestHandlerMetaInfo {
   header: string
+  mask: Mask
   callFrame: string | undefined
 }
 

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -60,7 +60,10 @@ export type ResponseResolver<
   context: ContextType,
 ) => AsyncResponseResolverReturnType<MockedResponse<BodyType>>
 
-export interface RequestHandlerMetaInfo {
+type RequestHandlerType = 'rest' | 'graphql'
+
+export interface RequestHandlerMetaInfo<Type = RequestHandlerType> {
+  type: Type
   header: string
   mask: Mask
   callFrame: string | undefined

--- a/src/utils/internal/getCallFrame.ts
+++ b/src/utils/internal/getCallFrame.ts
@@ -1,0 +1,26 @@
+/**
+ * Return the stack trace frame of a function's invocation.
+ */
+export function getCallFrame() {
+  try {
+    const inspectionError = new Error()
+    inspectionError.name = 'Inspection Error'
+    throw inspectionError
+  } catch (error) {
+    const frames: string[] = error.stack.split('\n')
+
+    // Get the first frame that doesn't reference the library's internal trace.
+    // Assume that frame is the invocation frame.
+    const declarationFrame = frames.slice(1).find((frame) => {
+      return !/(node_modules)?\/lib\/(umd|esm)\//.test(frame)
+    })
+
+    if (!declarationFrame) {
+      return
+    }
+
+    // Extract file reference from the stack frame.
+    const [, declarationPath] = declarationFrame.match(/\((.+?)\)$/) || []
+    return declarationPath
+  }
+}

--- a/test/msw-api/setup-server/list.test.ts
+++ b/test/msw-api/setup-server/list.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment node
+ */
+import { bold } from 'chalk'
+import { rest, graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+const resolver = () => null
+
+const github = graphql.link('https://api.github.com')
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/book/:bookId', resolver),
+  graphql.query('GetUser', resolver),
+  graphql.mutation('UpdatePost', resolver),
+  graphql.operation(resolver),
+  github.query('GetRepo', resolver),
+  github.operation(resolver),
+)
+
+beforeAll(() => {
+  jest.spyOn(global.console, 'log').mockImplementation()
+  server.listen()
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+  server.close()
+})
+
+test('lists all current request handlers', () => {
+  server.list()
+
+  expect(console.log).toBeCalledTimes(6)
+
+  expect(console.log).toBeCalledWith(`\
+${bold('[rest] GET https://test.mswjs.io/book/:bookId')}
+  Declaration: ${__filename}:13:8
+`)
+
+  expect(console.log).toBeCalledWith(`\
+${bold('[graphql] query GetUser (origin: *)')}
+  Declaration: ${__filename}:14:11
+`)
+
+  expect(console.log).toBeCalledWith(`\
+${bold('[graphql] mutation UpdatePost (origin: *)')}
+  Declaration: ${__filename}:15:11
+`)
+
+  expect(console.log).toBeCalledWith(`\
+${bold('[graphql] all (origin: *)')}
+  Declaration: ${__filename}:16:11
+`)
+
+  expect(console.log).toBeCalledWith(`\
+${bold('[graphql] query GetRepo (origin: https://api.github.com)')}
+  Declaration: ${__filename}:17:10
+`)
+
+  expect(console.log).toBeCalledWith(`\
+${bold('[graphql] all (origin: https://api.github.com)')}
+  Declaration: ${__filename}:18:10
+`)
+})
+
+test('respects runtime request handlers when listing handlers', () => {
+  server.use(
+    rest.get('https://test.mswjs.io/book/:bookId', resolver),
+    graphql.query('GetRandomNumber', resolver),
+  )
+
+  server.list()
+
+  // Runtime handlers are prepended to the list of handlers
+  // and they DON'T remove the handlers they may override.
+  expect(console.log).toBeCalledTimes(8)
+
+  expect(console.log).toBeCalledWith(`\
+${bold('[rest] GET https://test.mswjs.io/book/:bookId')}
+  Declaration: ${__filename}:74:10
+`)
+
+  expect(console.log).toBeCalledWith(`\
+${bold('[graphql] query GetRandomNumber (origin: *)')}
+  Declaration: ${__filename}:75:13
+`)
+})

--- a/test/msw-api/setup-server/printHandlers.test.ts
+++ b/test/msw-api/setup-server/printHandlers.test.ts
@@ -34,7 +34,7 @@ afterAll(() => {
 })
 
 test('lists all current request handlers', () => {
-  server.list()
+  server.printHandlers()
 
   expect(console.log).toBeCalledTimes(6)
 
@@ -75,7 +75,7 @@ test('respects runtime request handlers when listing handlers', () => {
     graphql.query('GetRandomNumber', resolver),
   )
 
-  server.list()
+  server.printHandlers()
 
   // Runtime handlers are prepended to the list of handlers
   // and they DON'T remove the handlers they may override.

--- a/test/msw-api/setup-worker/printHandlers.mocks.ts
+++ b/test/msw-api/setup-worker/printHandlers.mocks.ts
@@ -1,0 +1,21 @@
+import { setupWorker, rest, graphql } from 'msw'
+
+const resolver = () => null
+
+const github = graphql.link('https://api.github.com')
+
+const worker = setupWorker(
+  rest.get('https://test.mswjs.io/book/:bookId', resolver),
+  graphql.query('GetUser', resolver),
+  graphql.mutation('UpdatePost', resolver),
+  graphql.operation(resolver),
+  github.query('GetRepo', resolver),
+  github.operation(resolver),
+)
+
+// @ts-ignore
+window.msw = {
+  worker,
+  rest,
+  graphql,
+}

--- a/test/msw-api/setup-worker/printHandlers.test.ts
+++ b/test/msw-api/setup-worker/printHandlers.test.ts
@@ -1,0 +1,90 @@
+import * as path from 'path'
+import { SetupWorkerApi, rest, graphql } from 'msw'
+import { runBrowserWith } from '../../support/runBrowserWith'
+import { captureConsole } from '../../support/captureConsole'
+
+declare namespace window {
+  // Annotate global references to the worker and rest request handlers.
+  export const msw: {
+    worker: SetupWorkerApi
+    rest: typeof rest
+    graphql: typeof graphql
+  }
+}
+
+function createRuntime() {
+  return runBrowserWith(path.resolve(__dirname, 'printHandlers.mocks.ts'))
+}
+
+test('lists rest request handlers', async () => {
+  const runtime = await createRuntime()
+  const { messages } = captureConsole(runtime.page)
+
+  await runtime.page.evaluate(() => {
+    window.msw.worker.printHandlers()
+  })
+
+  const { startGroupCollapsed, log } = messages
+
+  expect(startGroupCollapsed).toHaveLength(6)
+  expect(startGroupCollapsed).toContain(
+    '[rest] GET https://test.mswjs.io/book/:bookId',
+  )
+  expect(startGroupCollapsed).toContain('[graphql] query GetUser (origin: *)')
+  expect(startGroupCollapsed).toContain(
+    '[graphql] mutation UpdatePost (origin: *)',
+  )
+  expect(startGroupCollapsed).toContain('[graphql] all (origin: *)')
+  expect(startGroupCollapsed).toContain(
+    '[graphql] query GetRepo (origin: https://api.github.com)',
+  )
+  expect(startGroupCollapsed).toContain(
+    '[graphql] all (origin: https://api.github.com)',
+  )
+
+  const matchSuggestions = log.filter((message) => message.startsWith('Match:'))
+  expect(matchSuggestions).toHaveLength(1)
+  expect(matchSuggestions).toEqual([
+    'Match: https://mswjs.io/repl?path=https://test.mswjs.io/book/:bookId',
+  ])
+
+  const resolvers = log.filter((message) => message.startsWith('Resolver:'))
+  expect(resolvers).toHaveLength(6)
+
+  return runtime.cleanup()
+})
+
+test('respects runtime request handlers', async () => {
+  const runtime = await createRuntime()
+  const { messages } = captureConsole(runtime.page)
+
+  await runtime.page.evaluate(() => {
+    const { worker, rest, graphql } = window.msw
+    worker.use(
+      rest.post('/profile', () => null),
+      graphql.query('SubmitTransaction', () => null),
+    )
+
+    worker.printHandlers()
+  })
+
+  const { startGroupCollapsed, log } = messages
+
+  expect(startGroupCollapsed).toHaveLength(8)
+
+  expect(startGroupCollapsed).toContain('[rest] POST /profile')
+  expect(startGroupCollapsed).toContain(
+    '[graphql] query SubmitTransaction (origin: *)',
+  )
+
+  const matchSuggestions = log.filter((message) => message.startsWith('Match:'))
+  expect(matchSuggestions).toHaveLength(2)
+  expect(matchSuggestions).toContain(
+    'Match: https://mswjs.io/repl?path=/profile',
+  )
+
+  const resolvers = log.filter((message) => message.startsWith('Resolver:'))
+  expect(resolvers).toHaveLength(8)
+
+  return runtime.cleanup()
+})


### PR DESCRIPTION
## Changes

- Adds a new `.getMetaInfo()` method on a request handler object. Designed to return a publicly inspectable information about the handlers (i.e. mask, path, operation type, etc.)
- Adds a new `.list()` API to list currently active request handlers. Works for both browser and NodeJS API. 

## GitHub

- Fixes #310 

## Roadmap

- [x] Add browser integration tests
- [x] Come up with a more suitable API name than `.list()` (conflicts with auto-suggestions upon `server.listen`)
- [x] Consider if `getMetaInfo` should be a function, as its return data is static
- [x] Consider adding a matcher function for a given handler: pass actual URL string, see if it matches straight away
- [x] Exclude path matching REPL link for `graphql.*` request handlers (not supported on the web)