### PR TITLE
Implement virtual cookie store

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.0",
+    "@types/set-cookie-parser": "^2.4.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.2",
     "cookie": "^0.4.1",
@@ -71,6 +72,7 @@
     "node-fetch": "^2.6.1",
     "node-match-path": "^0.5.2",
     "node-request-interceptor": "^0.5.1",
+    "set-cookie-parser": "^2.4.6",
     "statuses": "^2.0.0",
     "yargs": "^16.0.3"
   },

--- a/src/cookie-store.ts
+++ b/src/cookie-store.ts
@@ -1,0 +1,18 @@
+import { Cookie } from 'set-cookie-parser'
+
+const cookieStore = new Map<string, Map<Cookie['name'], Omit<Cookie, 'name'>>>()
+
+const storedCookieStore = localStorage.getItem('_MSW_COOKIE_STORE')
+
+if (storedCookieStore) {
+  const parsedCookieStore: [
+    string,
+    [string, Omit<Cookie, 'name'>][],
+  ][] = JSON.parse(storedCookieStore)
+
+  parsedCookieStore.forEach(([origin, cookie]) =>
+    cookieStore.set(origin, new Map(cookie)),
+  )
+}
+
+export { cookieStore }

--- a/src/utils/request/getRequestCookies.ts
+++ b/src/utils/request/getRequestCookies.ts
@@ -1,8 +1,29 @@
 import * as cookieUtils from 'cookie'
+import { cookieStore } from '../../cookie-store'
 import { MockedRequest } from '../handlers/requestHandler'
 
-function getAllCookies() {
-  return cookieUtils.parse(document.cookie)
+function getVirtualCookies(origin: string) {
+  // @todo Respect the path of the cookies.
+  // @todo Make sure secure cookies are only appended for https domains.
+  // @todo Respect the SameSite attribute.
+  const cookies = cookieStore.get(origin)
+  const cookieEntries =
+    cookies === undefined ? [] : Array.from(cookies.entries())
+  const now = new Date()
+
+  return Object.fromEntries(
+    cookieEntries
+      .filter(([name, { expires }]) => {
+        if (expires !== undefined && expires < now) {
+          cookies?.delete(name)
+
+          return false
+        }
+
+        return true
+      })
+      .map(([name, { value }]) => [name, value]),
+  )
 }
 
 /**
@@ -13,12 +34,17 @@ export function getRequestCookies(req: MockedRequest) {
     case 'same-origin': {
       // Return document cookies only when requested a resource
       // from the same origin as the current document.
-      return location.origin === req.url.origin ? getAllCookies() : {}
+      return location.origin === req.url.origin
+        ? {
+            ...cookieUtils.parse(document.cookie),
+            ...getVirtualCookies(req.url.origin),
+          }
+        : {}
     }
 
     case 'include': {
       // Return all document cookies.
-      return getAllCookies()
+      return getVirtualCookies(req.url.origin)
     }
 
     default: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationDir": "lib/types",
-    "lib": ["es2017", "ESNext.AsyncIterable", "dom", "webworker"]
+    "lib": ["es2017", "ES2019.Object", "ESNext.AsyncIterable", "dom", "webworker"]
   },
   "include": ["global.d.ts", "src/**/*.ts"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
This PR is not really meant to be merged as is. It's just my quick and dirty implementation of a virtual cookie store. I only implemented what I needed for my specific use case. It does:

- store all cookies set by the mocked responses in memory
- scope cookies by origin
- add the appropriate cookies to each request depending on its `credentials` property
- delete expired cookies
- save cookies to local storage to make sure they survive a page reload

Given that the correct handling of cookies is very complex I think it would make sense to move all of this into a separate module. It could provide a virtual cookie store that has two methods which could have the following signature.

```ts
interface VirtualCookieStore {
    // This would add the appropriate cookies to a request.
    appendCookies(request: Request): void;

    // This would read cookies from the response to store them internally.
    storeCookies(request: Request, response: Response): void;
}
```