### PR TITLE
Declares and exports SetupServerApi interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as context from './context'
 
 export { setupWorker } from './setupWorker/setupWorker'
+export { SetupWorkerApi } from './setupWorker/glossary'
 export {
   response,
   defaultResponse,

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -11,10 +11,8 @@ import { getResponse } from '../utils/getResponse'
 import { parseBody } from '../utils/request/parseBody'
 import { isNodeProcess } from '../utils/internal/isNodeProcess'
 import * as requestHandlerUtils from '../utils/handlers/requestHandlerUtils'
-import { SharedOptions } from '../sharedOptions'
 import { onUnhandledRequest } from '../utils/request/onUnhandledRequest'
-
-type ListenOptions = SharedOptions
+import { ListenOptions, ServerInstance } from './glossary'
 
 const DEFAULT_LISTEN_OPTIONS: ListenOptions = {
   onUnhandledRequest: 'bypass',
@@ -28,7 +26,9 @@ export function createSetupServer(...interceptors: Interceptor[]) {
   /**
    * Sets up a server-side requests interception with the given mock definition.
    */
-  return function setupServer(...requestHandlers: RequestHandlersList) {
+  return function setupServer(
+    ...requestHandlers: RequestHandlersList
+  ): ServerInstance {
     requestHandlers.forEach((handler) => {
       if (Array.isArray(handler))
         throw new Error(
@@ -52,7 +52,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
       /**
        * Enables requests interception based on the previously provided mock definition.
        */
-      listen(options?: ListenOptions) {
+      listen(options?: ListenOptions): void {
         const resolvedOptions = Object.assign(
           {},
           DEFAULT_LISTEN_OPTIONS,
@@ -125,21 +125,21 @@ export function createSetupServer(...interceptors: Interceptor[]) {
       /**
        * Prepends given request handlers to the list of existing handlers.
        */
-      use(...handlers: RequestHandlersList) {
+      use(...handlers: RequestHandlersList): void {
         requestHandlerUtils.use(currentHandlers, ...handlers)
       },
 
       /**
        * Marks all request handlers that respond using `res.once()` as unused.
        */
-      restoreHandlers() {
+      restoreHandlers(): void {
         requestHandlerUtils.restoreHandlers(currentHandlers)
       },
 
       /**
        * Resets request handlers to the initial list given to the `setupServer` call, or to the explicit next request handlers list, if given.
        */
-      resetHandlers(...nextHandlers: RequestHandlersList) {
+      resetHandlers(...nextHandlers: RequestHandlersList): void {
         currentHandlers = requestHandlerUtils.resetHandlers(
           requestHandlers,
           ...nextHandlers,
@@ -149,7 +149,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
       /**
        * Stops requests interception by restoring all augmented modules.
        */
-      close() {
+      close(): void {
         interceptor.restore()
       },
     }

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -12,9 +12,10 @@ import { parseBody } from '../utils/request/parseBody'
 import { isNodeProcess } from '../utils/internal/isNodeProcess'
 import * as requestHandlerUtils from '../utils/handlers/requestHandlerUtils'
 import { onUnhandledRequest } from '../utils/request/onUnhandledRequest'
-import { ListenOptions, ServerInstance } from './glossary'
+import { SetupServerApi } from './glossary'
+import { SharedOptions } from '../sharedOptions'
 
-const DEFAULT_LISTEN_OPTIONS: ListenOptions = {
+const DEFAULT_LISTEN_OPTIONS: SharedOptions = {
   onUnhandledRequest: 'bypass',
 }
 
@@ -28,7 +29,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
    */
   return function setupServer(
     ...requestHandlers: RequestHandlersList
-  ): ServerInstance {
+  ): SetupServerApi {
     requestHandlers.forEach((handler) => {
       if (Array.isArray(handler))
         throw new Error(
@@ -49,10 +50,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
     let currentHandlers: RequestHandlersList = [...requestHandlers]
 
     return {
-      /**
-       * Enables requests interception based on the previously provided mock definition.
-       */
-      listen(options?: ListenOptions): void {
+      listen(options?: SharedOptions) {
         const resolvedOptions = Object.assign(
           {},
           DEFAULT_LISTEN_OPTIONS,
@@ -122,34 +120,22 @@ export function createSetupServer(...interceptors: Interceptor[]) {
         })
       },
 
-      /**
-       * Prepends given request handlers to the list of existing handlers.
-       */
-      use(...handlers: RequestHandlersList): void {
+      use(...handlers: RequestHandlersList) {
         requestHandlerUtils.use(currentHandlers, ...handlers)
       },
 
-      /**
-       * Marks all request handlers that respond using `res.once()` as unused.
-       */
-      restoreHandlers(): void {
+      restoreHandlers() {
         requestHandlerUtils.restoreHandlers(currentHandlers)
       },
 
-      /**
-       * Resets request handlers to the initial list given to the `setupServer` call, or to the explicit next request handlers list, if given.
-       */
-      resetHandlers(...nextHandlers: RequestHandlersList): void {
+      resetHandlers(...nextHandlers: RequestHandlersList) {
         currentHandlers = requestHandlerUtils.resetHandlers(
           requestHandlers,
           ...nextHandlers,
         )
       },
 
-      /**
-       * Stops requests interception by restoring all augmented modules.
-       */
-      close(): void {
+      close() {
         interceptor.restore()
       },
     }

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -50,7 +50,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
     let currentHandlers: RequestHandlersList = [...requestHandlers]
 
     return {
-      listen(options?: SharedOptions) {
+      listen(options) {
         const resolvedOptions = Object.assign(
           {},
           DEFAULT_LISTEN_OPTIONS,
@@ -120,7 +120,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
         })
       },
 
-      use(...handlers: RequestHandlersList) {
+      use(...handlers) {
         requestHandlerUtils.use(currentHandlers, ...handlers)
       },
 
@@ -128,7 +128,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
         requestHandlerUtils.restoreHandlers(currentHandlers)
       },
 
-      resetHandlers(...nextHandlers: RequestHandlersList) {
+      resetHandlers(...nextHandlers) {
         currentHandlers = requestHandlerUtils.resetHandlers(
           requestHandlers,
           ...nextHandlers,

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,0 +1,12 @@
+import { SharedOptions } from '../sharedOptions'
+import { RequestHandlersList } from '../setupWorker/glossary'
+
+export type ListenOptions = SharedOptions
+
+export interface ServerInstance {
+  listen: (options?: ListenOptions) => void
+  use: (...handlers: RequestHandlersList) => void
+  restoreHandlers: () => void
+  resetHandlers: (...nextHandlers: RequestHandlersList) => void
+  close: () => void
+}

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,12 +1,29 @@
 import { SharedOptions } from '../sharedOptions'
 import { RequestHandlersList } from '../setupWorker/glossary'
 
-export type ListenOptions = SharedOptions
+export interface SetupServerApi {
+  /**
+   * Enables requests interception based on the previously provided mock definition.
+   */
+  listen: (options?: SharedOptions) => void
 
-export interface ServerInstance {
-  listen: (options?: ListenOptions) => void
+  /**
+   * Prepends given request handlers to the list of existing handlers.
+   */
   use: (...handlers: RequestHandlersList) => void
+
+  /**
+   * Marks all request handlers that respond using `res.once()` as unused.
+   */
   restoreHandlers: () => void
+
+  /**
+   * Resets request handlers to the initial list given to the `setupServer` call, or to the explicit next request handlers list, if given.
+   */
   resetHandlers: (...nextHandlers: RequestHandlersList) => void
+
+  /**
+   * Stops requests interception by restoring all augmented modules.
+   */
   close: () => void
 }

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,1 +1,2 @@
 export { setupServer } from './setupServer'
+export { SetupServerApi } from './glossary'

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -3,6 +3,8 @@ import { RequestHandler } from '../utils/handlers/requestHandler'
 import { MockedResponse } from '../response'
 import { SharedOptions } from '../sharedOptions'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
+import { createStart } from './start/createStart'
+import { createStop } from './stop/createStop'
 
 export type Mask = RegExp | string
 export type ResolvedMask = Mask | URL
@@ -75,4 +77,23 @@ export type ResponseWithSerializedHeaders<BodyType = any> = Omit<
   'headers'
 > & {
   headers: HeadersList
+}
+export interface SetupWorkerApi {
+  start: ReturnType<typeof createStart>
+  stop: ReturnType<typeof createStop>
+
+  /**
+   * Prepends given request handlers to the list of existing handlers.
+   */
+  use: (...handlers: RequestHandlersList) => void
+
+  /**
+   * Marks all request handlers that respond using `res.once()` as unused.
+   */
+  restoreHandlers: () => void
+
+  /**
+   * Resets request handlers to the initial list given to the `setupWorker` call, or to the explicit next request handlers list, if given.
+   */
+  resetHandlers: (...nextHandlers: RequestHandlersList) => void
 }

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -78,6 +78,7 @@ export type ResponseWithSerializedHeaders<BodyType = any> = Omit<
 > & {
   headers: HeadersList
 }
+
 export interface SetupWorkerApi {
   start: ReturnType<typeof createStart>
   stop: ReturnType<typeof createStop>

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -1,29 +1,13 @@
-import { SetupWorkerInternalContext, RequestHandlersList } from './glossary'
+import {
+  SetupWorkerInternalContext,
+  RequestHandlersList,
+  SetupWorkerApi,
+} from './glossary'
 import { createStart } from './start/createStart'
 import { createStop } from './stop/createStop'
 import * as requestHandlerUtils from '../utils/handlers/requestHandlerUtils'
 import { isNodeProcess } from '../utils/internal/isNodeProcess'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
-
-export interface SetupWorkerApi {
-  start: ReturnType<typeof createStart>
-  stop: ReturnType<typeof createStop>
-
-  /**
-   * Prepends given request handlers to the list of existing handlers.
-   */
-  use: (...handlers: RequestHandlersList) => void
-
-  /**
-   * Marks all request handlers that respond using `res.once()` as unused.
-   */
-  restoreHandlers: () => void
-
-  /**
-   * Resets request handlers to the initial list given to the `setupWorker` call, or to the explicit next request handlers list, if given.
-   */
-  resetHandlers: (...nextHandlers: RequestHandlersList) => void
-}
 
 /**
  * Configures a Service Worker with the given request handler functions.

--- a/test/msw-api/setup-worker/resetHandlers.test.ts
+++ b/test/msw-api/setup-worker/resetHandlers.test.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
-import { rest } from 'msw'
+import { SetupWorkerApi, rest } from 'msw'
 import { runBrowserWith } from '../../support/runBrowserWith'
-import { SetupWorkerApi } from '../../../src/setupWorker/glossary'
 
 declare namespace window {
   // Annotate global references to the worker and rest request handlers.

--- a/test/msw-api/setup-worker/resetHandlers.test.ts
+++ b/test/msw-api/setup-worker/resetHandlers.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { rest } from 'msw'
 import { runBrowserWith } from '../../support/runBrowserWith'
-import { SetupWorkerApi } from '../../../src/setupWorker/setupWorker'
+import { SetupWorkerApi } from '../../../src/setupWorker/glossary'
 
 declare namespace window {
   // Annotate global references to the worker and rest request handlers.

--- a/test/msw-api/setup-worker/restoreHandlers.test.ts
+++ b/test/msw-api/setup-worker/restoreHandlers.test.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
-import { rest } from 'msw'
+import { SetupWorkerApi, rest } from 'msw'
 import { runBrowserWith } from '../../support/runBrowserWith'
-import { SetupWorkerApi } from '../../../src/setupWorker/glossary'
 
 declare namespace window {
   export const msw: {

--- a/test/msw-api/setup-worker/restoreHandlers.test.ts
+++ b/test/msw-api/setup-worker/restoreHandlers.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { rest } from 'msw'
 import { runBrowserWith } from '../../support/runBrowserWith'
-import { SetupWorkerApi } from '../../../src/setupWorker/setupWorker'
+import { SetupWorkerApi } from '../../../src/setupWorker/glossary'
 
 declare namespace window {
   export const msw: {

--- a/test/msw-api/setup-worker/use.test.ts
+++ b/test/msw-api/setup-worker/use.test.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
-import { rest } from 'msw'
+import { SetupWorkerApi, rest } from 'msw'
 import { runBrowserWith } from '../../support/runBrowserWith'
-import { SetupWorkerApi } from '../../../src/setupWorker/glossary'
 
 declare namespace window {
   // Annotate global references to the worker and rest request handlers.

--- a/test/msw-api/setup-worker/use.test.ts
+++ b/test/msw-api/setup-worker/use.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { rest } from 'msw'
 import { runBrowserWith } from '../../support/runBrowserWith'
-import { SetupWorkerApi } from '../../../src/setupWorker/setupWorker'
+import { SetupWorkerApi } from '../../../src/setupWorker/glossary'
 
 declare namespace window {
   // Annotate global references to the worker and rest request handlers.


### PR DESCRIPTION
## Description

Add a return type to the `setupServer` method.

### Why do we need this?
- Fixes https://github.com/mswjs/msw/issues/455

