### PR TITLE
Parses JSON req/res body if its content-type includes 'json'

### DIFF
--- a/src/utils/request/parseBody.test.ts
+++ b/src/utils/request/parseBody.test.ts
@@ -22,6 +22,17 @@ test('parses a body if the "Content-Type*/json" header is set', () => {
   })
 })
 
+test('parses a body if the "Content-Type:application/json; charset=UTF-8" header is set', () => {
+  expect(
+    parseBody(
+      `{"property":2}`,
+      new Headers({ 'Content-Type': 'application/json; charset=UTF-8' }),
+    ),
+  ).toEqual({
+    property: 2,
+  })
+})
+
 test('returns an invalid JSON body as-is even if the "Content-Type:*/json" header is set', () => {
   expect(
     parseBody('text-body', new Headers({ 'Content-Type': 'application/json' })),

--- a/src/utils/request/parseBody.ts
+++ b/src/utils/request/parseBody.ts
@@ -8,7 +8,7 @@ export function parseBody(body?: MockedRequest['body'], headers?: Headers) {
   if (body) {
     // If the intercepted request's body has a JSON Content-Type
     // parse it into an object, otherwise leave as-is.
-    const hasJsonContent = headers?.get('content-type')?.endsWith('json')
+    const hasJsonContent = headers?.get('content-type')?.includes('json')
 
     if (hasJsonContent && typeof body !== 'object') {
       return jsonParse(body) || body


### PR DESCRIPTION
This PR fixes #462. 

Version 0.22.0 added this [commit](https://github.com/mswjs/msw/commit/e6b60c0fbc467850ca3a4cbd117ad900bf19dd66) which changes the condition to parse the body.

So given the header:
```
Content-Type: application/json; charset=UTF-8
```

The body was not parsed.

This change rollback to the previous behaviour where we use `includes` instead of `endsWith`
