### PR TITLE
Supports async response transformers

### DIFF
--- a/src/context/body.test.ts
+++ b/src/context/body.test.ts
@@ -1,20 +1,9 @@
 import { body } from './body'
 import { response } from '../response'
 
-describe('body', () => {
-  describe('given a body value', () => {
-    let result: ReturnType<typeof response>
+test('sets a given body value without implicit "Content-Type" header', async () => {
+  const result = await response(body('Lorem ipsum'))
 
-    beforeAll(() => {
-      result = response(body('Lorem ipsum'))
-    })
-
-    it('should not have any "Content-Type" header set', () => {
-      expect(result.headers.get('content-type')).toBeNull()
-    })
-
-    it('should have body set to the given text', () => {
-      expect(result).toHaveProperty('body', 'Lorem ipsum')
-    })
-  })
+  expect(result).toHaveProperty('body', 'Lorem ipsum')
+  expect(result.headers.get('content-type')).toBeNull()
 })

--- a/src/context/cookie.node.test.ts
+++ b/src/context/cookie.node.test.ts
@@ -4,9 +4,7 @@
 import { cookie } from './cookie'
 import { response } from '../response'
 
-test('sets a cookie on the response headers, node environment', () => {
-  const result: ReturnType<typeof response> = response(
-    cookie('my-cookie', 'arbitrary-value'),
-  )
+test('sets a cookie on the response headers, node environment', async () => {
+  const result = await response(cookie('my-cookie', 'arbitrary-value'))
   expect(result.headers.get('set-cookie')).toEqual('my-cookie=arbitrary-value')
 })

--- a/src/context/cookie.test.ts
+++ b/src/context/cookie.test.ts
@@ -2,23 +2,12 @@ import * as cookieUtils from 'cookie'
 import { cookie } from './cookie'
 import { response } from '../response'
 
-describe('cookie', () => {
-  describe('given I set a cookie', () => {
-    let result: ReturnType<typeof response>
+test('sets a given cookie on the response', async () => {
+  const result = await response(cookie('my-cookie', 'arbitrary-value'))
 
-    beforeAll(() => {
-      result = response(cookie('my-cookie', 'arbitrary-value'))
-    })
+  expect(result.headers.get('set-cookie')).toEqual('my-cookie=arbitrary-value')
 
-    it('should be set on the response headers', () => {
-      expect(result.headers.get('set-cookie')).toEqual(
-        'my-cookie=arbitrary-value',
-      )
-    })
-
-    it('should set the cookie on "document.cookie"', () => {
-      const allCookies = cookieUtils.parse(document.cookie)
-      expect(allCookies).toHaveProperty('my-cookie', 'arbitrary-value')
-    })
-  })
+  // Propagates the response cookies on the document.
+  const allCookies = cookieUtils.parse(document.cookie)
+  expect(allCookies).toHaveProperty('my-cookie', 'arbitrary-value')
 })

--- a/src/context/data.test.ts
+++ b/src/context/data.test.ts
@@ -2,8 +2,8 @@ import { data } from './data'
 import { errors } from './errors'
 import { response } from '../response'
 
-test('sets a single data on the response JSON body', () => {
-  const result = response(data({ name: 'msw' }))
+test('sets a single data on the response JSON body', async () => {
+  const result = await response(data({ name: 'msw' }))
 
   expect(result.headers.get('content-type')).toBe('application/json')
   expect(result).toHaveProperty(
@@ -16,8 +16,8 @@ test('sets a single data on the response JSON body', () => {
   )
 })
 
-test('sets multiple data on the response JSON body', () => {
-  const result = response(
+test('sets multiple data on the response JSON body', async () => {
+  const result = await response(
     data({ name: 'msw' }),
     data({ description: 'API mocking library' }),
   )
@@ -34,8 +34,8 @@ test('sets multiple data on the response JSON body', () => {
   )
 })
 
-test('combines with error in the response JSON body', () => {
-  const result = response(
+test('combines with error in the response JSON body', async () => {
+  const result = await response(
     data({ name: 'msw' }),
     errors([
       {

--- a/src/context/delay.node.test.ts
+++ b/src/context/delay.node.test.ts
@@ -4,12 +4,12 @@
 import { delay, NODE_SERVER_RESPONSE_TIME } from './delay'
 import { response } from '../response'
 
-test('sets a NodeJS-specific response delay when not provided', () => {
-  const resolvedResponse = response(delay())
+test('sets a NodeJS-specific response delay when not provided', async () => {
+  const resolvedResponse = await response(delay())
   expect(resolvedResponse).toHaveProperty('delay', NODE_SERVER_RESPONSE_TIME)
 })
 
-test('allows response delay duration overrides', () => {
-  const resolvedResponse = response(delay(1234))
+test('allows response delay duration overrides', async () => {
+  const resolvedResponse = await response(delay(1234))
   expect(resolvedResponse).toHaveProperty('delay', 1234)
 })

--- a/src/context/delay.test.ts
+++ b/src/context/delay.test.ts
@@ -6,12 +6,12 @@
 import { delay, NODE_SERVER_RESPONSE_TIME } from './delay'
 import { response } from '../response'
 
-test('sets a NodeJS-specific response delay when not provided', () => {
-  const resolvedResponse = response(delay())
+test('sets a NodeJS-specific response delay when not provided', async () => {
+  const resolvedResponse = await response(delay())
   expect(resolvedResponse).toHaveProperty('delay', NODE_SERVER_RESPONSE_TIME)
 })
 
-test('allows response delay duration overrides', () => {
-  const resolvedResponse = response(delay(1234))
+test('allows response delay duration overrides', async () => {
+  const resolvedResponse = await response(delay(1234))
   expect(resolvedResponse).toHaveProperty('delay', 1234)
 })

--- a/src/context/errors.test.ts
+++ b/src/context/errors.test.ts
@@ -2,8 +2,8 @@ import { errors } from './errors'
 import { data } from './data'
 import { response } from '../response'
 
-test('sets a given error on the response JSON body', () => {
-  const result = response(errors([{ message: 'Error message' }]))
+test('sets a given error on the response JSON body', async () => {
+  const result = await response(errors([{ message: 'Error message' }]))
 
   expect(result.headers.get('content-type')).toEqual('application/json')
   expect(result).toHaveProperty(
@@ -18,8 +18,8 @@ test('sets a given error on the response JSON body', () => {
   )
 })
 
-test('sets given errors on the response JSON body', () => {
-  const result = response(
+test('sets given errors on the response JSON body', async () => {
+  const result = await response(
     errors([{ message: 'Error message' }, { message: 'Second error' }]),
   )
 
@@ -39,8 +39,8 @@ test('sets given errors on the response JSON body', () => {
   )
 })
 
-test('combines with data in the response JSON body', () => {
-  const result = response(
+test('combines with data in the response JSON body', async () => {
+  const result = await response(
     data({ name: 'msw' }),
     errors([{ message: 'exceeds the limit of awesomeness' }]),
   )
@@ -61,8 +61,8 @@ test('combines with data in the response JSON body', () => {
   )
 })
 
-test('bypasses undefined errors', () => {
-  const result = response(errors(undefined), errors(null))
+test('bypasses undefined errors', async () => {
+  const result = await response(errors(undefined), errors(null))
 
   expect(result.headers.get('content-type')).not.toEqual('application/json')
   expect(result).toHaveProperty('body', null)

--- a/src/context/fetch.test.ts
+++ b/src/context/fetch.test.ts
@@ -1,73 +1,33 @@
 import { augmentRequestInit } from './fetch'
 
-describe('augmentRequestInit', () => {
-  describe('given provided custom headers', () => {
-    describe('and headers is the instance of Headers', () => {
-      let result: ReturnType<typeof augmentRequestInit>
-      let headers: Headers
-
-      beforeAll(() => {
-        const init = {
-          headers: new Headers({ Authorization: 'token' }),
-        }
-
-        result = augmentRequestInit(init)
-        headers = new Headers(result.headers)
-      })
-
-      it('should preserve custom headers', () => {
-        expect(headers.get('Authorization')).toEqual('token')
-      })
-
-      it('should append "x-msw-bypass" header', () => {
-        expect(headers.get('x-msw-bypass')).toEqual('true')
-      })
-    })
-
-    describe('and headers is a string[][] object', () => {
-      let result: ReturnType<typeof augmentRequestInit>
-      let headers: Headers
-
-      beforeAll(() => {
-        const init = {
-          headers: [['Authorization', 'token']],
-        }
-
-        result = augmentRequestInit(init)
-        headers = new Headers(result.headers)
-      })
-
-      it('should append "x-msw-bypass" header', () => {
-        expect(headers.get('x-msw-bypass')).toEqual('true')
-      })
-
-      it('should preserve custom headers', () => {
-        expect(headers.get('authorization')).toEqual('token')
-      })
-    })
-
-    describe('and headers is a Record<string, string> object', () => {
-      let result: ReturnType<typeof augmentRequestInit>
-      let headers: Headers
-
-      beforeAll(() => {
-        const init = {
-          headers: {
-            Authorization: 'token',
-          },
-        }
-
-        result = augmentRequestInit(init)
-        headers = new Headers(result.headers)
-      })
-
-      it('should append "x-msw-bypass" header', () => {
-        expect(headers.get('x-msw-bypass')).toEqual('true')
-      })
-
-      it('should preserve custom headers', () => {
-        expect(headers.get('authorization')).toEqual('token')
-      })
-    })
+test('augments RequestInit with the Headers instance', () => {
+  const result = augmentRequestInit({
+    headers: new Headers({ Authorization: 'token' }),
   })
+  const headers = new Headers(result.headers)
+
+  expect(headers.get('Authorization')).toEqual('token')
+  expect(headers.get('x-msw-bypass')).toEqual('true')
+})
+
+test('augments RequestInit with the string[][] headers object', () => {
+  const result = augmentRequestInit({
+    headers: [['Authorization', 'token']],
+  })
+  const headers = new Headers(result.headers)
+
+  expect(headers.get('x-msw-bypass')).toEqual('true')
+  expect(headers.get('authorization')).toEqual('token')
+})
+
+test('aguments RequestInit with the Record<string, string> headers', () => {
+  const result = augmentRequestInit({
+    headers: {
+      Authorization: 'token',
+    },
+  })
+  const headers = new Headers(result.headers)
+
+  expect(headers.get('x-msw-bypass')).toEqual('true')
+  expect(headers.get('authorization')).toEqual('token')
 })

--- a/src/context/json.test.ts
+++ b/src/context/json.test.ts
@@ -1,34 +1,34 @@
 import { json } from './json'
 import { response } from '../response'
 
-test('sets response content type and body to the given JSON', () => {
-  const result = response(json({ firstName: 'John' }))
+test('sets response content type and body to the given JSON', async () => {
+  const result = await response(json({ firstName: 'John' }))
   expect(result.headers.get('content-type')).toEqual('application/json')
   expect(result).toHaveProperty('body', `{"firstName":"John"}`)
 })
 
-test('sets given Array as the response JSOn body', () => {
-  const result = response(json([1, '2', true, { ok: true }, '']))
+test('sets given Array as the response JSOn body', async () => {
+  const result = await response(json([1, '2', true, { ok: true }, '']))
   expect(result).toHaveProperty('body', `[1,"2",true,{"ok":true},""]`)
 })
 
-test('sets given string as the response JSON body', () => {
-  const result = response(json('some string'))
+test('sets given string as the response JSON body', async () => {
+  const result = await response(json('some string'))
   expect(result).toHaveProperty('body', `"some string"`)
 })
 
-test('sets given boolean as the response JSON body', () => {
-  const result = response(json(true))
+test('sets given boolean as the response JSON body', async () => {
+  const result = await response(json(true))
   expect(result).toHaveProperty('body', `true`)
 })
 
-test('sets given date as the response JSON body', () => {
-  const result = response(json(new Date(Date.UTC(2020, 0, 1))))
+test('sets given date as the response JSON body', async () => {
+  const result = await response(json(new Date(Date.UTC(2020, 0, 1))))
   expect(result).toHaveProperty('body', `"2020-01-01T00:00:00.000Z"`)
 })
 
-test('merges with an existing JSON body (shallow)', () => {
-  const result = response(
+test('merges with an existing JSON body (shallow)', async () => {
+  const result = await response(
     json({ firstName: 'John' }, { merge: true }),
     json({ lastName: 'Maverick' }, { merge: true }),
   )
@@ -39,8 +39,8 @@ test('merges with an existing JSON body (shallow)', () => {
   )
 })
 
-test('merges with an existing JSON body (deep)', () => {
-  const result = response(
+test('merges with an existing JSON body (deep)', async () => {
+  const result = await response(
     json(
       {
         firstName: 'John',

--- a/src/context/set.test.ts
+++ b/src/context/set.test.ts
@@ -1,39 +1,31 @@
 import { set } from './set'
 import { response } from '../response'
 
-describe('test', () => {
-  describe('given a single header', () => {
-    it('should set the header on the response', () => {
-      const { headers } = response(set('Content-Type', 'image/*'))
-      expect(headers.get('content-type')).toEqual('image/*')
-    })
-  })
+test('sets a single header', async () => {
+  const { headers } = await response(set('Content-Type', 'image/*'))
+  expect(headers.get('content-type')).toEqual('image/*')
+})
 
-  describe('given a single header with multiple values', () => {
-    it('should set the header with all the values on the response', () => {
-      const { headers } = response(
-        set({
-          Accept: ['application/json', 'image/png'],
-        }),
-      )
+test('sets a single header with multiple values', async () => {
+  const { headers } = await response(
+    set({
+      Accept: ['application/json', 'image/png'],
+    }),
+  )
 
-      expect(headers.get('accept')).toEqual('application/json, image/png')
-    })
-  })
+  expect(headers.get('accept')).toEqual('application/json, image/png')
+})
 
-  describe('given multiple headers', () => {
-    it('should set all the headers on the response', () => {
-      const { headers } = response(
-        set({
-          Accept: '*/*',
-          'Accept-Language': 'en',
-          'Content-Type': 'application/json',
-        }),
-      )
+test('sets multiple headers', async () => {
+  const { headers } = await response(
+    set({
+      Accept: '*/*',
+      'Accept-Language': 'en',
+      'Content-Type': 'application/json',
+    }),
+  )
 
-      expect(headers.get('accept')).toEqual('*/*')
-      expect(headers.get('accept-language')).toEqual('en')
-      expect(headers.get('content-type')).toEqual('application/json')
-    })
-  })
+  expect(headers.get('accept')).toEqual('*/*')
+  expect(headers.get('accept-language')).toEqual('en')
+  expect(headers.get('content-type')).toEqual('application/json')
 })

--- a/src/context/status.test.ts
+++ b/src/context/status.test.ts
@@ -1,14 +1,14 @@
 import { status } from './status'
 import { response } from '../response'
 
-test('sets given status code on the response', () => {
-  const result = response(status(403))
+test('sets given status code on the response', async () => {
+  const result = await response(status(403))
   expect(result).toHaveProperty('status', 403)
   expect(result).toHaveProperty('statusText', 'Forbidden')
 })
 
-test('supports custom status text', () => {
-  const result = response(status(301, 'Custom text'))
+test('supports custom status text', async () => {
+  const result = await response(status(301, 'Custom text'))
   expect(result).toHaveProperty('status', 301)
   expect(result).toHaveProperty('statusText', 'Custom text')
 })

--- a/src/context/text.test.ts
+++ b/src/context/text.test.ts
@@ -1,20 +1,9 @@
 import { text } from './text'
 import { response } from '../response'
 
-describe('text', () => {
-  describe('given a text body', () => {
-    let result: ReturnType<typeof response>
+test('sets a given text as the response body', async () => {
+  const result = await response(text('Lorem ipsum'))
 
-    beforeAll(() => {
-      result = response(text('Lorem ipsum'))
-    })
-
-    it('should have "Content-Type" as "text/plain"', () => {
-      expect(result.headers.get('content-type')).toEqual('text/plain')
-    })
-
-    it('should have body set to the given text', () => {
-      expect(result).toHaveProperty('body', 'Lorem ipsum')
-    })
-  })
+  expect(result.headers.get('content-type')).toEqual('text/plain')
+  expect(result).toHaveProperty('body', 'Lorem ipsum')
 })

--- a/src/context/xml.test.ts
+++ b/src/context/xml.test.ts
@@ -1,20 +1,9 @@
 import { xml } from './xml'
 import { response } from '../response'
 
-describe('xml', () => {
-  describe('given an XML string', () => {
-    let result: ReturnType<typeof response>
+test('sets a given XML as the response body', async () => {
+  const result = await response(xml('<firstName>John</firstName'))
 
-    beforeAll(() => {
-      result = response(xml('<firstName>John</firstName'))
-    })
-
-    it('should have "Content-Type" as "text/xml"', () => {
-      expect(result.headers.get('content-type')).toEqual('text/xml')
-    })
-
-    it('should have body set to the given XML', () => {
-      expect(result).toHaveProperty('body', '<firstName>John</firstName')
-    })
-  })
+  expect(result.headers.get('content-type')).toEqual('text/xml')
+  expect(result).toHaveProperty('body', '<firstName>John</firstName')
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,3 +37,6 @@ export {
   GraphQLRequestParsedResult,
 } from './graphql'
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'
+
+/* Utils */
+export { compose } from './utils/internal/compose'

--- a/src/response.ts
+++ b/src/response.ts
@@ -2,6 +2,9 @@ import { Headers } from 'headers-utils'
 import { compose } from './utils/internal/compose'
 import { NetworkError } from './utils/NetworkError'
 
+/**
+ * Internal representation of a mocked response instance.
+ */
 export interface MockedResponse<BodyType = any> {
   body: BodyType
   status: number
@@ -13,11 +16,11 @@ export interface MockedResponse<BodyType = any> {
 
 export type ResponseTransformer<BodyType = any> = (
   res: MockedResponse<BodyType>,
-) => MockedResponse<BodyType>
+) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
 
 export type ResponseFunction<BodyType = any> = (
   ...transformers: ResponseTransformer<BodyType>[]
-) => MockedResponse<BodyType>
+) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
 
 export type ResponseComposition<BodyType = any> = ResponseFunction<BodyType> & {
   /**
@@ -63,7 +66,7 @@ export function createResponseComposition<BodyType>(
     BodyType
   >[] = defaultResponseTransformers,
 ): ResponseFunction {
-  return (...transformers) => {
+  return async (...transformers) => {
     const initialResponse: MockedResponse = Object.assign(
       {},
       defaultResponse,

--- a/src/utils/internal/compose.test.ts
+++ b/src/utils/internal/compose.test.ts
@@ -1,6 +1,6 @@
 import { compose } from './compose'
 
-test('executes a list of given functions from right to left', () => {
+test('composes given functions from right to left', () => {
   const list: number[] = []
 
   const populateList = compose(
@@ -11,4 +11,14 @@ test('executes a list of given functions from right to left', () => {
   populateList()
 
   expect(list).toEqual([5, 7, 1])
+})
+
+test('composes a list of async functions from right to left', async () => {
+  const generateNumber = compose(
+    async (n) => n + 1,
+    async (n) => n * 5,
+  )
+  const number = await generateNumber(5)
+
+  expect(number).toEqual(26)
 })

--- a/src/utils/internal/compose.test.ts
+++ b/src/utils/internal/compose.test.ts
@@ -2,12 +2,12 @@ import { compose } from './compose'
 
 test('composes given functions from right to left', () => {
   const list: number[] = []
-
   const populateList = compose(
     () => list.push(1),
     () => list.push(7),
     () => list.push(5),
   )
+
   populateList()
 
   expect(list).toEqual([5, 7, 1])
@@ -15,8 +15,8 @@ test('composes given functions from right to left', () => {
 
 test('composes a list of async functions from right to left', async () => {
   const generateNumber = compose(
-    async (n) => n + 1,
-    async (n) => n * 5,
+    async (n: number) => n + 1,
+    async (n: number) => n * 5,
   )
   const number = await generateNumber(5)
 

--- a/src/utils/internal/compose.ts
+++ b/src/utils/internal/compose.ts
@@ -1,17 +1,31 @@
+type ArityOneFn = (arg: any) => any
+type PickLastInTuple<T extends any[]> = T extends [
+  ...rest: infer U,
+  argn: infer L,
+]
+  ? L
+  : never
+type FirstFnParameterType<T extends any[]> = Parameters<PickLastInTuple<T>>[any]
+type LastFnParameterType<T extends any[]> = ReturnType<T[0]>
+
 /**
  * Composes a given list of functions into a new function that
  * executes from right to left.
  */
-export function compose(...funcs: Array<(...args: any[]) => any>) {
-  return funcs.reduce((f, g) => {
-    return (...args: any[]) => {
-      const res = g(...args)
-
-      if (res instanceof Promise) {
-        return Promise.resolve(res).then(f)
-      }
-
-      return f(res)
-    }
-  })
+export function compose<
+  T extends ArityOneFn[],
+  LeftReturnType extends FirstFnParameterType<T>,
+  RightReturnType extends LastFnParameterType<T>
+>(
+  ...fns: T
+): (
+  ...args: LeftReturnType extends never ? never[] : [LeftReturnType]
+) => RightReturnType {
+  return (...args) => {
+    return fns.reduceRight((leftFn: any, rightFn) => {
+      return leftFn instanceof Promise
+        ? Promise.resolve(leftFn).then(rightFn)
+        : rightFn(leftFn)
+    }, args[0])
+  }
 }

--- a/src/utils/internal/compose.ts
+++ b/src/utils/internal/compose.ts
@@ -3,5 +3,15 @@
  * executes from right to left.
  */
 export function compose(...funcs: Array<(...args: any[]) => any>) {
-  return funcs.reduce((f, g) => (...args: any[]) => f(g(...args)))
+  return funcs.reduce((f, g) => {
+    return (...args: any[]) => {
+      const res = g(...args)
+
+      if (res instanceof Promise) {
+        return Promise.resolve(res).then(f)
+      }
+
+      return f(res)
+    }
+  })
 }

--- a/test/global.d.ts
+++ b/test/global.d.ts
@@ -1,0 +1,4 @@
+declare module 'url-loader!*' {
+  const content: string
+  export default content
+}

--- a/test/msw-api/context/async-response-transformer.mocks.ts
+++ b/test/msw-api/context/async-response-transformer.mocks.ts
@@ -1,0 +1,20 @@
+import { ResponseTransformer, setupWorker, rest, context, compose } from 'msw'
+import base64Image from 'url-loader!../../fixtures/image.jpg'
+
+async function jpeg(base64: string): Promise<ResponseTransformer> {
+  const buffer = await fetch(base64).then((res) => res.arrayBuffer())
+
+  return compose(
+    context.set('Content-Length', buffer.byteLength.toString()),
+    context.set('Content-Type', 'image/jpeg'),
+    context.body(buffer),
+  )
+}
+
+const worker = setupWorker(
+  rest.get('/image', async (req, res, ctx) => {
+    return res(ctx.status(201), await jpeg(base64Image))
+  }),
+)
+
+worker.start()

--- a/test/msw-api/context/async-response-transformer.mocks.ts
+++ b/test/msw-api/context/async-response-transformer.mocks.ts
@@ -1,4 +1,11 @@
-import { ResponseTransformer, setupWorker, rest, context, compose } from 'msw'
+import {
+  ResponseTransformer,
+  setupWorker,
+  rest,
+  context,
+  compose,
+  createResponseComposition,
+} from 'msw'
 import base64Image from 'url-loader!../../fixtures/image.jpg'
 
 async function jpeg(base64: string): Promise<ResponseTransformer> {
@@ -11,9 +18,23 @@ async function jpeg(base64: string): Promise<ResponseTransformer> {
   )
 }
 
+const customResponse = createResponseComposition(null, [
+  async (res) => {
+    res.statusText = 'Custom Status Text'
+    return res
+  },
+  async (res) => {
+    res.headers.set('x-custom', 'yes')
+    return res
+  },
+])
+
 const worker = setupWorker(
   rest.get('/image', async (req, res, ctx) => {
     return res(ctx.status(201), await jpeg(base64Image))
+  }),
+  rest.post('/search', (req, res, ctx) => {
+    return customResponse(ctx.status(301))
   }),
 )
 

--- a/test/msw-api/context/async-response-transformer.test.ts
+++ b/test/msw-api/context/async-response-transformer.test.ts
@@ -27,3 +27,25 @@ test('supports asynchronous response transformer', async () => {
 
   return runtime.cleanup()
 })
+
+test('supports asynchronous default response transformer', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'async-response-transformer.mocks.ts'),
+  )
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/search`,
+    fetchOptions: {
+      method: 'POST',
+    },
+  })
+  const status = res.status()
+  const statusText = res.statusText()
+  const headers = res.headers()
+
+  expect(status).toBe(301)
+  expect(statusText).toBe('Custom Status Text')
+  expect(headers).toHaveProperty('x-custom', 'yes')
+
+  return runtime.cleanup()
+})

--- a/test/msw-api/context/async-response-transformer.test.ts
+++ b/test/msw-api/context/async-response-transformer.test.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { runBrowserWith } from '../../support/runBrowserWith'
+
+test('supports asynchronous response transformer', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'async-response-transformer.mocks.ts'),
+  )
+
+  const res = await runtime.request({
+    url: `${runtime.origin}/image`,
+  })
+  const body = await res.buffer()
+  const expectedBuffer = fs.readFileSync(
+    path.resolve(__dirname, '../../fixtures/image.jpg'),
+  )
+  const status = res.status()
+  const headers = res.headers()
+
+  expect(status).toBe(201)
+  expect(headers).toHaveProperty('content-type', 'image/jpeg')
+  expect(headers).toHaveProperty(
+    'content-length',
+    expectedBuffer.byteLength.toString(),
+  )
+  expect(new Uint8Array(body)).toEqual(new Uint8Array(expectedBuffer))
+
+  return runtime.cleanup()
+})


### PR DESCRIPTION
## Changes

- Now it's possible to create async response transformers.
- Exports `compose` function publicly to compose multiple standard response transformers as a part of a custom response transformer.
- Adds browser integration tests for an async response transformer.
- Handles `response` calls as potentially async in unit tests.
- Aligns unit tests to be shallow (drops `describe` blocks).

## GitHub

- Closes #465 

## Roadmap

- [x] Annotate `compose` properly (infer function type, set return type)