### PR TITLE
fix: duplicate parameter in function with default parameter values

### DIFF
--- a/src/utils/request/onUnhandledRequest.ts
+++ b/src/utils/request/onUnhandledRequest.ts
@@ -11,10 +11,10 @@ export type OnUnhandledRequest =
 
 export function onUnhandledRequest(
   request: MockedRequest,
-  onUnhandledRequest: OnUnhandledRequest = 'bypass',
+  handler: OnUnhandledRequest = 'bypass',
 ): void {
-  if (typeof onUnhandledRequest === 'function') {
-    onUnhandledRequest(request)
+  if (typeof handler === 'function') {
+    handler(request)
     return
   }
 
@@ -30,7 +30,7 @@ export function onUnhandledRequest(
     return res(ctx.text('body'))
   })`
 
-  switch (onUnhandledRequest) {
+  switch (handler) {
     case 'error': {
       throw new Error(`[MSW] Error: ${message}`)
     }


### PR DESCRIPTION
**Summary**

When running a msw service worker with storybook in `Safari` I get the following error: `SyntaxError: Duplicate parameter 'onUnhandledRequest' not allowed in function with default parameter values.` It seems to be related to usage of the same function and parameter name with a default value in this [file](https://github.com/mswjs/msw/blob/e1656555e925d672b576e974716ad8e5e0a8aa18/src/utils/request/onUnhandledRequest.ts#L14). 

(For reference I found a similar type of issue in safari in another library https://github.com/jupyterlab/jupyterlab/pull/7993)