### PR TITLE
Updates README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,6 @@ test('handles login exception', () => {
 
 > **Tip:** Did you know that although the API is called `setupServer`, there are no actual servers established? The name is kept for familiarity, and API is designed to resemble operating with an actual server.
 
-## Using the library?
-
-Do you use `msw` at your company? [**Let us know**](https://twitter.com/compose/tweet?text=We%20are%20using%20@ApiMocking%20at%20%3CCOMPANY_NAME%3E%20and%20we%20love%20it!) and get your company's logo featured on [our website](https://mswjs.io) as a token of appreciation.
-
 ## Awards & Mentions
 
 <br />

--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@
   <a href="https://circleci.com/gh/mswjs/msw" target="_blank">
     <img src="https://img.shields.io/circleci/project/github/mswjs/msw/master.svg" alt="Build status" />
   </a>
-  <a href="https://david-dm.org/mswjs/msw" target="_blank">
-    <img src="https://img.shields.io/david/mswjs/msw.svg" alt="Dependencies status" />
+  <a href="https://www.npmjs.com/package/msw" target="_blank">
+    <img src="https://img.shields.io/npm/dw/msw" alt="Download rate" />
   </a>
-  <a href="https://david-dm.org/mswjs/msw?type=dev" target="_blank">
-    <img src="https://img.shields.io/david/dev/mswjs/msw.svg" alt="Dev dependencies status" />
-  </a>
+  <img alt="Libraries.io dependency status for latest release" src="https://img.shields.io/librariesio/release/npm/msw"/ >
    <a href="https://kcd.im/discord" target="_blank">
     <img src="https://img.shields.io/badge/chat-online-green" alt="Discord server" />
   </a>


### PR DESCRIPTION
## Changes

- Replaces David dependency badges with Libraries.io.
- Adds a weekly download rate badge.
- Removes company usage notice as we don't currently provide any sponsorship options for companies that would like to be featured on our website.