### PR TITLE
feat: add new recorder api

### DIFF
--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -153,6 +153,12 @@ ${bold(meta.header)}
       /**
        * Stops requests interception by restoring all augmented modules.
        */
+      removeAllHandlers() {
+        const handlers = currentHandlers
+        currentHandlers = []
+        return handlers
+      },
+
       close() {
         interceptor.restore()
       },

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,31 +1,11 @@
 import { SharedOptions } from '../sharedOptions'
-import { RequestHandlersList } from '../setupWorker/glossary'
+import { SetupApi } from '../setupWorker/glossary'
 
-export interface SetupServerApi {
+export interface SetupServerApi extends SetupApi {
   /**
    * Enables requests interception based on the previously provided mock definition.
    */
   listen: (options?: SharedOptions) => void
-
-  /**
-   * Prepends given request handlers to the list of existing handlers.
-   */
-  use: (...handlers: RequestHandlersList) => void
-
-  /**
-   * Marks all request handlers that respond using `res.once()` as unused.
-   */
-  restoreHandlers: () => void
-
-  /**
-   * Resets request handlers to the initial list given to the `setupServer` call, or to the explicit next request handlers list, if given.
-   */
-  resetHandlers: (...nextHandlers: RequestHandlersList) => void
-
-  /**
-   * Lists all active request handlers.
-   */
-  printHandlers: () => void
 
   /**
    * Stops requests interception by restoring all augmented modules.

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -5,7 +5,7 @@ import { SharedOptions } from '../sharedOptions'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
 import { createStart } from './start/createStart'
 import { createStop } from './stop/createStop'
-import { Recorder, ApiRecorder } from '../utils/Recorder'
+import { Recorder } from '../utils/Recorder'
 
 export type Mask = RegExp | string
 export type ResolvedMask = Mask | URL
@@ -13,7 +13,7 @@ export type ResolvedMask = Mask | URL
 export interface SetupWorkerInternalContext {
   worker: ServiceWorker | null
   registration: ServiceWorkerRegistration | null
-  requestHandlers: RequestHandler<any, any>[]
+  requestHandlers: RequestHandlersList
   keepAliveInterval?: number
   events: {
     /**
@@ -34,7 +34,6 @@ export interface SetupWorkerInternalContext {
      */
     once<T>(type: string): Promise<ServiceWorkerMessage<T>>
   }
-  recorder: Recorder
 }
 
 export type ServiceWorkerInstanceTuple = [
@@ -80,11 +79,7 @@ export type ResponseWithSerializedHeaders<BodyType = any> = Omit<
 > & {
   headers: HeadersList
 }
-
-export interface SetupWorkerApi {
-  start: ReturnType<typeof createStart>
-  stop: ReturnType<typeof createStop>
-
+export interface SetupApi {
   /**
    * Prepends given request handlers to the list of existing handlers.
    */
@@ -96,7 +91,7 @@ export interface SetupWorkerApi {
   restoreHandlers: () => void
 
   /**
-   * Resets request handlers to the initial list given to the `setupWorker` call, or to the explicit next request handlers list, if given.
+   * Resets request handlers to the initial list given to the `setupServer` call, or to the explicit next request handlers list, if given.
    */
   resetHandlers: (...nextHandlers: RequestHandlersList) => void
 
@@ -104,8 +99,19 @@ export interface SetupWorkerApi {
    * Lists all active request handlers.
    */
   printHandlers: () => void
+
+  /*
+   * Remove all handlers and return the list
+   */
+  removeAllHandlers: () => RequestHandlersList
+}
+
+export interface SetupWorkerApi extends SetupApi {
+  start: ReturnType<typeof createStart>
+  stop: ReturnType<typeof createStop>
+
   /**
    * Recorder API
    */
-  recorder: ApiRecorder
+  recorder: Recorder
 }

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -5,6 +5,7 @@ import { SharedOptions } from '../sharedOptions'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
 import { createStart } from './start/createStart'
 import { createStop } from './stop/createStop'
+import { Recorder, ApiRecorder } from '../utils/Recorder'
 
 export type Mask = RegExp | string
 export type ResolvedMask = Mask | URL
@@ -33,6 +34,7 @@ export interface SetupWorkerInternalContext {
      */
     once<T>(type: string): Promise<ServiceWorkerMessage<T>>
   }
+  recorder: Recorder
 }
 
 export type ServiceWorkerInstanceTuple = [
@@ -102,4 +104,8 @@ export interface SetupWorkerApi {
    * Lists all active request handlers.
    */
   printHandlers: () => void
+  /**
+   * Recorder API
+   */
+  recorder: ApiRecorder
 }

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -4,7 +4,7 @@ import { createStop } from './stop/createStop'
 import * as requestHandlerUtils from '../utils/handlers/requestHandlerUtils'
 import { isNodeProcess } from '../utils/internal/isNodeProcess'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
-import { Recorder, ApiRecorder } from '../utils/Recorder'
+import { Recorder } from '../utils/Recorder'
 export interface SetupWorkerApi {
   start: ReturnType<typeof createStart>
   stop: ReturnType<typeof createStop>
@@ -26,7 +26,7 @@ export interface SetupWorkerApi {
   /**
    * Record your APIS
    */
-  recorder: ApiRecorder
+  recorder: Recorder
 }
 
 interface Listener {
@@ -144,10 +144,6 @@ export function setupWorker(
       })
     },
 
-    recorder: {
-      record: () => recorder.record(),
-      getLogs: () => recorder.getLogs(),
-      stop: () => recorder.stop(),
-    },
+    recorder,
   }
 }

--- a/src/utils/Recorder.ts
+++ b/src/utils/Recorder.ts
@@ -33,16 +33,16 @@ async function createRecordFromRequest(
     if (hasJsonContent) {
       composeLines.push(`ctx.json(${body})`)
     } else {
-      composeLines.push(`ctx.body("${body}")`)
+      composeLines.push(`ctx.body(\`${body.replace(/`/g, '\\`')}\`)`)
     }
   }
 
   response.headers.forEach((value, key) => {
-    composeLines.push(`ctx.set('${key}', '${value}')`)
+    composeLines.push(`ctx.set('${key}', \`${value}\`)`)
   })
 
   lines.push(`return res(
-${composeLines.join(',\n')}
+${[...composeLines, `ctx.set('x-recorded-by', 'msw')`].join(',\n')}
   )`)
   lines.push(`})`)
   return {
@@ -79,7 +79,6 @@ class Recorder {
       ctx: typeof restContext,
     ) => {
       const response = await fetch(request)
-
       const log = await createRecordFromRequest(request, response)
       this._logs.push({
         function: log.function,

--- a/src/utils/Recorder.ts
+++ b/src/utils/Recorder.ts
@@ -26,11 +26,15 @@ async function createRecordFromRequest(
   composeLines.push(`ctx.status(${response.status})`)
   const body = await response.text()
 
-  const hasJsonContent = response.headers?.get('content-type')?.includes('json')
-  if (hasJsonContent) {
-    composeLines.push(`ctx.json(${body})`)
-  } else {
-    composeLines.push(`ctx.body("${body}")`)
+  if (body) {
+    const hasJsonContent = response.headers
+      ?.get('content-type')
+      ?.includes('json')
+    if (hasJsonContent) {
+      composeLines.push(`ctx.json(${body})`)
+    } else {
+      composeLines.push(`ctx.body("${body}")`)
+    }
   }
 
   response.headers.forEach((value, key) => {
@@ -92,6 +96,7 @@ class Recorder {
     this._mswInstance.use(rest.head('*', handleRequest))
     this._mswInstance.use(rest.options('*', handleRequest))
     this._mswInstance.use(rest.put('*', handleRequest))
+    this._mswInstance.use(rest.delete('*', handleRequest))
     this._isRecording = true
     this._logs = []
   }

--- a/src/utils/Recorder.ts
+++ b/src/utils/Recorder.ts
@@ -1,0 +1,83 @@
+import { MockedRequest } from './handlers/requestHandler'
+import { fetch } from '../context/fetch'
+
+async function createFunctionFromRequest(
+  request: MockedRequest,
+  response: Response,
+) {
+  const lines = []
+  const composeLines = []
+  lines.push(
+    `rest.${request.method.toLowerCase()}('${
+      request.url
+    }',function(req,res,ctx){`,
+  )
+
+  composeLines.push(`ctx.status(${response.status})`)
+  const body = await response.text()
+
+  const hasJsonContent = response.headers?.get('content-type')?.includes('json')
+  if (hasJsonContent) {
+    composeLines.push(`ctx.json(${body})`)
+  } else {
+    composeLines.push(`ctx.body(${body})`)
+  }
+
+  response.headers.forEach((value, key) => {
+    composeLines.push(`ctx.set('${key}', '${value}')`)
+  })
+
+  lines.push(`return res(
+${composeLines.join(',\n')}
+  )`)
+  lines.push(`})`)
+  return lines.join('\n')
+}
+
+class Recorder {
+  private isRecording: boolean
+  private logs: string[]
+  constructor() {
+    this.isRecording = false
+    this.logs = []
+  }
+
+  record() {
+    if (this.isRecording) {
+      return
+    }
+    this.isRecording = true
+    this.logs = []
+  }
+
+  _isRecording() {
+    return this.isRecording
+  }
+
+  async _handleRequest(request: MockedRequest) {
+    console.log(request)
+    const response = await fetch(request)
+
+    const log = await createFunctionFromRequest(request, response)
+
+    this.logs.push(log)
+    return response
+  }
+
+  getLogs() {
+    return [...this.logs]
+  }
+
+  stop() {
+    this.isRecording = false
+    return this.logs
+  }
+}
+
+type ApiRecorder = {
+  record: () => void
+  getLogs: () => string[]
+  stop: () => string[]
+}
+
+export { Recorder, ApiRecorder }

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -59,8 +59,7 @@ export const handleRequestWith = (
       if (type !== 'REQUEST') {
         return null
       }
-      console.log(recorder)
-      if (recorder._isRecording()) {
+      if (recorder.isRecording()) {
         const originalResponse = await recorder._handleRequest(req)
         return channel.send({
           type: 'MOCK_SUCCESS',

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -52,19 +52,11 @@ export const handleRequestWith = (
           return value
         },
       )
-      const { recorder } = context
       const { type, payload: req } = message
 
       // Ignore irrelevant worker message types
       if (type !== 'REQUEST') {
         return null
-      }
-      if (recorder.isRecording()) {
-        const originalResponse = await recorder._handleRequest(req)
-        return channel.send({
-          type: 'MOCK_SUCCESS',
-          payload: originalResponse,
-        })
       }
 
       // Parse the request's body based on the "Content-Type" header.

--- a/src/utils/handleRequestWith.ts
+++ b/src/utils/handleRequestWith.ts
@@ -52,12 +52,20 @@ export const handleRequestWith = (
           return value
         },
       )
-
+      const { recorder } = context
       const { type, payload: req } = message
 
       // Ignore irrelevant worker message types
       if (type !== 'REQUEST') {
         return null
+      }
+      console.log(recorder)
+      if (recorder._isRecording()) {
+        const originalResponse = await recorder._handleRequest(req)
+        return channel.send({
+          type: 'MOCK_SUCCESS',
+          payload: originalResponse,
+        })
       }
 
       // Parse the request's body based on the "Content-Type" header.

--- a/test/msw-api/setup-worker/recorder/record-requests.mocks.ts
+++ b/test/msw-api/setup-worker/recorder/record-requests.mocks.ts
@@ -1,0 +1,10 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker()
+
+worker.start()
+worker.use()
+// @ts-ignore
+window.__MSW__ = worker
+// @ts-ignore
+window.rest = rest

--- a/test/msw-api/setup-worker/recorder/record-requests.test.ts
+++ b/test/msw-api/setup-worker/recorder/record-requests.test.ts
@@ -34,6 +34,8 @@ test('should record GET request with object', async () => {
     return window.__MSW__.recorder.stop()
   })
 
+  expect(logs).toHaveLength(1)
+
   await runtime.page.evaluate((logs) => {
     // @ts-ignore
     return window.__MSW__.use(eval(logs[0].function))

--- a/test/msw-api/setup-worker/recorder/record-requests.test.ts
+++ b/test/msw-api/setup-worker/recorder/record-requests.test.ts
@@ -9,11 +9,22 @@ async function createRuntime() {
 
         return res.status(200).json({ name: 'John', surname: 'Maverick' }).end()
       })
+      app.post('/user', (req, res) => {
+        res.setHeader('x-recorder', 'true')
+
+        return res.status(201).json({ message: 'user created' }).end()
+      })
+      app.head('/info', (req, res) => {
+        res.setHeader('x-recorder', 'true')
+        res.setHeader('x-my-header', 'MSW')
+
+        return res.status(200).end()
+      })
     },
   })
 }
 
-test('should record GET request with object', async () => {
+test('should record GET request', async () => {
   const runtime = await createRuntime()
 
   await runtime.page.evaluate(() => {
@@ -52,6 +63,103 @@ test('should record GET request with object', async () => {
   expect(headers).toHaveProperty('x-recorder', 'true')
   expect(res.status()).toEqual(200)
   expect(body).toEqual({ name: 'John', surname: 'Maverick' })
+
+  return runtime.cleanup()
+})
+
+test('should record POST request', async () => {
+  const runtime = await createRuntime()
+
+  await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW__.recorder.record()
+  })
+
+  let res = await runtime.request({
+    url: `${runtime.origin}/user`,
+    fetchOptions: {
+      method: 'POST',
+    },
+  })
+
+  let headers = res.headers()
+
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+
+  const logs = await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW__.recorder.stop()
+  })
+
+  expect(logs).toHaveLength(1)
+
+  await runtime.page.evaluate((logs) => {
+    // @ts-ignore
+    return window.__MSW__.use(eval(logs[0].function))
+  }, logs)
+
+  res = await runtime.request({
+    url: `${runtime.origin}/user`,
+    fetchOptions: {
+      method: 'POST',
+    },
+  })
+
+  headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw,Express')
+  expect(headers).toHaveProperty('x-recorder', 'true')
+  expect(res.status()).toEqual(201)
+  expect(body).toEqual({ message: 'user created' })
+
+  return runtime.cleanup()
+})
+
+test('should record HEAD request', async () => {
+  const runtime = await createRuntime()
+
+  await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW__.recorder.record()
+  })
+
+  let res = await runtime.request({
+    url: `${runtime.origin}/info`,
+    fetchOptions: {
+      method: 'HEAD',
+    },
+  })
+
+  let headers = res.headers()
+
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+
+  const logs = await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW__.recorder.stop()
+  })
+
+  expect(logs).toHaveLength(1)
+
+  await runtime.page.evaluate((logs) => {
+    // @ts-ignore
+    return window.__MSW__.use(eval(logs[0].function))
+  }, logs)
+
+  res = await runtime.request({
+    url: `${runtime.origin}/info`,
+    fetchOptions: {
+      method: 'HEAD',
+    },
+  })
+
+  headers = res.headers()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw,Express')
+  expect(headers).toHaveProperty('x-recorder', 'true')
+  expect(headers).toHaveProperty('x-my-header', 'MSW')
+  expect(res.status()).toEqual(200)
 
   return runtime.cleanup()
 })

--- a/test/msw-api/setup-worker/recorder/record-requests.test.ts
+++ b/test/msw-api/setup-worker/recorder/record-requests.test.ts
@@ -1,0 +1,63 @@
+import * as path from 'path'
+import { runBrowserWith } from '../../../support/runBrowserWith'
+
+async function createRuntime() {
+  return runBrowserWith(path.resolve(__dirname, 'record-requests.mocks.ts'), {
+    withRoutes(app) {
+      app.get('/user', (req, res) => {
+        const { authorization } = req.headers
+
+        res.setHeader('x-recorder', 'true')
+
+        if (!authorization) {
+          return res.status(403).json({ message: 'error' }).end()
+        }
+
+        return res.status(200).json({ name: 'John', surname: 'Maverick' }).end()
+      })
+    },
+  })
+}
+
+test('should record GET request', async () => {
+  const runtime = await createRuntime()
+
+  await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW__.recorder.record()
+  })
+
+  let res = await runtime.request({
+    url: `${runtime.origin}/user`,
+  })
+
+  let headers = res.headers()
+
+  expect(headers).not.toHaveProperty('x-powered-by', 'msw')
+
+  const logs = await runtime.page.evaluate(() => {
+    // @ts-ignore
+    return window.__MSW__.recorder.stop()
+  })
+
+  await runtime.page.evaluate((logs) => {
+    // @ts-ignore
+    return window.__MSW__.use(eval(logs[0]))
+  }, logs)
+
+  res = await runtime.request({
+    url: `${runtime.origin}/user`,
+  })
+
+  headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw,Express')
+  expect(headers).toHaveProperty('x-recorder', 'true')
+  expect(res.status()).toEqual(403)
+  expect(body).toEqual({
+    message: 'error',
+  })
+
+  return runtime.cleanup()
+})

--- a/test/msw-api/setup-worker/recorder/record-requests.test.ts
+++ b/test/msw-api/setup-worker/recorder/record-requests.test.ts
@@ -5,13 +5,7 @@ async function createRuntime() {
   return runBrowserWith(path.resolve(__dirname, 'record-requests.mocks.ts'), {
     withRoutes(app) {
       app.get('/user', (req, res) => {
-        const { authorization } = req.headers
-
         res.setHeader('x-recorder', 'true')
-
-        if (!authorization) {
-          return res.status(403).json({ message: 'error' }).end()
-        }
 
         return res.status(200).json({ name: 'John', surname: 'Maverick' }).end()
       })
@@ -19,7 +13,7 @@ async function createRuntime() {
   })
 }
 
-test('should record GET request', async () => {
+test('should record GET request with object', async () => {
   const runtime = await createRuntime()
 
   await runtime.page.evaluate(() => {
@@ -54,10 +48,8 @@ test('should record GET request', async () => {
 
   expect(headers).toHaveProperty('x-powered-by', 'msw,Express')
   expect(headers).toHaveProperty('x-recorder', 'true')
-  expect(res.status()).toEqual(403)
-  expect(body).toEqual({
-    message: 'error',
-  })
+  expect(res.status()).toEqual(200)
+  expect(body).toEqual({ name: 'John', surname: 'Maverick' })
 
   return runtime.cleanup()
 })

--- a/test/msw-api/setup-worker/recorder/record-requests.test.ts
+++ b/test/msw-api/setup-worker/recorder/record-requests.test.ts
@@ -33,7 +33,7 @@ test('should record GET request', async () => {
 
   let headers = res.headers()
 
-  expect(headers).not.toHaveProperty('x-powered-by', 'msw')
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
 
   const logs = await runtime.page.evaluate(() => {
     // @ts-ignore

--- a/test/msw-api/setup-worker/recorder/record-requests.test.ts
+++ b/test/msw-api/setup-worker/recorder/record-requests.test.ts
@@ -36,7 +36,7 @@ test('should record GET request with object', async () => {
 
   await runtime.page.evaluate((logs) => {
     // @ts-ignore
-    return window.__MSW__.use(eval(logs[0]))
+    return window.__MSW__.use(eval(logs[0].function))
   }, logs)
 
   res = await runtime.request({


### PR DESCRIPTION
Hi guys,

I want to add this new feature. It's in draft and under development. 

### Goal
To use MSW the first thing to do is create `handlers`, so why not create a function to `record` responses from real APIs?

### How 
I have added in the `setupWorker` a new property `recorder`. You can:

1) `start`, start recording by using `worker.recorder.start()`. All your handlers will be paused until you called `stop` on the `recorder`. All intercepted handlers will be saved in a `logs` property of the `recorder`. All handlers are saved as `functions` so then you can copy and paste the code.

2) `stop`, stop recording by using `worker. recorder.stop()`. After that all your previous handlers will be restored.

3) `getLogs`, will return the list of functions for the latest recording.

### Readmap

- [ ] Create the new Recorder Class
- [ ] Support REST 
- [ ] Support graphql
- [ ] Support binary ( then the user will have a function with all the binary inside, I don't know if it is really useful ) 
- [ ] Add tests