### PR TITLE
ctx.data: Use "unknown" type instead of "any" type

### DIFF
--- a/src/context/data.ts
+++ b/src/context/data.ts
@@ -9,7 +9,7 @@ import { json } from './json'
  * res(ctx.data({ user: { firstName: 'John' }}))
  * @see {@link https://mswjs.io/docs/api/context/data `ctx.data()`}
  */
-export const data = <T extends Record<string, any>>(
+export const data = <T extends Record<string, unknown>>(
   payload: T,
 ): ResponseTransformer => {
   return (res) => {


### PR DESCRIPTION
In this case unknown would be a better type, since msw by itself doesn't care and users need to make clear what this is to use it.