### PR TITLE
export type, `RestContext`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,13 @@ export {
   ResponseResolverReturnType,
   AsyncResponseResolverReturnType,
 } from './utils/handlers/requestHandler'
-export { rest, restContext, RESTMethods, ParsedRestRequest } from './rest'
+export {
+  rest,
+  restContext,
+  RestContext,
+  RESTMethods,
+  ParsedRestRequest,
+} from './rest'
 export {
   graphql,
   graphqlContext,


### PR DESCRIPTION
I'd like to easily type a `ResponseResolver` — specifically in a rest context. Here's a contrived example of my current workaround:

```ts
import { MockedRequest, ResponseResolver, rest, restContext } from 'msw';
import { setupServer } from 'msw/node';

const server = setupServer();

// ...

function testSetup(
  // 🚨 This is how I'm currently forced to type this argument
  fetchListResolver: ResponseResolver<MockedRequest, typeof restContext>,
) {
  server.use(
    rest.get(
      '/api/list',
      fetchListResolver ?? ((req, res, ctx) => res(ctx.json(fixtures.list))),
    ),
  );

  // ...
}

// ...

test('empty list', () => {
  testSetup((req, res, ctx) => res(ctx.json([])));
});
```

Without the second generic being typed as `typeof restContext`, I get the following error:

```ts
const resolver: ResponseResolver = (req, res, ctx) => res(ctx.json([]));
//                                                            ^^^^
// Error: Property 'json' does not exist on type '...'
```

Setting aside the fact that I need to import `MockedRequest` and `RestContext` at all for now — as a quick stopgap, I'd prefer to use `RestContext` rather than `typeof restContext`. That would enable me to do something like the following:

```ts
import type * as msw from 'msw';

type RestResponseResolver = msw.ResponseResolver<msw.MockedRequest, msw.RestContext>;
```