### PR TITLE
fix: send null body and not empty string

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -200,7 +200,8 @@ If you wish to mock an error response, please refer to this guide: https://mswjs
             ok: clonedResponse.ok,
             status: clonedResponse.status,
             statusText: clonedResponse.statusText,
-            body: await clonedResponse.text(),
+            body:
+              clonedResponse.body === null ? null : await clonedResponse.text(),
             headers: serializeHeaders(clonedResponse.headers),
             redirected: clonedResponse.redirected,
           },

--- a/test/msw-api/life-cycle-events/regression/null-body.mocks.ts
+++ b/test/msw-api/life-cycle-events/regression/null-body.mocks.ts
@@ -6,8 +6,4 @@ const worker = setupWorker(
   }),
 )
 
-worker.on('response:mocked', async (res) => {
-  console.warn(`[response:mocked] ${res.body}`)
-})
-
 worker.start()

--- a/test/msw-api/life-cycle-events/regression/null-body.mocks.ts
+++ b/test/msw-api/life-cycle-events/regression/null-body.mocks.ts
@@ -1,0 +1,13 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('https://test.mswjs.io/api/books', (req, res, ctx) => {
+    return res(ctx.status(204))
+  }),
+)
+
+worker.on('response:mocked', async (res) => {
+  console.warn(`[response:mocked] ${res.body}`)
+})
+
+worker.start()

--- a/test/msw-api/life-cycle-events/regression/null-body.test.ts
+++ b/test/msw-api/life-cycle-events/regression/null-body.test.ts
@@ -1,0 +1,22 @@
+import * as path from 'path'
+import { runBrowserWith } from '../../../support/runBrowserWith'
+import { captureConsole } from '../../../support/captureConsole'
+import { sleep } from '../../../support/utils'
+
+function createRuntime() {
+  return runBrowserWith(path.resolve(__dirname, 'null-body.mocks.ts'))
+}
+
+test('lifecycle mothod should support null body', async () => {
+  const runtime = await createRuntime()
+  const { messages } = captureConsole(runtime.page)
+
+  await runtime.request({
+    url: 'https://test.mswjs.io/api/books',
+  })
+  await sleep(500)
+
+  expect(messages.warning).toEqual([`[response:mocked] null`])
+
+  return runtime.cleanup()
+})

--- a/test/msw-api/life-cycle-events/regression/null-body.test.ts
+++ b/test/msw-api/life-cycle-events/regression/null-body.test.ts
@@ -8,15 +8,19 @@ function createRuntime() {
 }
 
 test('lifecycle mothod should support null body', async () => {
+  let error
   const runtime = await createRuntime()
-  const { messages } = captureConsole(runtime.page)
+
+  runtime.page.on('pageerror', (err) => {
+    error = err
+  })
 
   await runtime.request({
     url: 'https://test.mswjs.io/api/books',
   })
   await sleep(500)
 
-  expect(messages.warning).toEqual([`[response:mocked] null`])
+  expect(error).not.toBeDefined()
 
   return runtime.cleanup()
 })


### PR DESCRIPTION
close #530

`response.text()` will return an empty string if the body is null. This will create some issues when for example the mocked response has a status 204 (no content). The event listener that will handle the response was creating a `Response` object with an empty string  instead of null.

