### PR TITLE
Support delay modes (ctx.delay)

### DIFF
--- a/src/context/delay.node.test.ts
+++ b/src/context/delay.node.test.ts
@@ -13,3 +13,28 @@ test('allows response delay duration overrides', async () => {
   const resolvedResponse = await response(delay(1234))
   expect(resolvedResponse).toHaveProperty('delay', 1234)
 })
+
+test('throws an exception given a too large duration', async () => {
+  const createErrorMessage = (value: any) => {
+    return `Failed to delay a response: provided delay duration (${value}) exceeds the maximum allowed duration for "setTimeout" (2147483647). This will cause the response to be returned immediately. Please use a number within the allowed range to delay the response by exact duration, or consider the "infinite" delay mode to delay the response indefinitely.`
+  }
+
+  const exceedingValues = [
+    Infinity,
+    Number.MAX_VALUE,
+    Number.MAX_SAFE_INTEGER,
+    2147483648,
+  ]
+
+  for (const value of exceedingValues) {
+    await expect(() => response(delay(value))).rejects.toThrow(
+      createErrorMessage(value),
+    )
+  }
+})
+
+test('throws an exception given an unknown delay mode', async () => {
+  await expect(() => response(delay('foo' as any))).rejects.toThrow(
+    'Failed to delay a response: unknown delay mode "foo". Please make sure you provide one of the supported modes ("real", "infinite") or a number to "ctx.delay".',
+  )
+})

--- a/src/context/delay.test.ts
+++ b/src/context/delay.test.ts
@@ -15,3 +15,28 @@ test('allows response delay duration overrides', async () => {
   const resolvedResponse = await response(delay(1234))
   expect(resolvedResponse).toHaveProperty('delay', 1234)
 })
+
+test('throws an exception given a too large duration', async () => {
+  const createErrorMessage = (value: any) => {
+    return `Failed to delay a response: provided delay duration (${value}) exceeds the maximum allowed duration for "setTimeout" (2147483647). This will cause the response to be returned immediately. Please use a number within the allowed range to delay the response by exact duration, or consider the "infinite" delay mode to delay the response indefinitely.`
+  }
+
+  const exceedingValues = [
+    Infinity,
+    Number.MAX_VALUE,
+    Number.MAX_SAFE_INTEGER,
+    2147483648,
+  ]
+
+  for (const value of exceedingValues) {
+    await expect(() => response(delay(value))).rejects.toThrow(
+      createErrorMessage(value),
+    )
+  }
+})
+
+test('throws an exception given an unknown delay mode', async () => {
+  await expect(() => response(delay('foo' as any))).rejects.toThrow(
+    'Failed to delay a response: unknown delay mode "foo". Please make sure you provide one of the supported modes ("real", "infinite") or a number to "ctx.delay".',
+  )
+})

--- a/src/context/delay.ts
+++ b/src/context/delay.ts
@@ -17,7 +17,7 @@ const getRandomServerResponseTime = () => {
   )
 }
 
-type DelayMode = 'real' | 'infinite'
+export type DelayMode = 'real' | 'infinite'
 
 /**
  * Delays the response by the given duration (ms).

--- a/src/context/delay.ts
+++ b/src/context/delay.ts
@@ -1,6 +1,7 @@
 import { ResponseTransformer } from '../response'
 import { isNodeProcess } from '../utils/internal/isNodeProcess'
 
+export const SET_TIMEOUT_MAX_ALLOWED_INT = 2147483647
 export const MIN_SERVER_RESPONSE_TIME = 100
 export const MAX_SERVER_RESPONSE_TIME = 400
 export const NODE_SERVER_RESPONSE_TIME = 5
@@ -16,16 +17,56 @@ const getRandomServerResponseTime = () => {
   )
 }
 
+type DelayMode = 'real' | 'infinite'
+
 /**
  * Delays the response by the given duration (ms).
  * @example
- * res(ctx.delay()) // realistic server response time
- * res(ctx.delay(1200))
+ * res(ctx.delay(1200)) // delay response by 1200ms
+ * res(ctx.delay()) // emilate realistic server response time
+ * res(ctx.delay('infinite')) // delay response infinitely
  * @see {@link https://mswjs.io/docs/api/context/delay `ctx.delay()`}
  */
-export const delay = (durationMs?: number): ResponseTransformer => {
+export const delay = (
+  durationOrMode?: DelayMode | number,
+): ResponseTransformer => {
   return (res) => {
-    res.delay = durationMs ?? getRandomServerResponseTime()
+    let delayTime: number
+
+    if (typeof durationOrMode === 'string') {
+      switch (durationOrMode) {
+        case 'infinite': {
+          // Using `Infinity` as a delay value executes the response timeout immediately.
+          // Instead, use the maximum allowed integer for `setTimeout`.
+          delayTime = SET_TIMEOUT_MAX_ALLOWED_INT
+          break
+        }
+        case 'real': {
+          delayTime = getRandomServerResponseTime()
+          break
+        }
+        default: {
+          throw new Error(
+            `Failed to delay a response: unknown delay mode "${durationOrMode}". Please make sure you provide one of the supported modes ("real", "infinite") or a number to "ctx.delay".`,
+          )
+        }
+      }
+    } else if (typeof durationOrMode === 'undefined') {
+      // Use random realistic server response time when no explicit delay duration was provided.
+      delayTime = getRandomServerResponseTime()
+    } else {
+      // Guard against passing values like `Infinity` or `Number.MAX_VALUE`
+      // as the response delay duration. They don't produce the result you may expect.
+      if (durationOrMode > SET_TIMEOUT_MAX_ALLOWED_INT) {
+        throw new Error(
+          `Failed to delay a response: provided delay duration (${durationOrMode}) exceeds the maximum allowed duration for "setTimeout" (${SET_TIMEOUT_MAX_ALLOWED_INT}). This will cause the response to be returned immediately. Please use a number within the allowed range to delay the response by exact duration, or consider the "infinite" delay mode to delay the response indefinitely.`,
+        )
+      }
+
+      delayTime = durationOrMode
+    }
+
+    res.delay = delayTime
     return res
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,3 +46,4 @@ export { matchRequestUrl } from './utils/matching/matchRequestUrl'
 
 /* Utils */
 export { compose } from './utils/internal/compose'
+export { DelayMode } from './context/delay'

--- a/test/msw-api/context/delay.mocks.ts
+++ b/test/msw-api/context/delay.mocks.ts
@@ -1,15 +1,12 @@
-import { setupWorker, rest } from 'msw'
+import { setupWorker, rest, DelayMode } from 'msw'
 
 const worker = setupWorker(
-  rest.get('/user', (req, res, ctx) => {
-    const delay = req.url.searchParams.get('delay')
-    const delayMs = delay ? Number(delay) : undefined
-
+  rest.get('/delay', (req, res, ctx) => {
+    const mode = req.url.searchParams.get('mode') as DelayMode
+    const duration = req.url.searchParams.get('duration')
     return res(
-      ctx.delay(delayMs),
-      ctx.json({
-        mocked: true,
-      }),
+      ctx.delay(duration ? Number(duration) : mode || undefined),
+      ctx.json({ mocked: true }),
     )
   }),
 )

--- a/test/msw-api/context/delay.test.ts
+++ b/test/msw-api/context/delay.test.ts
@@ -47,7 +47,7 @@ test('uses explicit server response delay', async () => {
   const runtime = await createRuntime()
   const startPerf = await performanceNow(runtime.page)
   const res = await runtime.request({
-    url: `${runtime.origin}/user?delay=1200`,
+    url: `${runtime.origin}/delay?duration=1200`,
   })
   const endPerf = await performanceNow(runtime.page)
 
@@ -65,11 +65,37 @@ test('uses explicit server response delay', async () => {
   return runtime.cleanup()
 })
 
-test('uses realistic server response delay, when not provided', async () => {
+test('uses realistic server response delay when no delay value is provided', async () => {
   const runtime = await createRuntime()
   const startPerf = await performanceNow(runtime.page)
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: `${runtime.origin}/delay`,
+  })
+  const endPerf = await performanceNow(runtime.page)
+
+  // Actual response time should lie within min/max boundaries
+  // of the random realistic response time.
+  const responseTime = endPerf - startPerf
+  expect(responseTime).toRoughlyEqual(250, 200)
+
+  const status = res.status()
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(status).toBe(200)
+  expect(body).toEqual({
+    mocked: true,
+  })
+
+  return runtime.cleanup()
+})
+
+test('uses realistic server response delay when "real" delay mode is provided', async () => {
+  const runtime = await createRuntime()
+  const startPerf = await performanceNow(runtime.page)
+  const res = await runtime.request({
+    url: `${runtime.origin}/delay?mode=real`,
   })
   const endPerf = await performanceNow(runtime.page)
 


### PR DESCRIPTION
## Motivation

Using `ctx.delay(Infinity)` executes the response timer immediately instead of delaying the response indefinitely, as expected. That's due to how `setTimeout` (that powers response callback to the worker) operates in JavaScript. These changes aim to add support for infinite response delays and add some safeguards against using large integers as the `ctx.delay` inpt. 

## Changes

- `ctx.delay` now supports delay modes—enums that abstract specific delay behaviors:
  - `real`, uses a random realistic server response time.
  - `infinite`, uses a maximum allowed integer as a `setTimeout` duration to delay a response indefinitely (useful when emulating pending/loading states).
- `ctx.delay` now throws an exception when given `Infinity`, `Number.MAX_VALUE`, `Number.MAX_SAFE_INTEGER`, or any integer value larger than the maximum allowed `setTimeout` duration.
- `ctx.delay` now throws an exception when given an unknown delay mode.

## Usage

```js
ctx.delay() // realistic response time
ctx.delay(500) // explicit response time
ctx.delay('real') // the same as `ctx.delay()`
ctx.delay('infinite') // infinite response time
```