### PR TITLE
Support an option for request body to be an object

### DIFF
--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -14,7 +14,10 @@ export const defaultContext = {
 }
 
 export type DefaultRequestBodyType = 
-  | Record<string, any> | string | any | undefined
+  | Record<string, any>
+  | string
+  | any
+  | undefined
 
 export interface MockedRequest<
   BodyType = DefaultRequestBodyType,

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -13,7 +13,8 @@ export const defaultContext = {
   fetch,
 }
 
-export type DefaultRequestBodyType = Record<string, any> | string | any | undefined
+export type DefaultRequestBodyType = 
+  | Record<string, any> | string | any | undefined
 
 export interface MockedRequest<
   BodyType = DefaultRequestBodyType,

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -13,7 +13,7 @@ export const defaultContext = {
   fetch,
 }
 
-export type DefaultRequestBodyType = Record<string, any> | string | undefined
+export type DefaultRequestBodyType = Record<string, any> | string | any | undefined
 
 export interface MockedRequest<
   BodyType = DefaultRequestBodyType,

--- a/src/utils/handlers/requestHandler.ts
+++ b/src/utils/handlers/requestHandler.ts
@@ -13,7 +13,7 @@ export const defaultContext = {
   fetch,
 }
 
-export type DefaultRequestBodyType = 
+export type DefaultRequestBodyType =
   | Record<string, any>
   | string
   | any


### PR DESCRIPTION
Since request body is parsed into an object if request is of type JSON, DefaultRequestBodyType needs to support this. Current workaround without having to explicitly cast to any is `rest.post<any, any>`, but should be supported by default type as well.