### PR TITLE
Annotates "msw" set on "window". Adds "runtime.makeUrl" utility

### DIFF
--- a/test/graphql-api/link.test.ts
+++ b/test/graphql-api/link.test.ts
@@ -142,7 +142,7 @@ test('bypasses a GraphQL operation to an unknown endpoint', async () => {
       },
     },
     {
-      uri: `${runtime.origin}/graphql`,
+      uri: runtime.makeUrl('/graphql'),
     },
   )
 

--- a/test/msw-api/context/async-response-transformer.test.ts
+++ b/test/msw-api/context/async-response-transformer.test.ts
@@ -8,7 +8,7 @@ test('supports asynchronous response transformer', async () => {
   )
 
   const res = await runtime.request({
-    url: `${runtime.origin}/image`,
+    url: runtime.makeUrl('/image'),
   })
   const body = await res.buffer()
   const expectedBuffer = fs.readFileSync(
@@ -34,7 +34,7 @@ test('supports asynchronous default response transformer', async () => {
   )
 
   const res = await runtime.request({
-    url: `${runtime.origin}/search`,
+    url: runtime.makeUrl('/search'),
     fetchOptions: {
       method: 'POST',
     },

--- a/test/msw-api/context/delay.test.ts
+++ b/test/msw-api/context/delay.test.ts
@@ -47,7 +47,7 @@ test('uses explicit server response delay', async () => {
   const runtime = await createRuntime()
   const startPerf = await performanceNow(runtime.page)
   const res = await runtime.request({
-    url: `${runtime.origin}/delay?duration=1200`,
+    url: runtime.makeUrl('/delay?duration=1200'),
   })
   const endPerf = await performanceNow(runtime.page)
 
@@ -69,7 +69,7 @@ test('uses realistic server response delay when no delay value is provided', asy
   const runtime = await createRuntime()
   const startPerf = await performanceNow(runtime.page)
   const res = await runtime.request({
-    url: `${runtime.origin}/delay`,
+    url: runtime.makeUrl('/delay'),
   })
   const endPerf = await performanceNow(runtime.page)
 
@@ -95,7 +95,7 @@ test('uses realistic server response delay when "real" delay mode is provided', 
   const runtime = await createRuntime()
   const startPerf = await performanceNow(runtime.page)
   const res = await runtime.request({
-    url: `${runtime.origin}/delay?mode=real`,
+    url: runtime.makeUrl('/delay?mode=real'),
   })
   const endPerf = await performanceNow(runtime.page)
 

--- a/test/msw-api/life-cycle-events/life-cycle-events.mocks.ts
+++ b/test/msw-api/life-cycle-events/life-cycle-events.mocks.ts
@@ -4,7 +4,7 @@ const worker = setupWorker(
   rest.get('/user', (req, res, ctx) => {
     return res(ctx.text('response-body'))
   }),
-  rest.post('/no-response', (req, res, ctx) => {
+  rest.post('/no-response', () => {
     return
   }),
 )
@@ -35,5 +35,8 @@ worker.on('response:bypass', (res, reqId) => {
 })
 
 worker.start()
+
 // @ts-ignore
-window.worker = worker
+window.msw = {
+  worker,
+}

--- a/test/msw-api/life-cycle-events/life-cycle-events.test.ts
+++ b/test/msw-api/life-cycle-events/life-cycle-events.test.ts
@@ -5,7 +5,9 @@ import { captureConsole } from '../../support/captureConsole'
 import { sleep } from '../../support/utils'
 
 declare namespace window {
-  export const worker: SetupWorkerApi
+  export const msw: {
+    worker: SetupWorkerApi
+  }
 }
 
 function createRuntime() {
@@ -91,7 +93,7 @@ test('stops emitting events once the worker is stopped', async () => {
   const endpointUrl = `${runtime.origin}/unknown-route`
 
   await runtime.page.evaluate(() => {
-    return window.worker.stop()
+    return window.msw.worker.stop()
   })
   await runtime.request({
     url: endpointUrl,

--- a/test/msw-api/life-cycle-events/life-cycle-events.test.ts
+++ b/test/msw-api/life-cycle-events/life-cycle-events.test.ts
@@ -24,7 +24,7 @@ function getRequestId(messages: ReturnType<typeof captureConsole>['messages']) {
 test('emits events for a handled request and mocked response', async () => {
   const runtime = await createRuntime()
   const { messages } = captureConsole(runtime.page)
-  const endpointUrl = `${runtime.origin}/user`
+  const endpointUrl = runtime.makeUrl('/user')
 
   await runtime.request({
     url: endpointUrl,
@@ -45,7 +45,7 @@ test('emits events for a handled request and mocked response', async () => {
 test('emits events for a handled request with no response', async () => {
   const runtime = await createRuntime()
   const { messages } = captureConsole(runtime.page)
-  const endpointUrl = `${runtime.origin}/no-response`
+  const endpointUrl = runtime.makeUrl('/no-response')
 
   await runtime.request({
     url: endpointUrl,
@@ -69,7 +69,7 @@ test('emits events for a handled request with no response', async () => {
 test('emits events for an unhandled request', async () => {
   const runtime = await createRuntime()
   const { messages } = captureConsole(runtime.page)
-  const endpointUrl = `${runtime.origin}/unknown-route`
+  const endpointUrl = runtime.makeUrl('/unknown-route')
 
   await runtime.request({
     url: endpointUrl,
@@ -90,7 +90,7 @@ test('emits events for an unhandled request', async () => {
 test('stops emitting events once the worker is stopped', async () => {
   const runtime = await createRuntime()
   const { messages } = captureConsole(runtime.page)
-  const endpointUrl = `${runtime.origin}/unknown-route`
+  const endpointUrl = runtime.makeUrl('/unknown-route')
 
   await runtime.page.evaluate(() => {
     return window.msw.worker.stop()

--- a/test/msw-api/setup-worker/printHandlers.test.ts
+++ b/test/msw-api/setup-worker/printHandlers.test.ts
@@ -4,7 +4,6 @@ import { runBrowserWith } from '../../support/runBrowserWith'
 import { captureConsole } from '../../support/captureConsole'
 
 declare namespace window {
-  // Annotate global references to the worker and rest request handlers.
   export const msw: {
     worker: SetupWorkerApi
     rest: typeof rest

--- a/test/msw-api/setup-worker/resetHandlers.test.ts
+++ b/test/msw-api/setup-worker/resetHandlers.test.ts
@@ -30,7 +30,7 @@ test('removes all runtime request handlers when resetting without explicit next 
 
   // Request handlers added on runtime affect the network communication.
   const loginResponse = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
     fetchOptions: {
       method: 'POST',
     },
@@ -49,7 +49,7 @@ test('removes all runtime request handlers when resetting without explicit next 
 
   // Any runtime request handlers are removed upon reset.
   const secondLoginResponse = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
     fetchOptions: {
       method: 'POST',
     },
@@ -59,7 +59,7 @@ test('removes all runtime request handlers when resetting without explicit next 
 
   // Initial request handlers (given to `setupWorker`) are not affected.
   const bookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const bookStatus = bookResponse.status()
   const bookBody = await bookResponse.json()
@@ -96,7 +96,7 @@ test('replaces all handlers with the explicit next runtime handlers upon reset',
 
   // Any runtime request handlers must be removed.
   const loginResponse = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
     fetchOptions: {
       method: 'POST',
     },
@@ -106,14 +106,14 @@ test('replaces all handlers with the explicit next runtime handlers upon reset',
 
   // Any initial request handler must be removed.
   const bookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const bookStatus = bookResponse.status()
   expect(bookStatus).toEqual(404)
 
   // Should leave only explicit reset request handlers.
   const productsResponse = await runtime.request({
-    url: `${runtime.origin}/products`,
+    url: runtime.makeUrl('/products'),
   })
   const productsStatus = productsResponse.status()
   const productsBody = await productsResponse.json()

--- a/test/msw-api/setup-worker/restoreHandlers.test.ts
+++ b/test/msw-api/setup-worker/restoreHandlers.test.ts
@@ -29,7 +29,7 @@ test('returns a mocked response from the used one-time request handler when rest
   // One-time request handler hasn't been used yet,
   // so expect its response upon first request hit.
   const bookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const bookStatus = bookResponse.status()
   const bookBody = await bookResponse.json()
@@ -39,7 +39,7 @@ test('returns a mocked response from the used one-time request handler when rest
   // One-time request handler has been used, so expect
   // the original response.
   const secondBookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const secondBookStatus = secondBookResponse.status()
   const secondBookBody = await secondBookResponse.json()
@@ -55,7 +55,7 @@ test('returns a mocked response from the used one-time request handler when rest
 
   // Once restored, one-time request handler affect network again.
   const thirdBookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const thirdBookStatus = thirdBookResponse.status()
   const thirdBookBody = await thirdBookResponse.json()

--- a/test/msw-api/setup-worker/scenarios/custom-transformers.test.ts
+++ b/test/msw-api/setup-worker/scenarios/custom-transformers.test.ts
@@ -8,7 +8,7 @@ test('uses a custom transformer to parse BigInt in response body', async () => {
   )
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
   })
   const body = await res.text()
 

--- a/test/msw-api/setup-worker/scenarios/fall-through.test.ts
+++ b/test/msw-api/setup-worker/scenarios/fall-through.test.ts
@@ -11,7 +11,7 @@ test('falls through all relevant request handlers until response is returned', a
   const { messages } = captureConsole(runtime.page)
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
   })
   const body = await res.json()
 
@@ -44,7 +44,7 @@ test('falls through all relevant handler even if none returns response', async (
   const { messages } = captureConsole(runtime.page)
 
   const res = await runtime.request({
-    url: `${runtime.origin}/blog/article`,
+    url: runtime.makeUrl('/blog/article'),
     fetchOptions: {
       method: 'POST',
     },

--- a/test/msw-api/setup-worker/scenarios/fall-through.test.ts
+++ b/test/msw-api/setup-worker/scenarios/fall-through.test.ts
@@ -15,26 +15,16 @@ test('falls through all relevant request handlers until response is returned', a
   })
   const body = await res.json()
 
-  const firstHandlerMessage = messages.log.find(
-    (text) => text === '[get] first',
-  )
-  const secondHandlerMessage = messages.log.find(
-    (text) => text === '[get] second',
-  )
-  const thirdHandlerMessage = messages.log.find(
-    (text) => text === '[get] third',
-  )
-
   // One of the handlers returns a mocked response.
   expect(body).toEqual({ firstName: 'John' })
 
   // These two handlers execute before the one that returned the response.
-  expect(firstHandlerMessage).toBeTruthy()
-  expect(secondHandlerMessage).toBeTruthy()
+  expect(messages.log).toContain('[get] first')
+  expect(messages.log).toContain('[get] second')
 
   // The third handler is listed after the one that returnes the response,
   // so it must never execute (response is sent).
-  expect(thirdHandlerMessage).toBeFalsy()
+  expect(messages.log).not.toContain('[get] third')
 
   await runtime.cleanup()
 })
@@ -53,16 +43,8 @@ test('falls through all relevant handler even if none returns response', async (
 
   // Neither of request handlers returned a mocked response.
   expect(status).toBe(404)
-
-  const firstHandlerMessage = messages.log.find(
-    (text) => text === '[post] first',
-  )
-  const secondHandlerMessage = messages.log.find(
-    (text) => text === '[post] second',
-  )
-
-  expect(firstHandlerMessage).toBeTruthy()
-  expect(secondHandlerMessage).toBeTruthy()
+  expect(messages.log).toContain('[post] first')
+  expect(messages.log).toContain('[post] second')
 
   await runtime.cleanup()
 })

--- a/test/msw-api/setup-worker/start/error.mocks.ts
+++ b/test/msw-api/setup-worker/start/error.mocks.ts
@@ -7,4 +7,6 @@ const worker = setupWorker(
 )
 
 // @ts-ignore
-window.__MSW_START__ = worker.start
+window.msw = {
+  worker,
+}

--- a/test/msw-api/setup-worker/start/error.test.ts
+++ b/test/msw-api/setup-worker/start/error.test.ts
@@ -1,6 +1,13 @@
 import * as path from 'path'
+import { SetupWorkerApi } from 'msw'
 import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorkerApi
+  }
+}
 
 let runtime: TestAPI
 
@@ -14,8 +21,7 @@ test('prints a custom error message when given a non-existing worker script', as
   const { messages } = captureConsole(runtime.page)
 
   await runtime.page.evaluate(() => {
-    // @ts-ignore
-    return window.window.__MSW_START__({
+    return window.msw.worker.start({
       serviceWorker: {
         url: 'invalidServiceWorker',
       },

--- a/test/msw-api/setup-worker/start/find-worker.error.mocks.ts
+++ b/test/msw-api/setup-worker/start/find-worker.error.mocks.ts
@@ -7,17 +7,20 @@ const worker = setupWorker(
 )
 
 // @ts-ignore
-window.__MSW_REGISTRATION__ = worker
-  .start({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    findWorker: (scriptURL, _mockServiceWorkerUrl) => {
-      return scriptURL.includes('some-bad-filename-that-does-not-exist.js')
-    },
-  })
-  .then((reg) => {
-    console.log('Registration Promise resolved')
-    return reg.constructor.name // This will throw as as there is no instance returned with a non-matching worker name
-  })
-  .catch((error) => {
-    console.error('Error - no worker instance after starting', error)
-  })
+window.msw = {
+  registration: worker
+    .start({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      findWorker: (scriptURL, _mockServiceWorkerUrl) => {
+        return scriptURL.includes('some-bad-filename-that-does-not-exist.js')
+      },
+    })
+    .then((reg) => {
+      console.log('Registration Promise resolved')
+      // This will throw as as there is no instance returned with a non-matching worker name.
+      return reg.constructor.name
+    })
+    .catch((error) => {
+      console.error('Error - no worker instance after starting', error)
+    }),
+}

--- a/test/msw-api/setup-worker/start/find-worker.mocks.ts
+++ b/test/msw-api/setup-worker/start/find-worker.mocks.ts
@@ -7,13 +7,16 @@ const worker = setupWorker(
 )
 
 // @ts-ignore
-window.__MSW_REGISTRATION__ = worker
-  .start({
-    // This is the default matching behavior if left unspecified
-    findWorker: (scriptURL, mockServiceWorkerUrl) =>
-      scriptURL === mockServiceWorkerUrl,
-  })
-  .then((reg) => {
-    console.log('Registration Promise resolved', reg)
-    return reg.constructor.name
-  })
+window.msw = {
+  registration: worker
+    .start({
+      // This is the default matching behavior if left unspecified.
+      findWorker(scriptURL, mockServiceWorkerUrl) {
+        return scriptURL === mockServiceWorkerUrl
+      },
+    })
+    .then((reg) => {
+      console.log('Registration Promise resolved', reg)
+      return reg.constructor.name
+    }),
+}

--- a/test/msw-api/setup-worker/start/find-worker.test.ts
+++ b/test/msw-api/setup-worker/start/find-worker.test.ts
@@ -1,9 +1,16 @@
 import * as path from 'path'
+import { SetupWorkerApi } from 'msw'
 import { runBrowserWith } from '../../../support/runBrowserWith'
 import {
   captureConsole,
   filterLibraryLogs,
 } from '../../../support/captureConsole'
+
+declare namespace window {
+  export const msw: {
+    registration: ReturnType<SetupWorkerApi['start']>
+  }
+}
 
 test('resolves the "start" Promise and returns a ServiceWorkerRegistration when using a findWorker that returns true', async () => {
   const runtime = await runBrowserWith(
@@ -11,8 +18,7 @@ test('resolves the "start" Promise and returns a ServiceWorkerRegistration when 
   )
 
   const resolvedPayload = await runtime.page.evaluate(() => {
-    // @ts-ignore
-    return window.__MSW_REGISTRATION__
+    return window.msw.registration
   })
 
   expect(resolvedPayload).toBe('ServiceWorkerRegistration')
@@ -44,8 +50,7 @@ test('fails to return a ServiceWorkerRegistration when using a findWorker that r
   )
 
   const resolvedPayload = await runtime.page.evaluate(() => {
-    // @ts-ignore
-    return window.__MSW_REGISTRATION__
+    return window.msw.registration
   })
 
   expect(resolvedPayload).toBe(undefined)

--- a/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
@@ -42,7 +42,7 @@ test('warns on an absolute unhandled request', async () => {
 test('warns on a relative unhandled request', async () => {
   const { messages } = captureConsole(runtime.page)
 
-  const url = `${runtime.origin}/user-details`
+  const url = runtime.makeUrl('/user-details')
   const res = await runtime.request({
     url,
   })

--- a/test/msw-api/setup-worker/start/options-sw-scope.test.ts
+++ b/test/msw-api/setup-worker/start/options-sw-scope.test.ts
@@ -16,12 +16,6 @@ afterAll(() => {
 
 test('respects a custom "scope" Service Worker option', async () => {
   const { messages } = captureConsole(runtime.page)
-
-  await runtime.page.evaluate(() => {
-    // @ts-ignore
-    return window.__MSW_REGISTRATION__
-  })
-
   await runtime.reload()
 
   const activationMessage = messages.startGroupCollapsed.find((text) => {

--- a/test/msw-api/setup-worker/start/options-sw-scope.test.ts
+++ b/test/msw-api/setup-worker/start/options-sw-scope.test.ts
@@ -24,7 +24,7 @@ test('respects a custom "scope" Service Worker option', async () => {
   expect(activationMessage).toBeTruthy()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
   })
   const status = res.status()
 

--- a/test/msw-api/setup-worker/start/quiet.mocks.ts
+++ b/test/msw-api/setup-worker/start/quiet.mocks.ts
@@ -12,7 +12,9 @@ const worker = setupWorker(
 )
 
 // @ts-ignore
-window.__MSW_REGISTRATION__ = worker.start({
-  // Disable logging of matched requests into browser's console
-  quiet: true,
-})
+window.msw = {
+  registration: worker.start({
+    // Disable logging of matched requests into browser's console
+    quiet: true,
+  }),
+}

--- a/test/msw-api/setup-worker/start/quiet.test.ts
+++ b/test/msw-api/setup-worker/start/quiet.test.ts
@@ -34,7 +34,7 @@ test('does not log the captured request when the "quiet" option is set to "true"
   expect(activationMessage).toBeFalsy()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
   })
 
   const headers = res.headers()

--- a/test/msw-api/setup-worker/start/quiet.test.ts
+++ b/test/msw-api/setup-worker/start/quiet.test.ts
@@ -1,6 +1,13 @@
 import * as path from 'path'
+import { SetupWorkerApi } from 'msw'
 import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
+
+declare namespace window {
+  export const msw: {
+    registration: ReturnType<SetupWorkerApi['start']>
+  }
+}
 
 let runtime: TestAPI
 
@@ -16,8 +23,7 @@ test('does not log the captured request when the "quiet" option is set to "true"
   const { messages } = captureConsole(runtime.page)
 
   await runtime.page.evaluate(() => {
-    // @ts-ignore
-    return window.__MSW_REGISTRATION__
+    return window.msw.registration
   })
 
   await runtime.reload()

--- a/test/msw-api/setup-worker/start/start.mocks.ts
+++ b/test/msw-api/setup-worker/start/start.mocks.ts
@@ -7,7 +7,9 @@ const worker = setupWorker(
 )
 
 // @ts-ignore
-window.__MSW_REGISTRATION__ = worker.start().then((reg) => {
-  console.log('Registration Promise resolved')
-  return reg.constructor.name
-})
+window.msw = {
+  registration: worker.start().then((reg) => {
+    console.log('Registration Promise resolved')
+    return reg.constructor.name
+  }),
+}

--- a/test/msw-api/setup-worker/start/start.test.ts
+++ b/test/msw-api/setup-worker/start/start.test.ts
@@ -1,6 +1,13 @@
 import * as path from 'path'
+import { SetupWorkerApi } from 'msw'
 import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
+
+declare namespace window {
+  export const msw: {
+    registration: ReturnType<SetupWorkerApi['start']>
+  }
+}
 
 let runtime: TestAPI
 
@@ -14,8 +21,7 @@ afterAll(() => {
 
 test('resolves the "start" Promise after the worker has been activated', async () => {
   const resolvedPayload = await runtime.page.evaluate(() => {
-    // @ts-ignore
-    return window.__MSW_REGISTRATION__
+    return window.msw.registration
   })
 
   expect(resolvedPayload).toBe('ServiceWorkerRegistration')

--- a/test/msw-api/setup-worker/start/wait-until-ready.error.mocks.ts
+++ b/test/msw-api/setup-worker/start/wait-until-ready.error.mocks.ts
@@ -11,7 +11,7 @@ const worker = setupWorker(
 
 worker.start({
   // Force an exception during Service Worker registration.
-  // @ts-ignore
+  // @ts-expect-error Providing invalid option value.
   serviceWorker: 'invalid-value',
 })
 

--- a/test/msw-api/setup-worker/stop.mocks.ts
+++ b/test/msw-api/setup-worker/stop.mocks.ts
@@ -9,4 +9,6 @@ const worker = setupWorker(
 worker.start()
 
 // @ts-ignore
-window.__mswStop = worker.stop
+window.msw = {
+  worker,
+}

--- a/test/msw-api/setup-worker/stop.test.ts
+++ b/test/msw-api/setup-worker/stop.test.ts
@@ -5,6 +5,7 @@ import {
   runBrowserWith,
   createRequestHelper,
 } from '../../support/runBrowserWith'
+import { sleep } from '../../support/utils'
 
 declare namespace window {
   export const msw: {
@@ -21,9 +22,7 @@ const stopWorkerOn = async (page: Page) => {
     return window.msw.worker.stop()
   })
 
-  return new Promise((resolve) => {
-    setTimeout(resolve, 1000)
-  })
+  return sleep(1000)
 }
 
 test('disables the mocking when the worker is stopped', async () => {

--- a/test/msw-api/setup-worker/stop.test.ts
+++ b/test/msw-api/setup-worker/stop.test.ts
@@ -1,9 +1,16 @@
 import * as path from 'path'
 import { Page } from 'puppeteer'
+import { SetupWorkerApi } from 'msw'
 import {
   runBrowserWith,
   createRequestHelper,
 } from '../../support/runBrowserWith'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorkerApi
+  }
+}
 
 function createRuntime() {
   return runBrowserWith(path.resolve(__dirname, 'stop.mocks.ts'))
@@ -11,8 +18,7 @@ function createRuntime() {
 
 const stopWorkerOn = async (page: Page) => {
   await page.evaluate(() => {
-    // @ts-ignore
-    return window.__mswStop()
+    return window.msw.worker.stop()
   })
 
   return new Promise((resolve) => {

--- a/test/msw-api/setup-worker/stop/removes-all-listeners.mocks.ts
+++ b/test/msw-api/setup-worker/stop/removes-all-listeners.mocks.ts
@@ -9,4 +9,6 @@ const createWorker = () => {
 }
 
 // @ts-ignore
-window.__MSW_CREATE_WORKER__ = createWorker
+window.msw = {
+  createWorker,
+}

--- a/test/msw-api/setup-worker/stop/removes-all-listeners.test.ts
+++ b/test/msw-api/setup-worker/stop/removes-all-listeners.test.ts
@@ -37,7 +37,7 @@ test.skip('removes all listeners when the worker is stopped', async () => {
   expect(activationMessages).toHaveLength(2)
 
   await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
   })
 
   const requestLogs = messages.startGroupCollapsed.filter((text) => {

--- a/test/msw-api/setup-worker/stop/removes-all-listeners.test.ts
+++ b/test/msw-api/setup-worker/stop/removes-all-listeners.test.ts
@@ -1,6 +1,13 @@
 import * as path from 'path'
+import { SetupWorkerApi } from 'msw'
 import { TestAPI, runBrowserWith } from '../../../support/runBrowserWith'
 import { captureConsole } from '../../../support/captureConsole'
+
+declare namespace window {
+  export const msw: {
+    createWorker(): SetupWorkerApi
+  }
+}
 
 let runtime: TestAPI
 
@@ -16,10 +23,8 @@ test.skip('removes all listeners when the worker is stopped', async () => {
   const { messages } = captureConsole(runtime.page)
 
   await runtime.page.evaluate(() => {
-    // @ts-ignore
-    const worker1 = window.window.__MSW_CREATE_WORKER__()
-    // @ts-ignore
-    const worker2 = window.window.__MSW_CREATE_WORKER__()
+    const worker1 = window.msw.createWorker()
+    const worker2 = window.msw.createWorker()
 
     return worker1.start().then(() => {
       worker1.stop()

--- a/test/msw-api/setup-worker/use.test.ts
+++ b/test/msw-api/setup-worker/use.test.ts
@@ -3,7 +3,6 @@ import { SetupWorkerApi, rest } from 'msw'
 import { runBrowserWith } from '../../support/runBrowserWith'
 
 declare namespace window {
-  // Annotate global references to the worker and rest request handlers.
   export const msw: {
     worker: SetupWorkerApi
     rest: typeof rest

--- a/test/msw-api/setup-worker/use.test.ts
+++ b/test/msw-api/setup-worker/use.test.ts
@@ -23,7 +23,7 @@ test('returns a mocked response from a runtime request handler upon match', asyn
   })
 
   const loginResponse = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
     fetchOptions: {
       method: 'POST',
     },
@@ -35,7 +35,7 @@ test('returns a mocked response from a runtime request handler upon match', asyn
 
   // Other request handlers are preserved, if there are no overlaps.
   const bookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const bookStatus = bookResponse.status()
   const bookBody = await bookResponse.json()
@@ -59,7 +59,7 @@ test('returns a mocked response from a persistent request handler override', asy
   })
 
   const bookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const bookStatus = bookResponse.status()
   const bookBody = await bookResponse.json()
@@ -67,7 +67,7 @@ test('returns a mocked response from a persistent request handler override', asy
   expect(bookBody).toEqual({ title: 'Permanent override' })
 
   const anotherBookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const anotherBookStatus = anotherBookResponse.status()
   const anotherBookBody = await anotherBookResponse.json()
@@ -91,7 +91,7 @@ test('returns a mocked response from a one-time request handler override only up
   })
 
   const bookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const bookStatus = bookResponse.status()
   const bookBody = await bookResponse.json()
@@ -99,7 +99,7 @@ test('returns a mocked response from a one-time request handler override only up
   expect(bookBody).toEqual({ title: 'One-time override' })
 
   const anotherBookResponse = await runtime.request({
-    url: `${runtime.origin}/book/abc-123`,
+    url: runtime.makeUrl('/book/abc-123'),
   })
   const anotherBookStatus = anotherBookResponse.status()
   const anotherBookBody = await anotherBookResponse.json()

--- a/test/msw-api/unregister.mocks.ts
+++ b/test/msw-api/unregister.mocks.ts
@@ -11,4 +11,6 @@ const worker = setupWorker(
 )
 
 // @ts-ignore
-window.__mswStart = worker.start
+window.msw = {
+  worker,
+}

--- a/test/msw-api/unregister.test.ts
+++ b/test/msw-api/unregister.test.ts
@@ -1,5 +1,13 @@
 import * as path from 'path'
+import { SetupWorkerApi } from 'msw'
 import { runBrowserWith } from '../support/runBrowserWith'
+import { sleep } from '../support/utils'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorkerApi
+  }
+}
 
 function createRuntime() {
   return runBrowserWith(path.resolve(__dirname, 'unregister.mocks.ts'))
@@ -8,12 +16,9 @@ function createRuntime() {
 test('unregisters itself when not prompted to be activated again', async () => {
   const runtime = await createRuntime()
   await runtime.page.evaluate(() => {
-    // @ts-ignore
-    return window.__mswStart()
+    return window.msw.worker.start()
   })
-  await new Promise((resolve) => {
-    setTimeout(resolve, 1000)
-  })
+  await sleep(1000)
 
   // Should have the mocking enabled.
   const firstResponse = await runtime.request({

--- a/test/rest-api/body-binary.test.ts
+++ b/test/rest-api/body-binary.test.ts
@@ -8,7 +8,7 @@ test('responds with a given binary body', async () => {
   )
 
   const res = await runtime.request({
-    url: `${runtime.origin}/images/abc-123`,
+    url: runtime.makeUrl('/images/abc-123'),
   })
   const status = res.status()
   const headers = res.headers()

--- a/test/rest-api/body.test.ts
+++ b/test/rest-api/body.test.ts
@@ -9,7 +9,7 @@ test('handles a GET request without a body', async () => {
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
   })
   const body = await res.json()
   expect(body).toEqual({ body: undefined })
@@ -21,7 +21,7 @@ test('handles a GET request without a body and "Content-Type: application/json" 
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
     fetchOptions: {
       headers: {
         'Content-Type': 'application/json',
@@ -38,7 +38,7 @@ test('handles a POST request with an explicit empty body', async () => {
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
     fetchOptions: {
       method: 'POST',
       body: '',
@@ -54,7 +54,7 @@ test('handles a POST request with a textual body', async () => {
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
     fetchOptions: {
       method: 'POST',
       body: 'text-body',
@@ -70,7 +70,7 @@ test('handles a POST request with a JSON body and "Content-Type: application/jso
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
     fetchOptions: {
       method: 'POST',
       headers: {

--- a/test/rest-api/cookies-request.test.ts
+++ b/test/rest-api/cookies-request.test.ts
@@ -16,7 +16,7 @@ test('returns all document cookies in "req.cookies" for "include" credentials', 
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
     fetchOptions: {
       credentials: 'include',
     },
@@ -39,7 +39,7 @@ test('returns all document cookies in "req.cookies" for "same-origin" credential
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
     fetchOptions: {
       credentials: 'same-origin',
     },
@@ -82,7 +82,7 @@ test('returns no cookies in "req.cookies" for "omit" credentials', async () => {
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
     fetchOptions: {
       credentials: 'omit',
     },

--- a/test/rest-api/cookies.test.ts
+++ b/test/rest-api/cookies.test.ts
@@ -10,7 +10,7 @@ test('allows setting cookies on the mocked response', async () => {
   const runtime = await createRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
   })
 
   const headers = res.headers()

--- a/test/rest-api/query-params-warning.test.ts
+++ b/test/rest-api/query-params-warning.test.ts
@@ -32,7 +32,7 @@ test('warns when a request handler URL contains a single query parameter', async
   expect(findQueryParametersWarning(messages.warning)).toBeUndefined()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user?id=123`,
+    url: runtime.makeUrl('/user?id=123'),
   })
   expect(res.status()).toBe(200)
 
@@ -56,7 +56,7 @@ test('warns when a request handler URL contains multiple query parameters', asyn
   expect(findQueryParametersWarning(messages.warning)).toBeUndefined()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/login?id=123`,
+    url: runtime.makeUrl('/login?id=123'),
     fetchOptions: {
       method: 'POST',
     },

--- a/test/rest-api/redirect.test.ts
+++ b/test/rest-api/redirect.test.ts
@@ -6,7 +6,7 @@ test('supports redirect in a mocked response', async () => {
     path.resolve(__dirname, 'redirect.mocks.ts'),
   )
   const res = await runtime.request({
-    url: `${runtime.origin}/login`,
+    url: runtime.makeUrl('/login'),
   })
 
   // Assert the original response returns redirect.
@@ -15,7 +15,7 @@ test('supports redirect in a mocked response', async () => {
   expect(res.status()).toBe(307)
 
   const redirectRes = await runtime.page.waitForResponse(
-    `${runtime.origin}/user`,
+    runtime.makeUrl('/user'),
   )
   const redirectStatus = redirectRes.status()
   const redirectHeaders = redirectRes.headers()

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -112,7 +112,7 @@ test('supports patching a HEAD request', async () => {
     },
     responsePredicate(res, url) {
       return (
-        match(`${runtime.origin}${url}`, res.url()).matches &&
+        match(runtime.makeUrl(url), res.url()).matches &&
         res.headers()['x-powered-by'] === 'msw'
       )
     },
@@ -143,7 +143,7 @@ test('supports patching a GET request', async () => {
     },
     responsePredicate(res, url) {
       return (
-        match(`${runtime.origin}${url}`, res.url()).matches &&
+        match(runtime.makeUrl(url), res.url()).matches &&
         res.headers()['x-powered-by'] === 'msw'
       )
     },
@@ -177,7 +177,7 @@ test('supports patching a POST request', async () => {
     },
     responsePredicate(res, url) {
       return (
-        match(`${runtime.origin}${url}`, res.url()).matches &&
+        match(runtime.makeUrl(url), res.url()).matches &&
         res.headers()['x-powered-by'] === 'msw'
       )
     },

--- a/test/rest-api/status.test.ts
+++ b/test/rest-api/status.test.ts
@@ -9,7 +9,7 @@ test('sets given status code on the mocked response', async () => {
   const runtime = await prepareRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/posts`,
+    url: runtime.makeUrl('/posts'),
   })
   const status = res.status()
   const statusText = res.statusText()
@@ -24,7 +24,7 @@ test('supports custom status text on the mocked response', async () => {
   const runtime = await prepareRuntime()
 
   const res = await runtime.request({
-    url: `${runtime.origin}/user`,
+    url: runtime.makeUrl('/user'),
   })
   const status = res.status()
   const statusText = res.statusText()


### PR DESCRIPTION
A long-awaited polishing and refactoring of the testing setup to improve the readability and quality of test suites. 

## Changes

- All integration tests that need to persist `msw` instance on `window` now do that in a standardized way: `window.msw`. Each test that references `window.msw` now has that property annotated, making those references type-safe.
- Adds `runtime.makeUrl()` utility function to replace `${runtime.origin}/${url}` notation in test.
- Tests that need a custom delay Promise now use the `sleep()` utility function instead of manually wrapping `setTimeout` in a Promise. 
- Uses `expect(messages[group]).toContain` where applicable, to produce a nicer diff upon a test failure. 