### PR TITLE
onUnhandledRequest: Uses "console.error" instead of throwing an exception

### DIFF
--- a/src/utils/request/onUnhandledRequest.ts
+++ b/src/utils/request/onUnhandledRequest.ts
@@ -32,11 +32,13 @@ export function onUnhandledRequest(
 
   switch (handler) {
     case 'error': {
-      throw new Error(`[MSW] Error: ${message}`)
+      console.error(`[MSW] Error: ${message}`)
+      break
     }
 
     case 'warn': {
       console.warn(`[MSW] Warning: ${message}`)
+      break
     }
 
     default:

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
@@ -20,10 +20,14 @@ afterAll(() => {
 })
 
 test('errors on unhandled request when using the "error" value', async () => {
+  jest.spyOn(console, 'error')
+
   const getResponse = () => fetch('https://test.mswjs.io')
 
-  await expect(getResponse()).rejects.toThrow(`\
-request to https://test.mswjs.io/ failed, reason: [MSW] Error: captured a GET https://test.mswjs.io/ request without a corresponding request handler.
+  await getResponse()
+
+  expect(console.error)
+    .toHaveBeenCalledWith(`[MSW] Error: captured a GET https://test.mswjs.io/ request without a corresponding request handler.
 
   If you wish to intercept this request, consider creating a request handler for it:
 


### PR DESCRIPTION
## GitHub

- Fixes #539
- Fixes #573 

## Changes

- `onUnhandledRequest: "error"` now prints a `console.error` message instead of throwing an exception. 