### PR TITLE
fix: add client guards in service worker

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -21,8 +21,13 @@ self.addEventListener('activate', async function (event) {
 })
 
 self.addEventListener('message', async function (event) {
+  if (!event.source.id) return
   const clientId = event.source.id
+
+  if (!event.currentTarget.clients) return
   const client = await event.currentTarget.clients.get(clientId)
+
+  if (!client) return
   const allClients = await self.clients.matchAll()
   const allClientIds = allClients.map((client) => client.id)
 

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -21,13 +21,18 @@ self.addEventListener('activate', async function (event) {
 })
 
 self.addEventListener('message', async function (event) {
-  if (!event.source.id) return
   const clientId = event.source.id
 
-  if (!event.currentTarget.clients) return
-  const client = await event.currentTarget.clients.get(clientId)
+  if (!clientId || !this.clients) {
+    return
+  }
 
-  if (!client) return
+  const client = await this.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
   const allClients = await self.clients.matchAll()
   const allClientIds = allClients.map((client) => client.id)
 

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -49,6 +49,11 @@ export function setupWorker(
           navigator.serviceWorker,
           'message',
           (event: MessageEvent) => {
+            // Avoid messages broadcasted from unrelated workers.
+            if (event.source !== context.worker) {
+              return
+            }
+
             const message = jsonParse<
               ServiceWorkerMessage<typeof eventType, any>
             >(event.data)


### PR DESCRIPTION
Closes #536


This PR adds guard clauses to prevent the service worker throwing errors when the client isn't found.
Making this a draft until we can reproduce the behavior in #536 