### PR TITLE
Skips "opaque" responses when handling life-cycle events

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -197,6 +197,7 @@ If you wish to mock an error response, please refer to this guide: https://mswjs
           type: 'RESPONSE',
           payload: {
             requestId,
+            type: clonedResponse.type,
             ok: clonedResponse.ok,
             status: clonedResponse.status,
             statusText: clonedResponse.statusText,

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -40,7 +40,10 @@ export interface ServiceWorkerIncomingRequest extends RequestWithoutMethods {
   body: string | undefined
 }
 
-export interface ServiceWorkerIncomingResponse extends Response {
+export type ServiceWorkerIncomingResponse = Pick<
+  Response,
+  'type' | 'ok' | 'status' | 'statusText' | 'body' | 'headers' | 'redirected'
+> & {
   requestId: string
 }
 

--- a/src/utils/worker/createResponseListener.ts
+++ b/src/utils/worker/createResponseListener.ts
@@ -21,7 +21,7 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
      * @see https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
      * @see https://github.com/mswjs/msw/issues/529
      */
-    if (responseJson.type.includes('opaque')) {
+    if (responseJson.type?.includes('opaque')) {
       return
     }
 

--- a/src/utils/worker/createResponseListener.ts
+++ b/src/utils/worker/createResponseListener.ts
@@ -12,14 +12,26 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
       ServiceWorkerIncomingEventsMap['RESPONSE']
     >,
   ) => {
-    const { payload } = message
-    const response = new Response(payload.body, payload)
+    const { payload: responseJson } = message
+
+    /**
+     * CORS requests with `mode: "no-cors"` result in "opaque" responses.
+     * That kind of responses cannot be manipulated in JavaScript due
+     * to the security considerations.
+     * @see https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
+     * @see https://github.com/mswjs/msw/issues/529
+     */
+    if (responseJson.type.includes('opaque')) {
+      return
+    }
+
+    const response = new Response(responseJson.body, responseJson)
     const isMockedResponse = response.headers.get('x-powered-by') === 'msw'
 
     if (isMockedResponse) {
-      context.emitter.emit('response:mocked', response, payload.requestId)
+      context.emitter.emit('response:mocked', response, responseJson.requestId)
     } else {
-      context.emitter.emit('response:bypass', response, payload.requestId)
+      context.emitter.emit('response:bypass', response, responseJson.requestId)
     }
   }
 }

--- a/test/rest-api/cors.mocks.ts
+++ b/test/rest-api/cors.mocks.ts
@@ -1,0 +1,5 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker()
+
+worker.start()

--- a/test/rest-api/cors.mocks.ts
+++ b/test/rest-api/cors.mocks.ts
@@ -3,10 +3,3 @@ import { setupWorker } from 'msw'
 const worker = setupWorker()
 
 worker.start()
-
-worker.on('response:mocked', (res) => {
-  console.log('[mocked]', res)
-})
-worker.on('response:bypass', (res) => {
-  console.log('[bypassed]', res)
-})

--- a/test/rest-api/cors.mocks.ts
+++ b/test/rest-api/cors.mocks.ts
@@ -1,5 +1,12 @@
-import { setupWorker, rest } from 'msw'
+import { setupWorker } from 'msw'
 
 const worker = setupWorker()
 
 worker.start()
+
+worker.on('response:mocked', (res) => {
+  console.log('[mocked]', res)
+})
+worker.on('response:bypass', (res) => {
+  console.log('[bypassed]', res)
+})

--- a/test/rest-api/cors.test.ts
+++ b/test/rest-api/cors.test.ts
@@ -1,0 +1,26 @@
+import * as path from 'path'
+import { runBrowserWith } from '../support/runBrowserWith'
+
+test('TKO a cors request', async () => {
+  const runtime = await runBrowserWith(path.resolve(__dirname, 'cors.mocks.ts'))
+
+  const errors = []
+  runtime.page.on('pageerror', (err) => {
+    errors.push(err)
+  })
+
+  await runtime.page.evaluate(() => {
+    const img = document.createElement('img')
+    img.src = 'https://via.placeholder.com/150'
+    const body = document.querySelector('body')
+    body.appendChild(img)
+  })
+
+  await sleep(2000)
+  expect(errors.length).toBe(0)
+  return runtime.cleanup()
+})
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/test/rest-api/cors.test.ts
+++ b/test/rest-api/cors.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { runBrowserWith } from '../support/runBrowserWith'
 
-test('TKO a cors request', async () => {
+test('handles a CORS request with an "opaque" response', async () => {
   const runtime = await runBrowserWith(path.resolve(__dirname, 'cors.mocks.ts'))
 
   const errors = []
@@ -10,17 +10,16 @@ test('TKO a cors request', async () => {
   })
 
   await runtime.page.evaluate(() => {
-    const img = document.createElement('img')
-    img.src = 'https://via.placeholder.com/150'
-    const body = document.querySelector('body')
-    body.appendChild(img)
+    const image = document.createElement('img')
+    image.src = 'https://via.placeholder.com/150'
+    document.body.appendChild(image)
+
+    return new Promise((resolve) => {
+      image.addEventListener('load', resolve)
+    })
   })
 
-  await sleep(2000)
-  expect(errors.length).toBe(0)
+  expect(errors).toEqual([])
+
   return runtime.cleanup()
 })
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}


### PR DESCRIPTION
## GitHub

- Fixes #529 

## Changes

- Response event handler now skips "opaque" responses (those originating from requests with `mode: "no-cors"`) based on their `response.type` value.
- Improves type annotation of the response object sent from the worker (it's only a partial representation of the `Response` type). 