### PR TITLE
Retrieves worker client from "ServiceWorkerGlobalScope" instead of "FetchEvent.target"

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -99,7 +99,7 @@ self.addEventListener('fetch', function (event) {
 
   event.respondWith(
     new Promise(async (resolve, reject) => {
-      const client = await event.target.clients.get(clientId)
+      const client = await this.clients.get(clientId)
 
       // Bypass mocking when the request client is not active.
       if (!client) {
@@ -190,7 +190,7 @@ If you wish to mock an error response, please refer to this guide: https://mswjs
       }
     })
       .then(async (response) => {
-        const client = await event.target.clients.get(clientId)
+        const client = await this.clients.get(clientId)
         const clonedResponse = response.clone()
 
         sendToClient(client, {


### PR DESCRIPTION
## GitHub

- Fixes #558

## Motivation

https://github.com/mswjs/msw/blob/af0dada2420a31d2dc17b4d3aeae55914c9ff205/src/mockServiceWorker.js#L193

`FetchEvent.target` equals `null` in Safari only. In other browsers `FetchEvent.target` equals `self` (ServiceWorkerGlobalScope) instance. Here's a snapshot of the entire "fetch" event scope in Safari:

<img width="841" alt="Screen Shot 2021-01-25 at 15 17 34" src="https://user-images.githubusercontent.com/14984911/105717548-8df26f80-5f20-11eb-85df-fa7f470f665d.png">

This pull request substitutes:

```diff
-event.target.clients.get(clientId)
+this.clients.get(clientId)
```

Since `clientId` comes from the `FetchEvent.clientId` and is persistent in all browsers, it matters little which ServiceWorker global scope resolves it. 