### PR TITLE
Uses explicit null as 204 response body when handling the "response" worker event

### DIFF
--- a/src/utils/worker/createResponseListener.ts
+++ b/src/utils/worker/createResponseListener.ts
@@ -25,7 +25,7 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
       return
     }
 
-    const response = new Response(responseJson.body, responseJson)
+    const response = new Response(responseJson.body || null, responseJson)
     const isMockedResponse = response.headers.get('x-powered-by') === 'msw'
 
     if (isMockedResponse) {

--- a/test/rest-api/204-response.test.ts
+++ b/test/rest-api/204-response.test.ts
@@ -1,0 +1,39 @@
+import * as path from 'path'
+import { ServerApi, createServer } from '@open-draft/test-server'
+import { runBrowserWith } from '../support/runBrowserWith'
+
+let server: ServerApi
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.get('/posts', (req, res) => {
+      return res.status(204).end()
+    })
+  })
+})
+
+afterAll(async () => {
+  await server.close()
+})
+
+test('handles a 204 status response without Response instance exceptions', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'basic.mocks.ts'),
+  )
+  let pageError: Error
+
+  runtime.page.on('pageerror', (error) => {
+    pageError = error
+  })
+
+  const res = await runtime.request({
+    url: server.http.makeUrl('/posts'),
+  })
+
+  // There must be no such exception:
+  // Failed to construct 'Response': Response with null body status cannot have body
+  expect(pageError).toBeUndefined()
+  expect(res.status()).toBe(204)
+
+  return runtime.cleanup()
+})


### PR DESCRIPTION
## Motivation

When handling a 204 status (actual) response, it's expected for it to have no body. However, there is no way to check if a response has no body given an arbitrary potentially 204 response:

```js
await potentially204Response.text() // "" (same as a response with the explicit "" response text)
await potentially204Response.body // ReadableStream, locked and cannot be read
```

Looks like we need a safe-guard on our side to prevent the construction of a `Response` instance with an empty string body in case of a 204 status response:

```js
new Response('', { status: 204 }) // Error
new Response(null, { status: 204 }) // OK
```

## Changes

- Uses `null` in case the response status is `204`, regardless of what its actual body is (in that case it's always `null`).
- Adds an integration test that asserts 204 status responses to be handled without page errors through the entire request/response life-cycle. 