### PR TITLE
build: validate types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "cross-env NODE_ENV=development rollup -c rollup.config.ts -w",
     "clean": "rimraf lib node/**/*.js",
     "lint": "eslint \"{cli,config,src,test}/**/*.ts\"",
-    "build": "yarn clean && cross-env NODE_ENV=production rollup -c rollup.config.ts",
+    "build": "yarn clean && tsc --noemit && cross-env NODE_ENV=production rollup -c rollup.config.ts",
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "cross-env BABEL_ENV=test jest --runInBand",
     "test:integration": "node --max_old_space_size=8000 node_modules/jest/bin/jest.js --config=test/jest.config.js --runInBand",

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -118,10 +118,10 @@ export interface SetupWorkerInternalContext {
      * Adds an event listener on the given target.
      * Returns a clean-up function that removes that listener.
      */
-    addListener<E extends Event>(
+    addListener(
       target: EventTarget,
       eventType: string,
-      listener: (event: E) => void,
+      listener: ((event: MessageEvent) => void) | EventListener,
     ): () => void
     /**
      * Removes all currently attached listeners.

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -76,13 +76,13 @@ export function setupWorker(
       addListener(
         target: EventTarget,
         eventType: string,
-        callback: EventListener,
+        listener: EventListener,
       ) {
-        target.addEventListener(eventType, callback)
-        listeners.push({ eventType, target, callback })
+        target.addEventListener(eventType, listener)
+        listeners.push({ eventType, target, callback: listener })
 
         return () => {
-          target.removeEventListener(eventType, callback)
+          target.removeEventListener(eventType, listener)
         }
       },
       removeAllListeners() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationDir": "lib/types",
+    "skipLibCheck": true,
     "lib": ["es2017", "ESNext.AsyncIterable", "dom", "webworker"]
   },
   "include": ["global.d.ts", "src/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,7 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationDir": "lib/types",
-    "skipLibCheck": true,
-    "lib": ["es2017", "ESNext.AsyncIterable", "dom", "webworker"]
+    "lib": ["es2017", "ESNext.AsyncIterable", "dom"]
   },
   "include": ["global.d.ts", "src/**/*.ts"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
From #577 (and #577 should be merged first to complete this PR)

It seems that the rollup plugin doesn't have an option to validate the types.
Some even created their [own plugin](https://github.com/ReactTraining/react-router/blob/dev/scripts/rollup/tsc-plugin.js) to make this work, which seemed like an overkill to me and something we don't want to maintain.

I started looking at `dtslint` and `tsd` to validate the types **after** the build but this had some drawbacks.
`dtslint`  expects a tsconfig at the root of the types.
For `tsd` we needed to copy-paste most of the `compilerOptions` `tsconfig` into our `package.json` and make some tweaks to the libs, and `tsd` also included the `node_modules` for some reason and there were also invalid types there...


Then I stumbled upon the `--noemit` option of `tsc` which does what it needs to do and is simple to implement and doesn't require an additional package. In this PR, we run `tsc` before the rollup build (without generating the output files).