### PR TITLE
Adds type checking for GraphQL data payload

### DIFF
--- a/src/context/data.ts
+++ b/src/context/data.ts
@@ -3,15 +3,15 @@ import { jsonParse } from '../utils/internal/jsonParse'
 import { mergeRight } from '../utils/internal/mergeRight'
 import { json } from './json'
 
+export type DataContext<T> = (payload: T) => ResponseTransformer
+
 /**
  * Sets a given payload as a GraphQL response body.
  * @example
  * res(ctx.data({ user: { firstName: 'John' }}))
  * @see {@link https://mswjs.io/docs/api/context/data `ctx.data()`}
  */
-export const data = <T extends Record<string, unknown>>(
-  payload: T,
-): ResponseTransformer => {
+export const data: DataContext<Record<string, unknown>> = (payload) => {
   return (res) => {
     const prevBody = jsonParse(res.body) || {}
     const nextBody = mergeRight(prevBody, { data: payload })

--- a/src/graphql.test-d.ts
+++ b/src/graphql.test-d.ts
@@ -1,0 +1,12 @@
+import { graphql } from './graphql'
+
+// @ts-expect-error
+graphql.query<{ key: string }, null>('', (req, res, ctx) => res(ctx.data({})))
+
+graphql.mutation<{ key: string }, null>('', (req, res, ctx) =>
+  // @ts-expect-error
+  res(ctx.data({})),
+)
+
+// @ts-expect-error
+graphql.operation<{ key: string }, null>((req, res, ctx) => res(ctx.data({})))

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -10,7 +10,7 @@ import { set } from './context/set'
 import { status } from './context/status'
 import { delay } from './context/delay'
 import { fetch } from './context/fetch'
-import { data } from './context/data'
+import { data, DataContext } from './context/data'
 import { errors } from './context/errors'
 
 /* Logging */
@@ -37,16 +37,16 @@ export type GraphQLMockedRequest<VariablesType = Record<string, any>> = Omit<
 // GraphQL related context should contain utility functions
 // useful for GraphQL. Functions like `xml()` bear no value
 // in the GraphQL universe.
-export interface GraphQLMockedContext {
+export interface GraphQLMockedContext<QueryType> {
   set: typeof set
   status: typeof status
   delay: typeof delay
   fetch: typeof fetch
-  data: typeof data
+  data: DataContext<QueryType>
   errors: typeof errors
 }
 
-export const graphqlContext: GraphQLMockedContext = {
+export const graphqlContext: GraphQLMockedContext<any> = {
   set,
   status,
   delay,
@@ -58,7 +58,7 @@ export const graphqlContext: GraphQLMockedContext = {
 export type GraphQLResponseResolver<QueryType, VariablesType> = (
   req: GraphQLMockedRequest<VariablesType>,
   res: ResponseComposition<any>,
-  context: GraphQLMockedContext,
+  context: GraphQLMockedContext<QueryType>,
 ) => AsyncResponseResolverReturnType<MockedResponse>
 
 export type GraphQLJSONRequestPayload<VariablesType> = {
@@ -140,7 +140,7 @@ function graphQLRequestHandler<QueryType, VariablesType = Record<string, any>>(
   resolver: GraphQLResponseResolver<QueryType, VariablesType>,
 ): RequestHandler<
   GraphQLMockedRequest<VariablesType>,
-  GraphQLMockedContext,
+  GraphQLMockedContext<QueryType>,
   GraphQLRequestParsedResult<VariablesType>
 > {
   const callFrame = getCallFrame()
@@ -313,7 +313,7 @@ const createGraphQLScopedHandler = (
     resolver: GraphQLResponseResolver<QueryType, VariablesType>,
   ): RequestHandler<
     GraphQLMockedRequest<VariablesType>,
-    GraphQLMockedContext,
+    GraphQLMockedContext<QueryType>,
     GraphQLRequestParsedResult<VariablesType>
   > => {
     return graphQLRequestHandler(
@@ -330,7 +330,7 @@ const createGraphQLOperationHandler = (mask: Mask) => {
     resolver: GraphQLResponseResolver<QueryType, VariablesType>,
   ): RequestHandler<
     GraphQLMockedRequest<VariablesType>,
-    GraphQLMockedContext,
+    GraphQLMockedContext<QueryType>,
     GraphQLRequestParsedResult<VariablesType>
   > => {
     return graphQLRequestHandler('all', new RegExp('.*'), mask, resolver)

--- a/src/utils/request/onUnhandledRequest.ts
+++ b/src/utils/request/onUnhandledRequest.ts
@@ -37,7 +37,7 @@ type RestRequestHandler = RequestHandler<
 
 type GraphQLRequestHandler = RequestHandler<
   GraphQLMockedRequest<any>,
-  GraphQLMockedContext,
+  GraphQLMockedContext<any>,
   GraphQLRequestParsedResult<any>
 >
 

--- a/test/graphql-api/link.mocks.ts
+++ b/test/graphql-api/link.mocks.ts
@@ -3,8 +3,28 @@ import { setupWorker, graphql } from 'msw'
 const github = graphql.link('https://api.github.com/graphql')
 const stripe = graphql.link('https://api.stripe.com/graphql')
 
+interface GetUserQuery {
+  user: {
+    id: string
+    username: string
+  }
+}
+
+interface PaymentQuery {
+  bankAccount: {
+    totalFunds: number
+  }
+}
+
+interface GetUserQuery {
+  user: {
+    id: string
+    username: string
+  }
+}
+
 const worker = setupWorker(
-  github.query('GetUser', (req, res, ctx) => {
+  github.query<GetUserQuery>('GetUser', (req, res, ctx) => {
     return res(
       ctx.data({
         user: {
@@ -14,7 +34,7 @@ const worker = setupWorker(
       }),
     )
   }),
-  stripe.mutation('Payment', (req, res, ctx) => {
+  stripe.mutation<PaymentQuery>('Payment', (req, res, ctx) => {
     return res(
       ctx.data({
         bankAccount: {
@@ -23,7 +43,7 @@ const worker = setupWorker(
       }),
     )
   }),
-  graphql.query('GetUser', (req, res, ctx) => {
+  graphql.query<GetUserQuery>('GetUser', (req, res, ctx) => {
     return res(
       ctx.set('x-request-handler', 'fallback'),
       ctx.data({

--- a/test/graphql-api/logging.mocks.ts
+++ b/test/graphql-api/logging.mocks.ts
@@ -1,7 +1,20 @@
 import { setupWorker, graphql } from 'msw'
 
+interface GetUserDetailQuery {
+  user: {
+    firstName: string
+    lastName: string
+  }
+}
+
+interface LoginQuery {
+  user: {
+    id: string
+  }
+}
+
 const worker = setupWorker(
-  graphql.query('GetUserDetail', (req, res, ctx) => {
+  graphql.query<GetUserDetailQuery>('GetUserDetail', (req, res, ctx) => {
     return res(
       ctx.data({
         user: {
@@ -11,7 +24,7 @@ const worker = setupWorker(
       }),
     )
   }),
-  graphql.mutation('Login', (req, res, ctx) => {
+  graphql.mutation<LoginQuery>('Login', (req, res, ctx) => {
     return res(
       ctx.data({
         user: {

--- a/test/graphql-api/mutation.mocks.ts
+++ b/test/graphql-api/mutation.mocks.ts
@@ -1,7 +1,13 @@
 import { setupWorker, graphql } from 'msw'
 
+interface LogoutQuery {
+  logout: {
+    userSession: boolean
+  }
+}
+
 const worker = setupWorker(
-  graphql.mutation('Logout', (req, res, ctx) => {
+  graphql.mutation<LogoutQuery>('Logout', (req, res, ctx) => {
     return res(
       ctx.data({
         logout: {

--- a/test/graphql-api/query.mocks.ts
+++ b/test/graphql-api/query.mocks.ts
@@ -1,7 +1,14 @@
 import { setupWorker, graphql } from 'msw'
 
+interface GetUserDetailQuery {
+  user: {
+    firstName: string
+    lastName: string
+  }
+}
+
 const worker = setupWorker(
-  graphql.query('GetUserDetail', (req, res, ctx) => {
+  graphql.query<GetUserDetailQuery>('GetUserDetail', (req, res, ctx) => {
     return res(
       ctx.data({
         user: {

--- a/test/graphql-api/response-patching.mocks.ts
+++ b/test/graphql-api/response-patching.mocks.ts
@@ -1,8 +1,15 @@
 import { setupWorker, graphql } from 'msw'
 import { createGraphQLClient, gql } from '../support/graphql'
 
+interface GetUserQuery {
+  user: {
+    firstName: string
+    lastName: string
+  }
+}
+
 const worker = setupWorker(
-  graphql.query('GetUser', async (req, res, ctx) => {
+  graphql.query<GetUserQuery>('GetUser', async (req, res, ctx) => {
     const originalResponse = await ctx.fetch(req)
     const originalJson = await originalResponse.json()
 

--- a/test/graphql-api/variables.mocks.ts
+++ b/test/graphql-api/variables.mocks.ts
@@ -1,44 +1,84 @@
 import { setupWorker, graphql } from 'msw'
 
+interface GetGitHubUserQuery {
+  user: {
+    username: string
+    firstName: string
+  }
+}
+
+interface GetGitHubUserQueryVariables {
+  username: string
+}
+
+interface DeletePostQuery {
+  deletePost: {
+    postId: string
+  }
+}
+
+interface DeletePostQueryVariables {
+  postId: string
+}
+
+interface GetActiveUserQuery {
+  user: {
+    id: number
+  }
+}
+
+interface GetActiveUserQueryVariables {
+  foo: string
+}
+
 const worker = setupWorker(
-  graphql.query('GetGithubUser', (req, res, ctx) => {
-    const { username } = req.variables
+  graphql.query<GetGitHubUserQuery, GetGitHubUserQueryVariables>(
+    'GetGithubUser',
+    (req, res, ctx) => {
+      const { username } = req.variables
 
-    return res(
-      ctx.data({
-        user: {
-          firstName: 'John',
-          username,
-        },
-      }),
-    )
-  }),
+      return res(
+        ctx.data({
+          user: {
+            username,
+            firstName: 'John',
+          },
+        }),
+      )
+    },
+  ),
 
-  graphql.mutation('DeletePost', (req, res, ctx) => {
-    const { postId } = req.variables
+  graphql.mutation<DeletePostQuery, DeletePostQueryVariables>(
+    'DeletePost',
+    (req, res, ctx) => {
+      const { postId } = req.variables
 
-    return res(
-      ctx.data({
-        deletePost: {
-          postId,
-        },
-      }),
-    )
-  }),
+      return res(
+        ctx.data({
+          deletePost: {
+            postId,
+          },
+        }),
+      )
+    },
+  ),
 
-  graphql.query('GetActiveUser', (req, res, ctx) => {
-    // Intentionally unused variable
-    // eslint-disable-next-line
-    const { foo } = req.variables
+  graphql.query<GetActiveUserQuery, GetActiveUserQueryVariables>(
+    'GetActiveUser',
+    (req, res, ctx) => {
+      // Intentionally unused variable
+      // eslint-disable-next-line
+      const { foo } = req.variables
 
-    return res(
-      ctx.data({
-        user: {
-          id: 1,
-        },
-      }),
-    )
-  }),
+      return res(
+        ctx.data({
+          user: {
+            id: 1,
+          },
+        }),
+      )
+    },
+  ),
 )
 
 worker.start()


### PR DESCRIPTION
Basically, this PR partially reverts changes to the types made in 8f989ef5fdc1680aac1d78f2e4d785ab93767bc1.

Moreover, I added `graphql.test-d.ts` file for type definition tests using [ts-expect-error](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments) which should help to ensure that graphql data response will not be broken by other refactorings in the future. Unfortunately, type checking (such as `tsc --noEmit`) is not a part of build pipeline at the moment, and, thus, the added tests will not stop build even if they are broken. However, this should be fixed by #579. But for now, they are only useful for TS errors in IDE. Let me know if you think that it does not make sense to have them in this PR and I will remove them.

- Closes #555
- Closes #574 (duplicate).