### PR TITLE
tests(iframe): Load the mocks in a nested iframe

### DIFF
--- a/test/msw-api/setup-worker/scenarios/iframe.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe.mocks.ts
@@ -6,9 +6,15 @@ const worker = setupWorker(
   }),
 )
 
-worker.start()
-
-// Append an iframe to the body and issue a request from it.
-const iframe = document.createElement('iframe')
-iframe.setAttribute('src', '/test/fixtures/iframe.html')
-document.body.appendChild(iframe)
+// @ts-ignore
+window.msw = {
+  worker,
+  name: 'what',
+  createIframe: (id: string, src: string) => {
+    // Append an iframe to the body and issue a request from it.
+    const iframe = document.createElement('iframe')
+    iframe.id = id
+    iframe.setAttribute('src', src)
+    document.body.appendChild(iframe)
+  },
+}

--- a/test/msw-api/setup-worker/scenarios/iframe.test.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe.test.ts
@@ -1,25 +1,48 @@
 import * as path from 'path'
+import { captureConsole } from '../../../support/captureConsole'
 import { runBrowserWith } from '../../../support/runBrowserWith'
 
 declare namespace window {
   export const request: () => Promise<any>
+  export const location: {
+    href: string
+  }
+  export const msw: {
+    createIframe: (id: string, src: string) => any
+    worker: {
+      start: () => any
+    }
+  }
 }
 
 test('intercepts a request made in an iframe (nested client)', async () => {
   const runtime = await runBrowserWith(
     path.resolve(__dirname, 'iframe.mocks.ts'),
   )
+  const { messages } = captureConsole(runtime.page)
 
-  const frame = runtime.page
-    .mainFrame()
-    .childFrames()
-    .find((frame) => frame.name() === '')
+  runtime.page.evaluate(() => {
+    window.msw.createIframe('middle', window.location.href)
+  })
 
-  await frame.evaluate(() => window.request())
-  const firstNameElement = await frame.waitForSelector('#first-name')
+  const middle = await runtime.page.waitForSelector('#middle')
+  const middleFrame = await middle.contentFrame()
+  await middleFrame.waitForSelector('h2')
+
+  await middleFrame.evaluate(() => {
+    window.msw.worker.start()
+    window.msw.createIframe('iframe', '/test/fixtures/iframe.html')
+  })
+
+  const iframe = await middleFrame.waitForSelector('#iframe')
+  const childFrame = await iframe.contentFrame()
+  await childFrame.evaluate(() => window.request())
+
+  const firstNameElement = await childFrame.waitForSelector('#first-name')
   const firstName = await firstNameElement.evaluate((node) => node.textContent)
 
   expect(firstName).toBe('John')
+  console.log(messages)
 
   return runtime.cleanup()
 })


### PR DESCRIPTION
@kettanaito this is how I think we can start the worker in a `nested` frame instead of the `top-level` frame.

- Top level loads `/` which uses `window.createIframe(id, src)` to create a child iframe with the same URL
- That iframe starts the worker creates another iframe which loads `iframe.html` and then makes a request
- This is not intercepted because the worker is on the middle iframe and not the parent

This mimics the document structure of Cypress with one exception — the URLs can be completely different on these iframes.

I'm going to look at a few options on how the user can specify which frame to use. Maybe some way to let them use regex to locate the page?