### PR TITLE
tests(iframe): Load the mocks in a nested iframe

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -270,7 +270,7 @@ function serializeHeaders(headers) {
   return reqHeaders
 }
 
-async function sendToClient(client, message) {
+function sendToClient(client, message) {
   return new Promise((resolve, reject) => {
     const channel = new MessageChannel()
 

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -239,6 +239,13 @@ self.addEventListener('fetch', function (event) {
     return
   }
 
+  // Bypass all requests when there are no active client IDs.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
   const requestId = uuidv4()
 
   return event.respondWith(

--- a/test/fixtures/iframe.html
+++ b/test/fixtures/iframe.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h2>Iframe</h2>
+    <script>
+      window.request = () => {
+        fetch('/user')
+          .then((res) => res.json())
+          .then((data) => {
+            const node = document.createElement('p')
+            node.setAttribute('id', 'first-name')
+            node.innerText = data.firstName
+            document.body.appendChild(node)
+          })
+      }
+
+      document.addEventListener('click', window.request)
+    </script>
+  </body>
+</html>

--- a/test/msw-api/setup-worker/scenarios/iframe.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe.mocks.ts
@@ -1,0 +1,14 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start()
+
+// Append an iframe to the body and issue a request from it.
+const iframe = document.createElement('iframe')
+iframe.setAttribute('src', '/test/fixtures/iframe.html')
+document.body.appendChild(iframe)

--- a/test/msw-api/setup-worker/scenarios/iframe.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe.mocks.ts
@@ -9,7 +9,6 @@ const worker = setupWorker(
 // @ts-ignore
 window.msw = {
   worker,
-  name: 'what',
   createIframe: (id: string, src: string) => {
     // Append an iframe to the body and issue a request from it.
     const iframe = document.createElement('iframe')

--- a/test/msw-api/setup-worker/scenarios/iframe.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe.mocks.ts
@@ -6,9 +6,15 @@ const worker = setupWorker(
   }),
 )
 
-worker.start()
-
-// Append an iframe to the body and issue a request from it.
-const iframe = document.createElement('iframe')
-iframe.setAttribute('src', '/test/fixtures/iframe.html')
-document.body.appendChild(iframe)
+// @ts-ignore
+window.msw = {
+  worker,
+  name: 'what',
+  createIframe: (id: string, src: string) => {
+    // Append an iframe to the body and issue a request from it.
+    const iframe = document.createElement('iframe')
+    iframe.id = id
+    iframe.setAttribute('src', src)
+    document.body.appendChild(iframe)
+  },
+}

--- a/test/msw-api/setup-worker/scenarios/iframe.test.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe.test.ts
@@ -1,0 +1,25 @@
+import * as path from 'path'
+import { runBrowserWith } from '../../../support/runBrowserWith'
+
+declare namespace window {
+  export const request: () => Promise<any>
+}
+
+test('intercepts a request made in an iframe (nested client)', async () => {
+  const runtime = await runBrowserWith(
+    path.resolve(__dirname, 'iframe.mocks.ts'),
+  )
+
+  const frame = runtime.page
+    .mainFrame()
+    .childFrames()
+    .find((frame) => frame.name() === '')
+
+  await frame.evaluate(() => window.request())
+  const firstNameElement = await frame.waitForSelector('#first-name')
+  const firstName = await firstNameElement.evaluate((node) => node.textContent)
+
+  expect(firstName).toBe('John')
+
+  return runtime.cleanup()
+})

--- a/test/msw-api/setup-worker/scenarios/iframe.test.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe.test.ts
@@ -22,7 +22,7 @@ test('intercepts a request made in an iframe (nested client)', async () => {
   const { messages } = captureConsole(runtime.page)
 
   runtime.page.evaluate(() => {
-    window.msw.createIframe('middle', window.location.href)
+    window.msw.createIframe('middle', `window.location.href?name=middle`)
   })
 
   const middle = await runtime.page.waitForSelector('#middle')

--- a/test/msw-api/setup-worker/scenarios/iframe.test.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe.test.ts
@@ -1,25 +1,48 @@
 import * as path from 'path'
+import { captureConsole } from '../../../support/captureConsole'
 import { runBrowserWith } from '../../../support/runBrowserWith'
 
 declare namespace window {
   export const request: () => Promise<any>
+  export const location: {
+    href: string
+  }
+  export const msw: {
+    createIframe: (id: string, src: string) => any
+    worker: {
+      start: () => any
+    }
+  }
 }
 
 test('intercepts a request made in an iframe (nested client)', async () => {
   const runtime = await runBrowserWith(
     path.resolve(__dirname, 'iframe.mocks.ts'),
   )
+  const { messages } = captureConsole(runtime.page)
 
-  const frame = runtime.page
-    .mainFrame()
-    .childFrames()
-    .find((frame) => frame.name() === '')
+  runtime.page.evaluate(() => {
+    window.msw.createIframe('middle', window.location.href)
+  })
 
-  await frame.evaluate(() => window.request())
-  const firstNameElement = await frame.waitForSelector('#first-name')
+  const middle = await runtime.page.waitForSelector('#middle')
+  const middleFrame = await middle.contentFrame()
+  await middleFrame.waitForSelector('h2')
+
+  await middleFrame.evaluate(() => {
+    window.msw.worker.start()
+    window.msw.createIframe('iframe', '/test/fixtures/iframe.html')
+  })
+
+  const iframe = await middleFrame.waitForSelector('#iframe')
+  const childFrame = await iframe.contentFrame()
+  await childFrame.evaluate(() => window.request())
+
+  const firstNameElement = await childFrame.waitForSelector('#first-name')
   const firstName = await firstNameElement.evaluate((node) => node.textContent)
 
   expect(firstName).toBe('John')
+  console.log(messages)
 
   return runtime.cleanup()
 })


### PR DESCRIPTION
@kettanaito this is how I think we can start the worker in a `nested` frame instead of the `top-level` frame.

- Top level loads `/` which uses `window.createIframe(id, src)` to create a child iframe with the same URL
- That iframe starts the worker creates another iframe which loads `iframe.html` and then makes a request
- This is not intercepted because the worker is on the middle iframe and not the parent

This mimics the document structure of Cypress with one exception — the URLs can be completely different on these iframes.

I'm going to look at a few options on how the user can specify which frame to use. Maybe some way to let them use regex to locate the page?