### PR TITLE
TypeScript: Fixes declarations auto-import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@ __*
 .DS_*
 node_modules
 /lib
-/native/**/*.js
+/native/**/*
 /node/**/*
 !/node/package.json
+!/native/package.json
 tmp
 *-error.log
 ./package-lock.json

--- a/native/package.json
+++ b/native/package.json
@@ -1,3 +1,4 @@
 {
+  "main": "lib",
   "types": "../lib/types/native"
 }

--- a/node/package.json
+++ b/node/package.json
@@ -1,3 +1,4 @@
 {
+  "main": "lib",
   "types": "../lib/types/node"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Seamless REST/GraphQL API mocking library for browser and Node.",
   "main": "lib/umd/index.js",
   "module": "lib/esm/index.js",
-  "types": "lib/types",
+  "types": "lib/umd",
   "bin": {
     "msw": "cli/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Seamless REST/GraphQL API mocking library for browser and Node.",
   "main": "lib/umd/index.js",
   "module": "lib/esm/index.js",
-  "types": "lib/umd",
+  "types": "lib/types/index.d.ts",
   "bin": {
     "msw": "cli/index.js"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=development rollup -c rollup.config.ts -w",
-    "clean": "rimraf lib node/**/*.js",
+    "clean": "rimraf lib {native,node}/lib",
     "lint": "eslint \"{cli,config,src,test}/**/*.ts\"",
     "build": "yarn clean && yarn lint && cross-env NODE_ENV=production rollup -c rollup.config.ts && yarn test:ts",
     "test": "yarn test:unit && yarn test:integration",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -26,9 +26,7 @@ const plugins = [
     input: SERVICE_WORKER_SOURCE_PATH,
     output: SERVICE_WORKER_BUILD_PATH,
   }),
-  typescript({
-    useTsconfigDeclarationDir: true,
-  }),
+  typescript(),
   commonjs(),
 ]
 
@@ -96,6 +94,10 @@ const buildNode = {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
     }),
     typescript({
+      /**
+       * @fixme Export only "msw/node" relevant type declarations
+       * to enable auto-imports from "msw/node".
+       */
       useTsconfigDeclarationDir: true,
       tsconfigOverride: {
         outDir: './node',

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -26,7 +26,9 @@ const plugins = [
     input: SERVICE_WORKER_SOURCE_PATH,
     output: SERVICE_WORKER_BUILD_PATH,
   }),
-  typescript(),
+  typescript({
+    useTsconfigDeclarationDir: true,
+  }),
   commonjs(),
 ]
 
@@ -35,17 +37,17 @@ const plugins = [
  */
 const buildEsm = {
   input: [
-    // Split modules so they can be tree-shaken
+    // Split modules so they can be tree-shaken.
     'src/index.ts',
     'src/rest.ts',
     'src/graphql.ts',
     'src/context/index.ts',
   ],
   output: {
+    format: 'esm',
     entryFileNames: '[name].js',
     chunkFileNames: '[name]-deps.js',
     dir: path.dirname(packageJson.module),
-    format: 'esm',
   },
   plugins,
 }
@@ -56,9 +58,9 @@ const buildEsm = {
 const buildUmd = {
   input: 'src/index.ts',
   output: {
+    format: 'umd',
     file: packageJson.main,
     name: 'MockServiceWorker',
-    format: 'umd',
     esModule: false,
   },
   plugins,
@@ -83,8 +85,8 @@ const buildNode = {
     'node-request-interceptor/lib/interceptors/XMLHttpRequest',
   ],
   output: {
-    file: 'node/index.js',
     format: 'cjs',
+    file: 'node/lib/index.js',
   },
   plugins: [
     json(),
@@ -94,14 +96,9 @@ const buildNode = {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
     }),
     typescript({
-      /**
-       * @fixme Export only "msw/node" relevant type declarations
-       * to enable auto-imports from "msw/node".
-       */
       useTsconfigDeclarationDir: true,
       tsconfigOverride: {
-        outDir: './node',
-        declarationDir: './node',
+        outDir: './node/lib',
       },
     }),
     inject({
@@ -127,7 +124,7 @@ const buildNative = {
     'node-request-interceptor/lib/interceptors/XMLHttpRequest',
   ],
   output: {
-    file: 'native/index.js',
+    file: 'native/lib/index.js',
     format: 'cjs',
   },
   plugins: [
@@ -140,8 +137,7 @@ const buildNative = {
     typescript({
       useTsconfigDeclarationDir: true,
       tsconfigOverride: {
-        outDir: './native',
-        declarationDir: './native',
+        outDir: './native/lib',
       },
     }),
     commonjs(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,14 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "declarationDir": "lib/types",
-    "lib": ["es2017", "ES2019.Object", "ESNext.AsyncIterable", "dom", "webworker"]
+    "declarationDir": "lib/umd",
+    "lib": [
+      "es2017",
+      "ES2019.Object",
+      "ESNext.AsyncIterable",
+      "dom",
+      "webworker"
+    ]
   },
   "include": ["global.d.ts", "src/**/*.ts"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "declarationDir": "lib/umd",
+    "declarationDir": "lib/types",
     "lib": [
       "es2017",
       "ES2019.Object",


### PR DESCRIPTION
## GitHub

- Fixes #596

## Changes

- Type declarations are not emitted next to each build target directory (esm, umd, cjs, iife).

## Roadmap

- [x] Ensure auto-imports from the `msw` package (defaults to `lib/umd`).
- [x] Ensure auto-imports from the `msw/node` package.