### PR TITLE
fix: not await for .text() when receiving a response

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -115,21 +115,23 @@ async function handleRequest(event, requestId) {
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (activeClientIds.has(client.id)) {
-    const clonedResponse = response.clone()
-
-    sendToClient(client, {
-      type: 'RESPONSE',
-      payload: {
-        requestId,
-        type: clonedResponse.type,
-        ok: clonedResponse.ok,
-        status: clonedResponse.status,
-        statusText: clonedResponse.statusText,
-        body: clonedResponse.body === null ? null : await clonedResponse.text(),
-        headers: serializeHeaders(clonedResponse.headers),
-        redirected: clonedResponse.redirected,
-      },
-    })
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: serializeHeaders(clonedResponse.headers),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
   }
 
   return response

--- a/test/msw-api/life-cycle-events/life-cycle-events.test.ts
+++ b/test/msw-api/life-cycle-events/life-cycle-events.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { SetupWorkerApi } from 'msw'
 import { ScenarioApi, pageWith } from 'page-with'
-import { sleep } from '../../support/utils'
+import { sleep, waitUntil } from '../../support/utils'
 
 declare namespace window {
   export const msw: {
@@ -30,12 +30,14 @@ test('emits events for a handled request and mocked response', async () => {
   await sleep(500)
 
   const requestId = getRequestId(consoleSpy)
-  expect(consoleSpy.get('warning')).toEqual([
-    `[request:start] GET ${endpointUrl} ${requestId}`,
-    `[request:match] GET ${endpointUrl} ${requestId}`,
-    `[request:end] GET ${endpointUrl} ${requestId}`,
-    `[response:mocked] response-body ${requestId}`,
-  ])
+  waitUntil(() =>
+    expect(consoleSpy.get('warning')).toEqual([
+      `[request:start] GET ${endpointUrl} ${requestId}`,
+      `[request:match] GET ${endpointUrl} ${requestId}`,
+      `[request:end] GET ${endpointUrl} ${requestId}`,
+      `[response:mocked] response-body ${requestId}`,
+    ]),
+  )
 })
 
 test('emits events for a handled request with no response', async () => {
@@ -48,12 +50,14 @@ test('emits events for a handled request with no response', async () => {
   await sleep(500)
 
   const requestId = getRequestId(consoleSpy)
-  expect(consoleSpy.get('warning')).toEqual([
-    `[request:start] POST ${endpointUrl} ${requestId}`,
-    `[request:unhandled] POST ${endpointUrl} ${requestId}`,
-    `[request:end] POST ${endpointUrl} ${requestId}`,
-    `[response:bypass] ${requestId}`,
-  ])
+  waitUntil(() =>
+    expect(consoleSpy.get('warning')).toEqual([
+      `[request:start] POST ${endpointUrl} ${requestId}`,
+      `[request:unhandled] POST ${endpointUrl} ${requestId}`,
+      `[request:end] POST ${endpointUrl} ${requestId}`,
+      `[response:bypass] ${requestId}`,
+    ]),
+  )
 })
 
 test('emits events for an unhandled request', async () => {
@@ -64,12 +68,14 @@ test('emits events for an unhandled request', async () => {
   await sleep(500)
 
   const requestId = getRequestId(consoleSpy)
-  expect(consoleSpy.get('warning')).toEqual([
-    `[request:start] GET ${endpointUrl} ${requestId}`,
-    `[request:unhandled] GET ${endpointUrl} ${requestId}`,
-    `[request:end] GET ${endpointUrl} ${requestId}`,
-    `[response:bypass] ${requestId}`,
-  ])
+  waitUntil(() =>
+    expect(consoleSpy.get('warning')).toEqual([
+      `[request:start] GET ${endpointUrl} ${requestId}`,
+      `[request:unhandled] GET ${endpointUrl} ${requestId}`,
+      `[request:end] GET ${endpointUrl} ${requestId}`,
+      `[response:bypass] ${requestId}`,
+    ]),
+  )
 })
 
 test('stops emitting events once the worker is stopped', async () => {

--- a/test/msw-api/life-cycle-events/regression/handle-stream.mocks.ts
+++ b/test/msw-api/life-cycle-events/regression/handle-stream.mocks.ts
@@ -1,0 +1,10 @@
+import { setupWorker } from 'msw'
+
+const worker = setupWorker()
+
+worker.on('response:bypass', async (res) => {
+  const textResponse = await res.text()
+  console.warn(`[response:bypass] ${textResponse}`)
+})
+
+worker.start()

--- a/test/msw-api/life-cycle-events/regression/handle-stream.test.ts
+++ b/test/msw-api/life-cycle-events/regression/handle-stream.test.ts
@@ -1,0 +1,60 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { waitUntil } from '../../../support/utils'
+
+function createRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'handle-stream.mocks.ts'),
+    routes(app) {
+      app.get('/stream', (req, res) => {
+        res.write('first-chunk')
+
+        setTimeout(() => {
+          res.write(' last-chunk')
+          res.end()
+        }, 250 * 6)
+      })
+    },
+  })
+}
+
+test('handles a stream response without throwing a timeout error', async () => {
+  const runtime = await createRuntime()
+
+  const getStreamResponse = () => {
+    return runtime.page.evaluate(() => {
+      const abortController = new AbortController()
+      const abortTimeout = setTimeout(() => abortController.abort(), 250 * 5)
+
+      return new Promise<string>((resolve, reject) => {
+        let textResponse = ''
+        const decoder = new TextDecoder()
+        return fetch('/stream', { signal: abortController.signal })
+          .then((response) => {
+            const reader = response.body.getReader()
+            clearTimeout(abortTimeout)
+            reader.read().then(function processStream({ done, value }) {
+              if (done) {
+                resolve(textResponse)
+                return
+              }
+
+              textResponse += decoder.decode(value, { stream: true })
+              return reader.read().then(processStream)
+            })
+          })
+          .catch(reject)
+      })
+    })
+  }
+
+  const response = await getStreamResponse()
+
+  await waitUntil(() => {
+    expect(runtime.consoleSpy.get('warning')).toEqual([
+      `[response:bypass] first-chunk last-chunk`,
+    ])
+  })
+
+  expect(response).toEqual('first-chunk last-chunk')
+})


### PR DESCRIPTION
This PR should fix an issue on browser that causing some timeout using streams.

The problem was that in the service worker the response was delayed to send the response to the client.

This behavior seems to be happening also in the browser as for #636 