### PR TITLE
refactor: throw on start fail, vs null return

### DIFF
--- a/src/setupWorker/start/createStart.ts
+++ b/src/setupWorker/start/createStart.ts
@@ -1,11 +1,7 @@
 import { until } from '@open-draft/until'
 import { getWorkerInstance } from './utils/getWorkerInstance'
 import { activateMocking } from './utils/activateMocking'
-import {
-  SetupWorkerInternalContext,
-  ServiceWorkerInstanceTuple,
-  StartOptions,
-} from '../glossary'
+import { SetupWorkerInternalContext, StartOptions } from '../glossary'
 import { createRequestListener } from '../../utils/worker/createRequestListener'
 import { requestIntegrityCheck } from '../../utils/internal/requestIntegrityCheck'
 import { deferNetworkRequestsUntil } from '../../utils/deferNetworkRequestsUntil'

--- a/test/msw-api/setup-worker/start/error.test.ts
+++ b/test/msw-api/setup-worker/start/error.test.ts
@@ -14,22 +14,15 @@ function createRuntime() {
   })
 }
 
-test('prints a custom error message when given a non-existing worker script', async () => {
-  const { page, consoleSpy } = await createRuntime()
-  await page.evaluate(() => {
-    return window.msw.worker.start({
-      serviceWorker: {
-        url: 'invalidServiceWorker',
-      },
-    })
-  })
-
-  const workerNotFoundMessage = consoleSpy.get('error').find((text) => {
-    return (
-      text.startsWith('[MSW] Failed to register a Service Worker for scope') &&
-      text.includes('Did you forget to run "npx msw init <PUBLIC_DIR>"?')
-    )
-  })
-
-  expect(workerNotFoundMessage).toBeTruthy()
+test('rejects with a custom error message when given a non-existing worker script', async () => {
+  const { page } = await createRuntime()
+  await expect(
+    page.evaluate(() => {
+      return window.msw.worker.start({
+        serviceWorker: {
+          url: 'invalidServiceWorker',
+        },
+      })
+    }),
+  ).rejects.toThrowError(/\[MSW\] Failed/)
 })

--- a/test/msw-api/setup-worker/start/find-worker.error.mocks.ts
+++ b/test/msw-api/setup-worker/start/find-worker.error.mocks.ts
@@ -22,5 +22,6 @@ window.msw = {
     })
     .catch((error) => {
       console.error('Error - no worker instance after starting', error)
+      throw error
     }),
 }

--- a/test/msw-api/setup-worker/start/find-worker.test.ts
+++ b/test/msw-api/setup-worker/start/find-worker.test.ts
@@ -39,11 +39,9 @@ test('fails to return a ServiceWorkerRegistration when using a findWorker that r
     example: path.resolve(__dirname, 'find-worker.error.mocks.ts'),
   })
 
-  const resolvedPayload = await page.evaluate(() => {
-    return window.msw.registration
+  const workerStartError = await page.evaluate(() => {
+    return window.msw.registration.catch((err) => err)
   })
-
-  expect(resolvedPayload).toBeUndefined()
 
   const activationMessage = consoleSpy
     .get('startGroupCollapsed')
@@ -55,13 +53,7 @@ test('fails to return a ServiceWorkerRegistration when using a findWorker that r
     return text.includes('Error - no worker instance after starting')
   })
 
-  const mswErrorMessage = consoleSpy.get('error').find((text) => {
-    return /\[MSW\] Failed to locate the Service Worker registration using a custom "findWorker" predicate/.test(
-      text,
-    )
-  })
-
-  expect(mswErrorMessage).toMatch(`\
+  expect(workerStartError).toMatch(`\
 [MSW] Failed to locate the Service Worker registration using a custom "findWorker" predicate.
 
 Please ensure that the custom predicate properly locates the Service Worker registration at "/mockServiceWorker.js".


### PR DESCRIPTION
# Problem

Fixes #603. A failure currently just returns `null`

# Solution

Failing to start the worker now results in a `throw`, as the expressed intent of `start(...)` failed