### PR TITLE
CLI: Fixes "INIT_CWD"/"CWD" for standalone and in-script execution

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -5,12 +5,12 @@ const inquirer = require('inquirer')
 const invariant = require('./invariant')
 const { SERVICE_WORKER_BUILD_PATH } = require('../config/constants')
 
-const CWD = process.env.INIT_CWD || process.cwd()
+const CWD = process.cwd()
 
 module.exports = function init(args) {
   const { publicDir, save } = args
 
-  // When running as a part of "postinstall" script, CWD equals the library's directory.
+  // When running as a part of "postinstall" script, "cwd" equals the library's directory.
   // The "postinstall" script resolves the right absolute public directory path.
   const absolutePublicDir = path.isAbsolute(publicDir)
     ? publicDir

--- a/config/scripts/postinstall.js
+++ b/config/scripts/postinstall.js
@@ -1,10 +1,15 @@
 const fs = require('fs')
 const path = require('path')
-const cwd = process.env.INIT_CWD
+const { execSync } = require('child_process')
+
+// When executing the "postinstall" script, the "process.cwd" equals
+// the package directory, not the parent project where the package is installed.
+// NPM stores the parent project directory in the "INIT_CWD" env variable.
+const parentPackageCwd = process.env.INIT_CWD
 
 // 1. Check if "package.json" has "msw.workerDirectory" property set.
 const packageJson = JSON.parse(
-  fs.readFileSync(path.resolve(cwd, 'package.json'), 'utf8'),
+  fs.readFileSync(path.resolve(parentPackageCwd, 'package.json'), 'utf8'),
 )
 
 if (!packageJson.msw || !packageJson.msw.workerDirectory) {
@@ -13,7 +18,7 @@ if (!packageJson.msw || !packageJson.msw.workerDirectory) {
 
 // 2. Check if the worker directory is an existing path.
 const { workerDirectory } = packageJson.msw
-const absoluteWorkerDirectory = path.resolve(cwd, workerDirectory)
+const absoluteWorkerDirectory = path.resolve(parentPackageCwd, workerDirectory)
 
 if (!fs.existsSync(absoluteWorkerDirectory)) {
   return console.error(
@@ -23,10 +28,13 @@ if (!fs.existsSync(absoluteWorkerDirectory)) {
 }
 
 // 3. Update the worker script.
-const init = require('../../cli/init')
+const cliExecutable = path.resolve(process.cwd(), '../../cli/index.js')
+const relativeCliExecutable = path.relative(parentPackageCwd, cliExecutable)
 
 try {
-  init({ publicDir: absoluteWorkerDirectory })
+  execSync(`node ${relativeCliExecutable} init ${absoluteWorkerDirectory}`, {
+    cwd: parentPackageCwd,
+  })
 } catch (error) {
   console.error(
     `[MSW] Failed to automatically update the worker script:\n${error}`,

--- a/config/scripts/postinstall.js
+++ b/config/scripts/postinstall.js
@@ -28,11 +28,10 @@ if (!fs.existsSync(absoluteWorkerDirectory)) {
 }
 
 // 3. Update the worker script.
-const cliExecutable = path.resolve(process.cwd(), '../../cli/index.js')
-const relativeCliExecutable = path.relative(parentPackageCwd, cliExecutable)
+const cliExecutable = path.resolve(process.cwd(), 'cli/index.js')
 
 try {
-  execSync(`node ${relativeCliExecutable} init ${absoluteWorkerDirectory}`, {
+  execSync(`node ${cliExecutable} init ${absoluteWorkerDirectory}`, {
     cwd: parentPackageCwd,
   })
 } catch (error) {

--- a/test/msw-api/auto-update-worker.test.ts
+++ b/test/msw-api/auto-update-worker.test.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs'
+import { execSync } from 'child_process'
+import { createTeardown, addFile, addDirectory } from 'fs-teardown'
+
+test('updates the worker script on the postinstall hook', async () => {
+  const { prepare, cleanup, getPath } = createTeardown(
+    'tmp/auto-update-worker',
+    addDirectory('public'),
+    addFile('package.json', {
+      name: 'example',
+      msw: {
+        workerDirectory: 'public',
+      },
+    }),
+  )
+  await prepare()
+
+  // Pack the current state of the `msw` package.
+  execSync(`yarn pack --filename ${getPath('msw.tgz')}`, {
+    stdio: 'inherit',
+  })
+
+  // Install `msw` from the tarball into the dummy project.
+  execSync('npm install msw.tgz', {
+    cwd: getPath('.'),
+    stdio: 'inherit',
+  })
+
+  // Asset the worker script has been created/updated.
+  expect(fs.existsSync(getPath('public/mockServiceWorker.js'))).toBe(true)
+
+  await cleanup()
+})

--- a/test/msw-api/cli/init.test.ts
+++ b/test/msw-api/cli/init.test.ts
@@ -74,10 +74,8 @@ test('saves the worker directory in package.json when none are present', async (
   await prepare()
 
   const { stderr, stdout } = await promisifyChildProcess(
-    exec(`node cli/index.js init ${getPath('public')} --save`, {
-      env: {
-        INIT_CWD: getPath('.'),
-      },
+    exec(`node ../../../../cli/index.js init ${getPath('public')} --save`, {
+      cwd: getPath('.'),
     }),
   )
 
@@ -113,10 +111,8 @@ test('warns when current public directory does not match the saved directory fro
   await prepare()
 
   const { stderr, stdout } = await promisifyChildProcess(
-    exec(`node cli/index.js init ${getPath('public')} --save`, {
-      env: {
-        INIT_CWD: getPath('.'),
-      },
+    exec(`node ../../../../cli/index.js init ${getPath('public')} --save`, {
+      cwd: getPath('.'),
     }),
   )
 


### PR DESCRIPTION
## GitHub

- Follow up to #606 
- Related to #605 

## Motivation

When running `msw init` as a part of the smoke tests via Lerna, the `process.env.INIT_CWD` equals the monorepo's root directory. Lerna automatically sets CWD to each monorepo's package while executing a command, but npm always stores the root of the project in `process.env.INIT_CWD`. The `msw init` command cannot rely on `INIT_CWD`.

## Changes

- `msw init` now always resolves paths against `process.cwd()`.
- The `postinstall` script executes `msw init` via `child_process.execSync` and sets its `cwd` to equal `process.env.INIT_CWD` (parent project directory when running npm scripts).
- Adjusts tests to call `msw init` the same way the `postinstall` script does (relative path to the executable). 
- The `postinstall` script always resolves the CLI path against the CWD (it equals the `node_modules/msw` package path). 
- Adds integration test for the `postinstall` script. 