### PR TITLE
Exports previously exported types, drops "Type" suffix from types

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,12 +1,12 @@
 import { Mask } from './setupWorker/glossary'
 import { ResponseResolver } from './handlers/RequestHandler'
 import {
-  ExpectedOperationTypeNode,
   GraphQLHandler,
   GraphQLContext,
-  GraphQLRequestType,
+  GraphQLRequest,
+  GraphQLVariables,
+  ExpectedOperationTypeNode,
   GraphQLHandlerNameSelector,
-  GraphQLVariablesType,
 } from './handlers/GraphQLHandler'
 
 function createScopedGraphQLHandler(
@@ -14,13 +14,13 @@ function createScopedGraphQLHandler(
   url: Mask,
 ) {
   return <
-    QueryType extends Record<string, any>,
-    VariablesType extends GraphQLVariablesType = GraphQLVariablesType
+    Query extends Record<string, any>,
+    Variables extends GraphQLVariables = GraphQLVariables
   >(
     operationName: GraphQLHandlerNameSelector,
     resolver: ResponseResolver<
-      GraphQLRequestType<VariablesType>,
-      GraphQLContext<QueryType>
+      GraphQLRequest<Variables>,
+      GraphQLContext<Query>
     >,
   ) => {
     return new GraphQLHandler(operationType, operationName, url, resolver)
@@ -29,12 +29,12 @@ function createScopedGraphQLHandler(
 
 function createGraphQLOperationHandler(url: Mask) {
   return <
-    QueryType extends Record<string, any>,
-    VariablesType extends GraphQLVariablesType = GraphQLVariablesType
+    Query extends Record<string, any>,
+    Variables extends GraphQLVariables = GraphQLVariables
   >(
     resolver: ResponseResolver<
-      GraphQLRequestType<VariablesType>,
-      GraphQLContext<QueryType>
+      GraphQLRequest<Variables>,
+      GraphQLContext<Query>
     >,
   ) => {
     return new GraphQLHandler('all', new RegExp('.*'), url, resolver)

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -47,40 +47,36 @@ export const graphqlContext: GraphQLContext<any> = {
   errors,
 }
 
-export type GraphQLVariablesType = Record<string, any>
+export type GraphQLVariables = Record<string, any>
 
 export interface GraphQLHandlerInfo {
   operationType: ExpectedOperationTypeNode
   operationName: GraphQLHandlerNameSelector
 }
 
-export type GraphQLRequestBodyType<
-  VariablesType extends GraphQLVariablesType
-> =
+export type GraphQLRequestBody<VariablesType extends GraphQLVariables> =
   | GraphQLJsonRequestBody<VariablesType>
   | GraphQLMultipartRequestBody
   | Record<string, any>
   | undefined
 
-export interface GraphQLJsonRequestBody<
-  VariablesType extends GraphQLVariablesType
-> {
+export interface GraphQLJsonRequestBody<Variables extends GraphQLVariables> {
   query: string
-  variables?: VariablesType
+  variables?: Variables
 }
 
-export interface GraphQLRequestType<VariablesType extends GraphQLVariablesType>
-  extends MockedRequest<GraphQLRequestBodyType<VariablesType>> {
-  variables: VariablesType
+export interface GraphQLRequest<Variables extends GraphQLVariables>
+  extends MockedRequest<GraphQLRequestBody<Variables>> {
+  variables: Variables
 }
 
 export class GraphQLHandler<
-  RequestType extends GraphQLRequestType<any> = GraphQLRequestType<any>
+  Request extends GraphQLRequest<any> = GraphQLRequest<any>
 > extends RequestHandler<
   GraphQLHandlerInfo,
-  RequestType,
+  Request,
   ParsedGraphQLRequest | null,
-  GraphQLRequestType<any>
+  GraphQLRequest<any>
 > {
   private endpoint: Mask
 
@@ -108,21 +104,21 @@ export class GraphQLHandler<
     this.endpoint = endpoint
   }
 
-  parse(request: RequestType) {
+  parse(request: Request) {
     return parseGraphQLRequest(request)
   }
 
   protected getPublicRequest(
-    request: RequestType,
+    request: Request,
     parsedResult: ParsedGraphQLRequest,
-  ): GraphQLRequestType<any> {
+  ): GraphQLRequest<any> {
     return {
       ...request,
       variables: parsedResult?.variables || {},
     }
   }
 
-  predicate(request: RequestType, parsedResult: ParsedGraphQLRequest) {
+  predicate(request: Request, parsedResult: ParsedGraphQLRequest) {
     if (!parsedResult) {
       return false
     }
@@ -153,7 +149,7 @@ Consider naming this operation or using "graphql.operation" request handler to i
     )
   }
 
-  log(request: RequestType, response: ResponseWithSerializedHeaders<any>) {
+  log(request: Request, response: ResponseWithSerializedHeaders<any>) {
     const loggedRequest = prepareRequest(request)
     const loggedResponse = prepareResponse(response)
 

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -18,18 +18,18 @@ export const defaultContext = {
   fetch,
 }
 
-export type DefaultMultipartBodyType = Record<
+export type DefaultRequestMultipartBody = Record<
   string,
   string | File | (string | File)[]
 >
 
-export type DefaultRequestBodyType =
+export type DefaultRequestBody =
   | Record<string, any>
-  | DefaultMultipartBodyType
+  | DefaultRequestMultipartBody
   | string
   | undefined
 
-export interface MockedRequest<BodyType = DefaultRequestBodyType> {
+export interface MockedRequest<Body = DefaultRequestBody> {
   id: string
   url: URL
   method: Request['method']
@@ -44,7 +44,7 @@ export interface MockedRequest<BodyType = DefaultRequestBodyType> {
   redirect: Request['redirect']
   referrer: Request['referrer']
   referrerPolicy: Request['referrerPolicy']
-  body: BodyType
+  body: Body
   bodyUsed: Request['bodyUsed']
 }
 
@@ -88,9 +88,9 @@ export interface RequestHandlerExecutionResult<PublicRequestType> {
 
 export abstract class RequestHandler<
   HandlerInfo extends Record<string, any> = Record<string, any>,
-  RequestType extends MockedRequest = MockedRequest,
+  Request extends MockedRequest = MockedRequest,
   ParsedResult = any,
-  PublicRequestType extends MockedRequest = RequestType
+  PublicRequest extends MockedRequest = Request
 > {
   public info: RequestHandlerDefaultInfo & RequestHandlerInfo<HandlerInfo>
   private ctx: ContextMap
@@ -113,13 +113,13 @@ export abstract class RequestHandler<
   /**
    * Determine if the captured request should be mocked.
    */
-  abstract predicate(request: RequestType, parsedResult: ParsedResult): boolean
+  abstract predicate(request: Request, parsedResult: ParsedResult): boolean
 
   /**
    * Print out the successfully handled request.
    */
   abstract log(
-    request: RequestType,
+    request: Request,
     res: any,
     handler: this,
     parsedResilt: ParsedResult,
@@ -129,14 +129,14 @@ export abstract class RequestHandler<
    * Parse the captured request to extract additional information from it.
    * Parsed result is then exposed to other methods of this request handler.
    */
-  parse(request: RequestType): ParsedResult {
+  parse(request: Request): ParsedResult {
     return null as any
   }
 
   /**
    * Test if this handler matches the given request.
    */
-  public test(request: RequestType): boolean {
+  public test(request: Request): boolean {
     return this.predicate(request, this.parse(request))
   }
 
@@ -145,9 +145,9 @@ export abstract class RequestHandler<
    * from the captured request and its parsed result.
    */
   protected getPublicRequest(
-    request: RequestType,
+    request: Request,
     parsedResult: ParsedResult,
-  ): PublicRequestType {
+  ): PublicRequest {
     return request as any
   }
 
@@ -160,8 +160,8 @@ export abstract class RequestHandler<
    * using the given resolver function.
    */
   public async run(
-    request: RequestType,
-  ): Promise<RequestHandlerExecutionResult<PublicRequestType> | null> {
+    request: Request,
+  ): Promise<RequestHandlerExecutionResult<PublicRequest> | null> {
     if (this.shouldSkip) {
       return null
     }
@@ -189,9 +189,9 @@ export abstract class RequestHandler<
 
   private createExecutionResult(
     parsedResult: ParsedResult,
-    request: PublicRequestType,
+    request: PublicRequest,
     response: any,
-  ): RequestHandlerExecutionResult<PublicRequestType> {
+  ): RequestHandlerExecutionResult<PublicRequest> {
     return {
       handler: this,
       parsedResult: parsedResult || null,

--- a/src/handlers/RestHandler.test.ts
+++ b/src/handlers/RestHandler.test.ts
@@ -1,11 +1,11 @@
-import { RestHandler, RestRequestType, RestContext } from './RestHandler'
+import { RestHandler, RestRequest, RestContext } from './RestHandler'
 import { createMockedRequest } from '../../test/support/utils'
 import { response } from '../response'
 import { context } from '..'
 import { ResponseResolver } from './RequestHandler'
 
 const resolver: ResponseResolver<
-  RestRequestType<{ userId: string }>,
+  RestRequest<{ userId: string }>,
   RestContext
 > = (req, res, ctx) => {
   return res(ctx.json({ userId: req.params.userId }))

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -20,7 +20,7 @@ import { matchRequestUrl } from '../utils/matching/matchRequestUrl'
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
 import { getUrlByMask } from '../utils/url/getUrlByMask'
 import {
-  DefaultRequestBodyType,
+  DefaultRequestBody,
   MockedRequest,
   RequestHandler,
   ResponseResolver,
@@ -75,26 +75,26 @@ export type RequestQuery = {
   [queryName: string]: any
 }
 
-export interface RestRequestType<
-  BodyType extends DefaultRequestBodyType = DefaultRequestBodyType,
+export interface RestRequest<
+  BodyType extends DefaultRequestBody = DefaultRequestBody,
   ParamsType extends RequestParams = Record<string, any>
 > extends MockedRequest<BodyType> {
   params: ParamsType
 }
 
-type ParsedResult = Match
+export type ParsedRestRequest = Match
 
 /**
  * Request handler for REST API requests.
  * Provides request matching based on method and URL.
  */
 export class RestHandler<
-  RequestType extends MockedRequest<DefaultRequestBodyType> = MockedRequest<DefaultRequestBodyType>
+  RequestType extends MockedRequest<DefaultRequestBody> = MockedRequest<DefaultRequestBody>
 > extends RequestHandler<
   RestHandlerInfo,
   RequestType,
-  ParsedResult,
-  RestRequestType<RequestParams>
+  ParsedRestRequest,
+  RestRequest<RequestParams>
 > {
   constructor(
     method: string,
@@ -146,15 +146,15 @@ ${queryParams
 
   protected getPublicRequest(
     request: RequestType,
-    parsedResult: ParsedResult,
-  ): RestRequestType<any, RequestParams> {
+    parsedResult: ParsedRestRequest,
+  ): RestRequest<any, RequestParams> {
     return {
       ...request,
       params: parsedResult.params,
     }
   }
 
-  predicate(request: RequestType, parsedResult: ParsedResult) {
+  predicate(request: RequestType, parsedResult: ParsedRestRequest) {
     return (
       isStringEqual(this.info.method, request.method) && parsedResult.matches
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ export {
   ResponseResolver,
   ResponseResolverReturnType,
   AsyncResponseResolverReturnType,
-  DefaultRequestBodyType,
-  DefaultMultipartBodyType,
+  DefaultRequestBody,
+  DefaultRequestMultipartBody,
   defaultContext,
 } from './handlers/RequestHandler'
 export { rest } from './rest'
@@ -31,16 +31,17 @@ export {
   RestContext,
   RequestParams,
   RequestQuery,
-  RestRequestType,
+  RestRequest,
+  ParsedRestRequest,
   restContext,
 } from './handlers/RestHandler'
 export { graphql } from './graphql'
 export {
   GraphQLHandler,
   GraphQLContext,
-  GraphQLVariablesType,
-  GraphQLRequestType,
-  GraphQLRequestBodyType,
+  GraphQLVariables,
+  GraphQLRequest,
+  GraphQLRequestBody,
   GraphQLJsonRequestBody,
   graphqlContext,
 } from './handlers/GraphQLHandler'
@@ -49,3 +50,4 @@ export {
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'
 export { compose } from './utils/internal/compose'
 export { DelayMode } from './context/delay'
+export { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,27 +1,24 @@
 import { Mask } from './setupWorker/glossary'
-import {
-  DefaultRequestBodyType,
-  ResponseResolver,
-} from './handlers/RequestHandler'
+import { DefaultRequestBody, ResponseResolver } from './handlers/RequestHandler'
 import {
   RESTMethods,
   RestContext,
   RestHandler,
-  RestRequestType,
+  RestRequest,
   RequestParams,
 } from './handlers/RestHandler'
 
 function createRestHandler(method: RESTMethods) {
   return <
-    RequestBodyType extends DefaultRequestBodyType = DefaultRequestBodyType,
-    ResponseBodyType extends DefaultRequestBodyType = any,
-    RequestParamsType extends RequestParams = RequestParams
+    RequestBodyType extends DefaultRequestBody = DefaultRequestBody,
+    ResponseBody extends DefaultRequestBody = any,
+    Params extends RequestParams = RequestParams
   >(
     mask: Mask,
     resolver: ResponseResolver<
-      RestRequestType<RequestBodyType, RequestParamsType>,
+      RestRequest<RequestBodyType, Params>,
       RestContext,
-      ResponseBodyType
+      ResponseBody
     >,
   ) => {
     return new RestHandler(method, mask, resolver)

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -1,12 +1,12 @@
 import { OperationDefinitionNode, OperationTypeNode, parse } from 'graphql'
-import { GraphQLVariablesType } from '../../handlers/GraphQLHandler'
+import { GraphQLVariables } from '../../handlers/GraphQLHandler'
 import { MockedRequest } from '../../handlers/RequestHandler'
 import { getPublicUrlFromRequest } from '../request/getPublicUrlFromRequest'
 import { jsonParse } from './jsonParse'
 
 interface GraphQLInput {
   query: string | null
-  variables?: GraphQLVariablesType
+  variables?: GraphQLVariables
 }
 
 export interface ParsedGraphQLQuery {
@@ -15,7 +15,7 @@ export interface ParsedGraphQLQuery {
 }
 
 export type ParsedGraphQLRequest<
-  VariablesType extends GraphQLVariablesType = GraphQLVariablesType
+  VariablesType extends GraphQLVariables = GraphQLVariables
 > =
   | (ParsedGraphQLQuery & {
       variables?: VariablesType
@@ -47,7 +47,7 @@ export type GraphQLMultipartRequestBody = {
   [fileName: string]: File
 }
 
-function extractMultipartVariables<VariablesType extends GraphQLVariablesType>(
+function extractMultipartVariables<VariablesType extends GraphQLVariables>(
   variables: VariablesType,
   map: GraphQLParsedOperationsMap,
   files: Record<string, File>,
@@ -107,7 +107,7 @@ function getGraphQLInput(request: MockedRequest<any>): GraphQLInput | null {
           ...files
         } = request.body as GraphQLMultipartRequestBody
         const parsedOperations =
-          jsonParse<{ query?: string; variables?: GraphQLVariablesType }>(
+          jsonParse<{ query?: string; variables?: GraphQLVariables }>(
             operations,
           ) || {}
 

--- a/src/utils/internal/parseMultipartData.ts
+++ b/src/utils/internal/parseMultipartData.ts
@@ -1,5 +1,5 @@
 import { stringToHeaders } from 'headers-utils'
-import { DefaultMultipartBodyType } from '../../handlers/RequestHandler'
+import { DefaultRequestMultipartBody } from '../../handlers/RequestHandler'
 
 interface ParsedContentHeaders {
   name: string
@@ -43,7 +43,7 @@ function parseContentHeaders(headersString: string): ParsedContentHeaders {
  * Parses a given string as a multipart/form-data.
  * Does not throw an exception on an invalid multipart string.
  */
-export function parseMultipartData<T extends DefaultMultipartBodyType>(
+export function parseMultipartData<T extends DefaultRequestMultipartBody>(
   data: string,
   headers?: Headers,
 ): T | undefined {
@@ -72,7 +72,7 @@ export function parseMultipartData<T extends DefaultMultipartBodyType>(
     return undefined
   }
 
-  const parsedBody: DefaultMultipartBodyType = {}
+  const parsedBody: DefaultRequestMultipartBody = {}
 
   try {
     for (const field of fields) {


### PR DESCRIPTION
## GitHub

- Follow up to #561 

## Changes

- Prepares for the `0.27.0` release by exporting some of the previously available type removed in https://github.com/mswjs/msw/pull/561.
- Drops the `Type` suffix from most of the types as it's redundant. 