### PR TITLE
Adds tests for "GraphQLHandler" class

### DIFF
--- a/src/handlers/GraphQLHandler.test.ts
+++ b/src/handlers/GraphQLHandler.test.ts
@@ -1,0 +1,373 @@
+import { Headers } from 'headers-utils/lib'
+import { context } from '..'
+import { createMockedRequest } from '../../test/support/utils'
+import { response } from '../response'
+import {
+  GraphQLContext,
+  GraphQLHandler,
+  GraphQLRequest,
+  GraphQLRequestBody,
+} from './GraphQLHandler'
+import { MockedRequest, ResponseResolver } from './RequestHandler'
+
+const resolver: ResponseResolver<
+  GraphQLRequest<{ userId: string }>,
+  GraphQLContext<any>
+> = (req, res, ctx) => {
+  return res(
+    ctx.data({
+      user: { id: req.variables.userId },
+    }),
+  )
+}
+
+function createGetGraphQLRequest(
+  body: GraphQLRequestBody<any>,
+  hostname = 'https://example.com',
+) {
+  const requestUrl = new URL(hostname)
+  requestUrl.searchParams.set('query', body?.query)
+  requestUrl.searchParams.set('variables', JSON.stringify(body?.variables))
+  return createMockedRequest({
+    url: requestUrl,
+  })
+}
+
+function createPostGraphQLRequest(
+  body: GraphQLRequestBody<any>,
+  hostname = 'https://example.com',
+  initMockedRequest: Partial<MockedRequest> = {},
+) {
+  return createMockedRequest({
+    method: 'POST',
+    url: new URL(hostname),
+    ...initMockedRequest,
+    headers: new Headers({ 'Content-Type': 'application/json ' }),
+    body,
+  })
+}
+
+const GET_USER = `
+  query GetUser {
+    user {
+      id
+    }
+  }
+`
+
+const LOGIN = `
+  mutation Login {
+    user {
+      id
+    }
+  }
+`
+
+describe('info', () => {
+  test('exposes request handler information for query', () => {
+    const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+
+    expect(handler.info).toHaveProperty('header', 'query GetUser (origin: *)')
+    expect(handler.info).toHaveProperty('operationType', 'query')
+    expect(handler.info).toHaveProperty('operationName', 'GetUser')
+  })
+
+  test('exposes request handler information for mutation', () => {
+    const handler = new GraphQLHandler('mutation', 'Login', '*', resolver)
+
+    expect(handler.info).toHaveProperty('header', 'mutation Login (origin: *)')
+    expect(handler.info).toHaveProperty('operationType', 'mutation')
+    expect(handler.info).toHaveProperty('operationName', 'Login')
+  })
+})
+
+describe('parse', () => {
+  describe('query', () => {
+    test('parses a query without variables (GET)', () => {
+      const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+      const request = createGetGraphQLRequest({
+        query: GET_USER,
+      })
+
+      expect(handler.parse(request)).toEqual({
+        operationType: 'query',
+        operationName: 'GetUser',
+        variables: undefined,
+      })
+    })
+
+    test('parses a query with variables (GET)', () => {
+      const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+      const request = createGetGraphQLRequest({
+        query: GET_USER,
+        variables: {
+          userId: 'abc-123',
+        },
+      })
+
+      expect(handler.parse(request)).toEqual({
+        operationType: 'query',
+        operationName: 'GetUser',
+        variables: {
+          userId: 'abc-123',
+        },
+      })
+    })
+
+    test('parses a query without variables (POST)', () => {
+      const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+      const request = createPostGraphQLRequest({
+        query: GET_USER,
+      })
+
+      expect(handler.parse(request)).toEqual({
+        operationType: 'query',
+        operationName: 'GetUser',
+        variables: undefined,
+      })
+    })
+
+    test('parses a query with variables (POST)', () => {
+      const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+      const request = createPostGraphQLRequest({
+        query: GET_USER,
+        variables: {
+          userId: 'abc-123',
+        },
+      })
+
+      expect(handler.parse(request)).toEqual({
+        operationType: 'query',
+        operationName: 'GetUser',
+        variables: {
+          userId: 'abc-123',
+        },
+      })
+    })
+  })
+
+  describe('mutation', () => {
+    test('parses a mutation without variables (GET)', () => {
+      const handler = new GraphQLHandler('mutation', 'GetUser', '*', resolver)
+      const request = createGetGraphQLRequest({
+        query: LOGIN,
+      })
+
+      expect(handler.parse(request)).toEqual({
+        operationType: 'mutation',
+        operationName: 'Login',
+        variables: undefined,
+      })
+    })
+
+    test('parses a mutation with variables (GET)', () => {
+      const handler = new GraphQLHandler('mutation', 'GetUser', '*', resolver)
+      const request = createGetGraphQLRequest({
+        query: LOGIN,
+        variables: {
+          userId: 'abc-123',
+        },
+      })
+
+      expect(handler.parse(request)).toEqual({
+        operationType: 'mutation',
+        operationName: 'Login',
+        variables: {
+          userId: 'abc-123',
+        },
+      })
+    })
+
+    test('parses a mutation without variables (POST)', () => {
+      const handler = new GraphQLHandler('mutation', 'GetUser', '*', resolver)
+      const request = createPostGraphQLRequest({
+        query: LOGIN,
+      })
+
+      expect(handler.parse(request)).toEqual({
+        operationType: 'mutation',
+        operationName: 'Login',
+        variables: undefined,
+      })
+    })
+
+    test('parses a mutation with variables (POST)', () => {
+      const handler = new GraphQLHandler('mutation', 'GetUser', '*', resolver)
+      const request = createPostGraphQLRequest({
+        query: LOGIN,
+        variables: {
+          userId: 'abc-123',
+        },
+      })
+
+      expect(handler.parse(request)).toEqual({
+        operationType: 'mutation',
+        operationName: 'Login',
+        variables: {
+          userId: 'abc-123',
+        },
+      })
+    })
+  })
+})
+
+describe('predicate', () => {
+  test('respects operation type', () => {
+    const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+    const request = createPostGraphQLRequest({
+      query: GET_USER,
+    })
+    const alienRequest = createPostGraphQLRequest({
+      query: LOGIN,
+    })
+
+    expect(handler.predicate(request, handler.parse(request))).toBe(true)
+    expect(handler.predicate(alienRequest, handler.parse(alienRequest))).toBe(
+      false,
+    )
+  })
+
+  test('respects operation name', () => {
+    const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+    const request = createPostGraphQLRequest({
+      query: GET_USER,
+    })
+    const alienRequest = createPostGraphQLRequest({
+      query: `
+          query GetAllUsers {
+            user {
+              id
+            }
+          }
+        `,
+    })
+
+    expect(handler.predicate(request, handler.parse(request))).toBe(true)
+    expect(handler.predicate(alienRequest, handler.parse(alienRequest))).toBe(
+      false,
+    )
+  })
+
+  test('respects custom endpoint', () => {
+    const handler = new GraphQLHandler(
+      'query',
+      'GetUser',
+      'https://api.github.com/graphql',
+      resolver,
+    )
+    const request = createPostGraphQLRequest(
+      {
+        query: GET_USER,
+      },
+      'https://api.github.com/graphql',
+    )
+    const alienRequest = createPostGraphQLRequest({
+      query: GET_USER,
+    })
+
+    expect(handler.predicate(request, handler.parse(request))).toBe(true)
+    expect(handler.predicate(alienRequest, handler.parse(alienRequest))).toBe(
+      false,
+    )
+  })
+})
+
+describe('test', () => {
+  test('respects operation type', () => {
+    const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+    const request = createPostGraphQLRequest({
+      query: GET_USER,
+    })
+    const alienRequest = createPostGraphQLRequest({
+      query: LOGIN,
+    })
+
+    expect(handler.test(request)).toBe(true)
+    expect(handler.test(alienRequest)).toBe(false)
+  })
+
+  test('respects operation name', () => {
+    const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+    const request = createPostGraphQLRequest({
+      query: GET_USER,
+    })
+    const alienRequest = createPostGraphQLRequest({
+      query: `
+          query GetAllUsers {
+            user {
+              id
+            }
+          }
+        `,
+    })
+
+    expect(handler.test(request)).toBe(true)
+    expect(handler.test(alienRequest)).toBe(false)
+  })
+
+  test('respects custom endpoint', () => {
+    const handler = new GraphQLHandler(
+      'query',
+      'GetUser',
+      'https://api.github.com/graphql',
+      resolver,
+    )
+    const request = createPostGraphQLRequest(
+      {
+        query: GET_USER,
+      },
+      'https://api.github.com/graphql',
+    )
+    const alienRequest = createPostGraphQLRequest({
+      query: GET_USER,
+    })
+
+    expect(handler.test(request)).toBe(true)
+    expect(handler.test(alienRequest)).toBe(false)
+  })
+})
+
+describe('run', () => {
+  test('returns a mocked response given a matching query', async () => {
+    const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+    const request = createPostGraphQLRequest({
+      query: GET_USER,
+      variables: {
+        userId: 'abc-123',
+      },
+    })
+    const result = await handler.run(request)
+
+    expect(result).toEqual({
+      handler,
+      request: {
+        ...request,
+        variables: {
+          userId: 'abc-123',
+        },
+      },
+      parsedResult: {
+        operationType: 'query',
+        operationName: 'GetUser',
+        variables: {
+          userId: 'abc-123',
+        },
+      },
+      response: await response(
+        context.data({
+          user: { id: 'abc-123' },
+        }),
+      ),
+    })
+  })
+
+  test('returns null given a non-matching query', async () => {
+    const handler = new GraphQLHandler('query', 'GetUser', '*', resolver)
+    const request = createPostGraphQLRequest({
+      query: LOGIN,
+    })
+    const result = await handler.run(request)
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -104,7 +104,7 @@ export class GraphQLHandler<
     this.endpoint = endpoint
   }
 
-  parse(request: Request) {
+  parse(request: MockedRequest) {
     return parseGraphQLRequest(request)
   }
 
@@ -118,7 +118,7 @@ export class GraphQLHandler<
     }
   }
 
-  predicate(request: Request, parsedResult: ParsedGraphQLRequest) {
+  predicate(request: MockedRequest, parsedResult: ParsedGraphQLRequest) {
     if (!parsedResult) {
       return false
     }

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -113,7 +113,10 @@ export abstract class RequestHandler<
   /**
    * Determine if the captured request should be mocked.
    */
-  abstract predicate(request: Request, parsedResult: ParsedResult): boolean
+  abstract predicate(
+    request: MockedRequest,
+    parsedResult: ParsedResult,
+  ): boolean
 
   /**
    * Print out the successfully handled request.
@@ -129,14 +132,14 @@ export abstract class RequestHandler<
    * Parse the captured request to extract additional information from it.
    * Parsed result is then exposed to other methods of this request handler.
    */
-  parse(request: Request): ParsedResult {
+  parse(request: MockedRequest): ParsedResult {
     return null as any
   }
 
   /**
    * Test if this handler matches the given request.
    */
-  public test(request: Request): boolean {
+  public test(request: MockedRequest): boolean {
     return this.predicate(request, this.parse(request))
   }
 
@@ -145,10 +148,10 @@ export abstract class RequestHandler<
    * from the captured request and its parsed result.
    */
   protected getPublicRequest(
-    request: Request,
+    request: MockedRequest,
     parsedResult: ParsedResult,
-  ): PublicRequest {
-    return request as any
+  ) {
+    return request as PublicRequest
   }
 
   public markAsSkipped(shouldSkip = true) {
@@ -160,7 +163,7 @@ export abstract class RequestHandler<
    * using the given resolver function.
    */
   public async run(
-    request: Request,
+    request: MockedRequest,
   ): Promise<RequestHandlerExecutionResult<PublicRequest> | null> {
     if (this.shouldSkip) {
       return null

--- a/src/utils/internal/parseGraphQLRequest.test.ts
+++ b/src/utils/internal/parseGraphQLRequest.test.ts
@@ -35,7 +35,7 @@ test('returns false given a GraphQL-incompatible request', () => {
     url: new URL('http://localhost:8080/query'),
     headers: new Headers({ 'content-type': 'application/json' }),
   })
-  expect(parseGraphQLRequest(getRequest)).toBeNull()
+  expect(parseGraphQLRequest(getRequest)).toBeUndefined()
 
   const postRequest = createMockedRequest({
     method: 'POST',
@@ -45,5 +45,5 @@ test('returns false given a GraphQL-incompatible request', () => {
       queryUser: true,
     },
   })
-  expect(parseGraphQLRequest(postRequest)).toBeNull()
+  expect(parseGraphQLRequest(postRequest)).toBeUndefined()
 })

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -142,11 +142,11 @@ function getGraphQLInput(request: MockedRequest<any>): GraphQLInput | null {
  */
 export function parseGraphQLRequest(
   request: MockedRequest<any>,
-): ParsedGraphQLRequest | null {
+): ParsedGraphQLRequest {
   const input = getGraphQLInput(request)
 
   if (!input || !input.query) {
-    return null
+    return undefined
   }
 
   const { query, variables } = input
@@ -161,7 +161,7 @@ export function parseGraphQLRequest(
       `[MSW] Failed to intercept a GraphQL request to "${request.method} ${requestPublicUrl}": cannot parse query. See the error message from the parser below.`,
     )
     console.error(parsedResult)
-    return null
+    return undefined
   }
 
   return {


### PR DESCRIPTION
## Changes

- Changes the `request` argument type from `Request` to `MockedRequest` in the GraphQL handler, because it gets a general `MockedRequest` and only then parses/transforms it. 
- Adds tests for the `GraphQLHandler` class. 