### PR TITLE
Sets "process.env.NODE_ENV" to "development" during the build

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -21,6 +21,10 @@ const plugins = [
     mainFields: ['module', 'main', 'jsnext:main', 'browser'],
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
   }),
+  replace({
+    preventAssignment: true,
+    'process.env.NODE_ENV': JSON.stringify('development'),
+  }),
   integrityCheck({
     checksumPlaceholder: '<INTEGRITY_CHECKSUM>',
     input: SERVICE_WORKER_SOURCE_PATH,

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -1,10 +1,5 @@
 import { Headers } from 'headers-utils'
-import {
-  ResponseTransformer,
-  MockedResponse,
-  response,
-  ResponseComposition,
-} from '../response'
+import { MockedResponse, response, ResponseComposition } from '../response'
 import { getCallFrame } from '../utils/internal/getCallFrame'
 import { status } from '../context/status'
 import { set } from '../context/set'


### PR DESCRIPTION
## GitHub

- Fixes #609

## Changes

- The `process.env.NODE_ENV` expression is evaluated to "development" during all builds. This way the third-party code that relies on that expression knows that we're bundling for the development environment. 