### PR TITLE
Replace Object.fromEntries()

### DIFF
--- a/src/utils/request/setRequestCookies.ts
+++ b/src/utils/request/setRequestCookies.ts
@@ -6,10 +6,11 @@ export function setRequestCookies(request: MockedRequest) {
   store.hydrate()
   request.cookies = {
     ...getRequestCookies(request),
-    ...Object.fromEntries(
-      Array.from(
-        store.get({ ...request, url: request.url.toString() })?.entries(),
-      ).map(([name, { value }]) => [name, value]),
+    ...Array.from(
+      store.get({ ...request, url: request.url.toString() })?.entries(),
+    ).reduce(
+      (cookies, [name, { value }]) => Object.assign(cookies, { [name]: value }),
+      {},
     ),
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "declarationDir": "lib/types",
     "lib": [
       "es2017",
-      "ES2019.Object",
       "ESNext.AsyncIterable",
       "dom",
       "webworker"


### PR DESCRIPTION
This PR is intended to fix #625. It replaces the usage of `Object.fromEntries()` with a solution that's compatible with Node.js v10.