### PR TITLE
Updates "headers-utils" to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "chokidar": "^3.4.2",
     "cookie": "^0.4.1",
     "graphql": "^15.4.0",
-    "headers-utils": "^1.2.0",
+    "headers-utils": "^2.0.0",
     "inquirer": "^7.3.3",
     "js-levenshtein": "^1.1.6",
     "node-fetch": "^2.6.1",

--- a/test/msw-api/setup-server/scenarios/xhr.test.ts
+++ b/test/msw-api/setup-server/scenarios/xhr.test.ts
@@ -1,8 +1,8 @@
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
-import { stringToHeaders } from 'headers-utils'
+import { Headers, stringToHeaders } from 'headers-utils'
 
-describe('setupServer / XHR', () => {
+describe('setupServer / XMLHttpRequest', () => {
   const server = setupServer(
     rest.get('http://test.mswjs.io', (req, res, ctx) => {
       return res(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,6 +4204,11 @@ headers-utils@^1.2.0:
   resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-1.2.0.tgz#5e10d1bc9d2bccf789547afca5b991a3167241e8"
   integrity sha512-4/BMXcWrJErw7JpM87gF8MNEXcIMLzepYZjNRv/P9ctgupl2Ywa3u1PgHtNhSRq84bHH9Ndlkdy7bSi+bZ9I9A==
 
+headers-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-2.0.0.tgz#71416271cef9cc145e31f8246ca4501810268235"
+  integrity sha512-LrlYDUo4PIr/wTbJ/HtaMuqYvaYD7eJSwgF2tcpXCmFjvGyrjpKSD39rH8kMGmSEczuFVABQSiAT68FtfAMa+w==
+
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"


### PR DESCRIPTION
- Includes the `Headers.forEach()` callback arguments order fix. 
- Ensures the `Headers` polyfill is compatible with the standard `window.Headers` class (adds iterators). 