### PR TITLE
change `DropFirstInTuple` type for backwards compatibility with older TS versions

### DIFF
--- a/src/utils/internal/compose.ts
+++ b/src/utils/internal/compose.ts
@@ -4,10 +4,10 @@ type LengthOfTuple<Tuple extends any[]> = Tuple extends { length: infer L }
   ? L
   : never
 
-type DropFirstInTuple<Tuple extends any[]> = Tuple extends [
+type DropFirstInTuple<Tuple extends any[]> = ((...args: Tuple) => any) extends (
   arg: any,
   ...rest: infer LastArg
-]
+) => any
   ? LastArg
   : Tuple
 
@@ -34,7 +34,7 @@ export function compose<
 >(
   ...fns: Functions
 ): (
-  ...args: LeftReturnType extends never ? never[] : [LeftReturnType]
+  ...args: [LeftReturnType] extends [never] ? never[] : [LeftReturnType]
 ) => RightReturnType {
   return (...args) => {
     return fns.reduceRight((leftFn: any, rightFn) => {


### PR DESCRIPTION
Right now, just having msw installed in TS versions <= 3.8 will result in a parsing error, completely halting tsc:

[![image](https://user-images.githubusercontent.com/4282439/111801329-237d0080-88cd-11eb-90f7-92c8f94a90f4.png)](https://github.com/rtk-incubator/rtk-query/runs/2149226738?check_suite_focus=true)

This should solve that behaviour.

- Related to #512, #641 