### PR TITLE
Migrates to "@mswjs/interceptors"

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "sideEffects": false,
   "dependencies": {
     "@mswjs/cookies": "^0.1.4",
+    "@mswjs/interceptors": "^0.8.0",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.0",
     "@types/inquirer": "^7.3.1",
@@ -73,12 +74,11 @@
     "chokidar": "^3.4.2",
     "cookie": "^0.4.1",
     "graphql": "^15.4.0",
-    "headers-utils": "^1.2.0",
+    "headers-utils": "^3.0.2",
     "inquirer": "^7.3.3",
     "js-levenshtein": "^1.1.6",
     "node-fetch": "^2.6.1",
     "node-match-path": "^0.6.1",
-    "node-request-interceptor": "^0.6.3",
     "statuses": "^2.0.0",
     "strict-event-emitter": "^0.1.0",
     "yargs": "^16.2.0"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -83,13 +83,13 @@ const buildNode = {
     'tty',
     'os',
     'timers',
-    'node-request-interceptor',
+    '@mswjs/interceptors',
     /**
      * Exclude Node.js request interceptors from being compiled.
-     * @see https://github.com/mswjs/node-request-interceptor/issues/52
+     * @see https://github.com/mswjs/interceptors/issues/52
      */
-    'node-request-interceptor/lib/interceptors/ClientRequest',
-    'node-request-interceptor/lib/interceptors/XMLHttpRequest',
+    '@mswjs/interceptors/lib/interceptors/ClientRequest',
+    '@mswjs/interceptors/lib/interceptors/XMLHttpRequest',
   ],
   output: {
     format: 'cjs',
@@ -125,13 +125,13 @@ const buildNative = {
     'os',
     'util',
     'events',
-    'node-request-interceptor',
+    '@mswjs/interceptors',
     /**
      * Exclude Node.js request interceptors from being compiled.
-     * @see https://github.com/mswjs/node-request-interceptor/issues/52
+     * @see https://github.com/mswjs/interceptors/issues/52
      */
-    'node-request-interceptor/lib/interceptors/ClientRequest',
-    'node-request-interceptor/lib/interceptors/XMLHttpRequest',
+    '@mswjs/interceptors/lib/interceptors/ClientRequest',
+    '@mswjs/interceptors/lib/interceptors/XMLHttpRequest',
   ],
   output: {
     file: 'native/lib/index.js',

--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -13,7 +13,7 @@ export const augmentRequestInit = (requestInit: RequestInit): RequestInit => {
 
   return {
     ...requestInit,
-    headers: headers.getAllHeaders(),
+    headers: headers.all(),
   }
 }
 

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -1,4 +1,4 @@
-import { interceptXMLHttpRequest } from 'node-request-interceptor/lib/interceptors/XMLHttpRequest'
+import { interceptXMLHttpRequest } from '@mswjs/interceptors/lib/interceptors/XMLHttpRequest'
 import { createSetupServer } from '../node/createSetupServer'
 
 // Provision request interception via patching the `XMLHttpRequest` class only

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,4 +1,4 @@
-import { MockedResponse as MockedInterceptedResponse } from 'node-request-interceptor'
+import { IsomorphicResponse } from '@mswjs/interceptors'
 import { MockedRequest, RequestHandler } from '../handlers/RequestHandler'
 import { SharedOptions } from '../sharedOptions'
 
@@ -7,14 +7,8 @@ export interface ServerLifecycleEventsMap {
   'request:match': (request: MockedRequest) => void
   'request:unhandled': (request: MockedRequest) => void
   'request:end': (request: MockedRequest) => void
-  'response:mocked': (
-    response: MockedInterceptedResponse,
-    requestId: string,
-  ) => void
-  'response:bypass': (
-    response: MockedInterceptedResponse,
-    requestId: string,
-  ) => void
+  'response:mocked': (response: IsomorphicResponse, requestId: string) => void
+  'response:bypass': (response: IsomorphicResponse, requestId: string) => void
 }
 
 export interface SetupServerApi {

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,5 +1,5 @@
-import { interceptClientRequest } from 'node-request-interceptor/lib/interceptors/ClientRequest'
-import { interceptXMLHttpRequest } from 'node-request-interceptor/lib/interceptors/XMLHttpRequest'
+import { interceptClientRequest } from '@mswjs/interceptors/lib/interceptors/ClientRequest'
+import { interceptXMLHttpRequest } from '@mswjs/interceptors/lib/interceptors/XMLHttpRequest'
 import { createSetupServer } from './createSetupServer'
 
 /**
@@ -8,6 +8,8 @@ import { createSetupServer } from './createSetupServer'
  * @see {@link https://mswjs.io/docs/api/setup-server `setupServer`}
  */
 export const setupServer = createSetupServer(
+  // List each interceptor separately instead of using the "node" preset
+  // so that MSW wouldn't bundle the unnecessary classes (i.e. "SocketPolyfill").
   interceptClientRequest,
   interceptXMLHttpRequest,
 )

--- a/src/utils/logging/prepareRequest.ts
+++ b/src/utils/logging/prepareRequest.ts
@@ -6,6 +6,6 @@ import { MockedRequest } from '../../handlers/RequestHandler'
 export function prepareRequest(request: MockedRequest) {
   return {
     ...request,
-    headers: request.headers.getAllHeaders(),
+    headers: request.headers.all(),
   }
 }

--- a/src/utils/matching/getCleanMask.ts
+++ b/src/utils/matching/getCleanMask.ts
@@ -1,4 +1,4 @@
-import { getCleanUrl } from 'node-request-interceptor/lib/utils/getCleanUrl'
+import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
 import { Mask, ResolvedMask } from '../../setupWorker/glossary'
 import { getAbsoluteUrl } from '../url/getAbsoluteUrl'
 

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -1,5 +1,5 @@
 import { match } from 'node-match-path'
-import { getCleanUrl } from 'node-request-interceptor/lib/utils/getCleanUrl'
+import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
 import { Mask } from '../../setupWorker/glossary'
 import { getUrlByMask } from '../url/getUrlByMask'
 import { getCleanMask } from './getCleanMask'

--- a/test/graphql-api/response-patching.mocks.ts
+++ b/test/graphql-api/response-patching.mocks.ts
@@ -33,7 +33,7 @@ window.msw = {
 }
 
 // @ts-ignore
-window.dispatchGraphQLQUery = (uri: string) => {
+window.dispatchGraphQLQuery = (uri: string) => {
   const client = createGraphQLClient({ uri })
 
   return client({

--- a/test/msw-api/life-cycle-events/life-cycle-events.node.test.ts
+++ b/test/msw-api/life-cycle-events/life-cycle-events.node.test.ts
@@ -50,7 +50,7 @@ beforeAll(() => {
   })
 
   server.on('response:bypass', (res, reqId) => {
-    listener(`[response:bypass] ${res.headers.server} ${reqId}`)
+    listener(`[response:bypass] ${res.headers.get('server')} ${reqId}`)
   })
 })
 

--- a/test/rest-api/response-patching.mocks.ts
+++ b/test/rest-api/response-patching.mocks.ts
@@ -36,7 +36,7 @@ const worker = setupWorker(
   rest.get('https://test.mswjs.io/headers', async (req, res, ctx) => {
     const originalResponse = await ctx.fetch('/headers-proxy', {
       method: 'POST',
-      headers: req.headers.getAllHeaders(),
+      headers: req.headers.all(),
     })
     const body = await originalResponse.json()
 

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -60,7 +60,7 @@ test('bypasses the original request when it equals the mocked request', async ()
     null,
     (res, url) => {
       return (
-        // Await for the response from MSW, so that original response
+        // Await the response from MSW so that the original response
         // from the same URL would not interfere.
         match(url, res.url()).matches && res.headers()['x-powered-by'] === 'msw'
       )
@@ -91,7 +91,8 @@ test('forwards custom request headers to the original request', async () => {
   const res = await reqPromise
 
   expect(req.headers()).toHaveProperty('authorization', 'token')
-  expect(req.headers()).not.toHaveProperty('map')
+  expect(req.headers()).not.toHaveProperty('_headers')
+  expect(req.headers()).not.toHaveProperty('_names')
 
   const status = res.status()
   const body = await res.json()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,16 @@
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"
 
+"@mswjs/interceptors@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.8.0.tgz#3cf4ff1a8925c999133e8c077b94df5150c54ab1"
+  integrity sha512-Z+ocUNjEYNbTtyKiSAvoX0koN1mXvUzrR1ZqcgzF0jvt1Uqdj8zFmUDB0Lg75O63F53CnngWAF5PN8ueSQnesA==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    debug "^4.3.0"
+    headers-utils "^3.0.2"
+    strict-event-emitter "^0.2.0"
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -3570,6 +3580,11 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 eventsource@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.7.tgz#8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0"
@@ -4203,6 +4218,11 @@ headers-utils@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-1.2.0.tgz#5e10d1bc9d2bccf789547afca5b991a3167241e8"
   integrity sha512-4/BMXcWrJErw7JpM87gF8MNEXcIMLzepYZjNRv/P9ctgupl2Ywa3u1PgHtNhSRq84bHH9Ndlkdy7bSi+bZ9I9A==
+
+headers-utils@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-3.0.2.tgz#dfc65feae4b0e34357308aefbcafa99c895e59ef"
+  integrity sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==
 
 hosted-git-info@^2.1.4:
   version "2.8.8"
@@ -5780,16 +5800,6 @@ node-releases@^1.1.70:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.70.tgz#66e0ed0273aa65666d7fe78febe7634875426a08"
   integrity sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
 
-node-request-interceptor@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.6.3.tgz#f2f0dbec2d421584419dd39ff6782ce1e02b42a7"
-  integrity sha512-8I2V7H2Ch0NvW7qWcjmS0/9Lhr0T6x7RD6PDirhvWEkUQvy83x8BA4haYMr09r/rig7hcgYSjYh6cd4U7G1vLA==
-  dependencies:
-    "@open-draft/until" "^1.0.3"
-    debug "^4.3.0"
-    headers-utils "^1.2.0"
-    strict-event-emitter "^0.1.0"
-
 normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -7196,6 +7206,13 @@ strict-event-emitter@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz#fd742c1fb7e3852f0b964ecdae2d7666a6fb7ef8"
   integrity sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==
+
+strict-event-emitter@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz#78e2f75dc6ea502e5d8a877661065a1e2deedecd"
+  integrity sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==
+  dependencies:
+    events "^3.3.0"
 
 string-argv@0.3.1:
   version "0.3.1"


### PR DESCRIPTION
> BREAKING CHANGE (public).

## Changes

- Updates to @mswjs/interceptors.
- Updates to headers-utils v3.0.x

## Breaking changes

- Calling `setupServer` no longer enables the interception. Calling `server.listen()` does.
- The `response` instance in the life-cycle events now has `response.headers` as the `HeadersPolyfill` instance.

## GitHub

- Closes #648 