### PR TITLE
content-type header parsing: be more forgiving

### DIFF
--- a/src/utils/internal/parseMultipartData.test.ts
+++ b/src/utils/internal/parseMultipartData.test.ts
@@ -1,6 +1,24 @@
 import { parseMultipartData } from './parseMultipartData'
 
 test('parses a given valid multipart string', async () => {
+  expect.assertions(3)
+  await testMultipartDataWithContentType(
+    'multipart/form-data; boundary=WebKitFormBoundaryvZ1cVXWyK0ilQdab',
+  )
+})
+
+test('parses a given valid multipart string give non-pretty content-type', async () => {
+  expect.assertions(3)
+  // node-fetch will serialize content-type in this format, which is valid according to HTTP
+  // https://github.com/node-fetch/node-fetch/blob/d8fc32d6b29bd43d1ad377e80b3e439fe37f2904/test/main.js#L1438
+  await testMultipartDataWithContentType(
+    'multipart/form-data;boundary=WebKitFormBoundaryvZ1cVXWyK0ilQdab',
+  )
+})
+
+async function testMultipartDataWithContentType(
+  contentType: string,
+): Promise<void> {
   const body = `\
 ------WebKitFormBoundaryvZ1cVXWyK0ilQdab\r
 Content-Disposition: form-data; name="file"; filename="file1.txt"\r
@@ -23,8 +41,7 @@ another text content 2\r
 \r
 ------WebKitFormBoundaryvZ1cVXWyK0ilQdab--`
   const headers = new Headers({
-    'content-type':
-      'multipart/form-data; boundary=WebKitFormBoundaryvZ1cVXWyK0ilQdab',
+    'content-type': contentType,
   })
   const parsed = parseMultipartData(body, headers)
 
@@ -37,7 +54,7 @@ another text content 2\r
     'another text content',
     '\r\nanother text content 2\r\n',
   ])
-})
+}
 
 test('returns undefined without an error given an invalid multipart string', () => {
   const headers = new Headers({

--- a/src/utils/internal/parseMultipartData.test.ts
+++ b/src/utils/internal/parseMultipartData.test.ts
@@ -7,12 +7,19 @@ test('parses a given valid multipart string', async () => {
   )
 })
 
-test('parses a given valid multipart string give non-pretty content-type', async () => {
+test('parses a given valid multipart string given non-pretty content-type', async () => {
   expect.assertions(3)
   // node-fetch will serialize content-type in this format, which is valid according to HTTP
   // https://github.com/node-fetch/node-fetch/blob/d8fc32d6b29bd43d1ad377e80b3e439fe37f2904/test/main.js#L1438
   await testMultipartDataWithContentType(
     'multipart/form-data;boundary=WebKitFormBoundaryvZ1cVXWyK0ilQdab',
+  )
+})
+
+test('parses a given valid multipart string given content-type with extra spaces', async () => {
+  expect.assertions(3)
+  await testMultipartDataWithContentType(
+    'multipart/form-data;   boundary=WebKitFormBoundaryvZ1cVXWyK0ilQdab',
   )
 })
 

--- a/src/utils/internal/parseMultipartData.ts
+++ b/src/utils/internal/parseMultipartData.ts
@@ -53,7 +53,7 @@ export function parseMultipartData<T extends DefaultRequestMultipartBody>(
     return undefined
   }
 
-  const [, ...directives] = contentType.split('; ')
+  const [, ...directives] = contentType.split(/; */)
   const boundary = directives
     .filter((d) => d.startsWith('boundary='))
     .map((s) => s.replace(/^boundary=/, ''))[0]


### PR DESCRIPTION
The space after the semicolon delimiter in HTTP header content is optional according to the standard, and a number of implementations will not add such whitespace.

I ran into this problem when mocking form data using the form-data lib (https://www.npmjs.com/package/form-data), which does not add the optional space when serializing headers.

Please let me know if it's worth adding a test _just_ to demonstrate the tolerance of "no-whitespace" headers. I figured that passing the current test should be enough.