### PR TITLE
Consider request unhandled only when it has no handler

### DIFF
--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -103,16 +103,16 @@ export function createSetupServer(...interceptors: Interceptor[]) {
 
         if (!handler) {
           emitter.emit('request:unhandled', mockedRequest)
-        }
-
-        if (!response) {
-          emitter.emit('request:end', mockedRequest)
 
           onUnhandledRequest(
             mockedRequest,
             currentHandlers,
             resolvedOptions.onUnhandledRequest,
           )
+        }
+
+        if (!response) {
+          emitter.emit('request:end', mockedRequest)
           return
         }
 

--- a/src/utils/getResponse.ts
+++ b/src/utils/getResponse.ts
@@ -44,8 +44,17 @@ export const getResponse = async <
 
     const result = await handler.run(request)
 
-    if (result === null || !result.response || result.handler.shouldSkip) {
+    if (result === null || result.handler.shouldSkip) {
       return null
+    }
+
+    if (!result.response) {
+      return {
+        request: result.request,
+        handler: result.handler,
+        response: undefined,
+        parsedResult: result.parsedResult,
+      }
     }
 
     if (result.response.once) {

--- a/test/msw-api/life-cycle-events/life-cycle-events.node.test.ts
+++ b/test/msw-api/life-cycle-events/life-cycle-events.node.test.ts
@@ -81,7 +81,6 @@ test('emits events for a handled request with no response', async () => {
 
   expect(listener.mock.calls).toEqual([
     [`[request:start] POST https://mswjs.io/no-response ${requestId}`],
-    [`[request:unhandled] POST https://mswjs.io/no-response ${requestId}`],
     [`[request:end] POST https://mswjs.io/no-response ${requestId}`],
     [`[response:bypass] Vercel ${requestId}`],
   ])

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
@@ -9,22 +9,37 @@ const server = setupServer(
   rest.get('https://test.mswjs.io/user', (req, res, ctx) => {
     return res(ctx.json({ mocked: true }))
   }),
+  rest.post('https://test.mswjs.io/explicit-return', () => {
+    // Short-circuiting in a handler makes it perform the request as-is,
+    // but still treats this request as handled.
+    return
+  }),
+  rest.post('https://test.mswjs.io/implicit-return', () => {
+    // The handler that has no return also performs the request as-is,
+    // still treating this request as handled.
+  }),
 )
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: 'error' })
 })
 
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation()
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
 afterAll(() => {
+  jest.restoreAllMocks()
   server.close()
 })
 
 test('errors on unhandled request when using the "error" value', async () => {
-  jest.spyOn(console, 'error')
-
-  const getResponse = () => fetch('https://test.mswjs.io')
-
-  await getResponse()
+  const makeRequest = () => fetch('https://test.mswjs.io')
+  await makeRequest()
 
   expect(console.error)
     .toHaveBeenCalledWith(`[MSW] Error: captured a request without a matching request handler:
@@ -33,4 +48,20 @@ test('errors on unhandled request when using the "error" value', async () => {
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
 Read more: https://mswjs.io/docs/getting-started/mocks`)
+})
+
+test('does not error on request which handler explicitly returns no mocked response', async () => {
+  const makeRequest = () =>
+    fetch('https://test.mswjs.io/explicit-return', { method: 'POST' })
+  await makeRequest()
+
+  expect(console.error).not.toHaveBeenCalled()
+})
+
+test('does not error on request which handler implicitly returns no mocked response', async () => {
+  const makeRequest = () =>
+    fetch('https://test.mswjs.io/implicit-return', { method: 'POST' })
+  await makeRequest()
+
+  expect(console.error).not.toHaveBeenCalled()
 })

--- a/test/msw-api/setup-worker/start/on-unhandled-request/warn.mocks.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/warn.mocks.ts
@@ -4,6 +4,15 @@ const worker = setupWorker(
   rest.get('/user', (req, res, ctx) => {
     return res(ctx.json({ firstName: 'John' }))
   }),
+  rest.post('/explicit-return', () => {
+    // Short-circuiting in a handler makes it perform the request as-is,
+    // but still treats this request as handled.
+    return
+  }),
+  rest.post('/implicit-return', () => {
+    // The handler that has no return also performs the request as-is,
+    // still treating this request as handled.
+  }),
 )
 
 worker.start({

--- a/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
@@ -9,7 +9,6 @@ function createRuntime() {
 
 test('warns on an unhandled REST API request with an absolute URL', async () => {
   const { request, consoleSpy } = await createRuntime()
-
   const res = await request('https://mswjs.io/non-existing-page')
   const status = res.status()
 
@@ -26,7 +25,6 @@ test('warns on an unhandled REST API request with an absolute URL', async () => 
 
 test('warns on an unhandled REST API request with a relative URL', async () => {
   const { request, consoleSpy } = await createRuntime()
-
   const res = await request('/user-details')
   const status = res.status()
 
@@ -39,4 +37,36 @@ test('warns on an unhandled REST API request with a relative URL', async () => {
   })
 
   expect(unhandledRequestWarning).toBeDefined()
+})
+
+test('does not warn on request which handler explicitly returns no mocked response', async () => {
+  const { request, consoleSpy } = await createRuntime()
+  const res = await request('/explicit-return', { method: 'POST' })
+  const status = res.status()
+
+  expect(status).toBe(404)
+
+  const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
+    return /\[MSW\] Warning: captured a request without a matching request handler/.test(
+      text,
+    )
+  })
+
+  expect(unhandledRequestWarning).not.toBeDefined()
+})
+
+test('does not warn on request which handler implicitly returns no mocked response', async () => {
+  const { request, consoleSpy } = await createRuntime()
+  const res = await request('/implicit-return', { method: 'POST' })
+  const status = res.status()
+
+  expect(status).toBe(404)
+
+  const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
+    return /\[MSW\] Warning: captured a request without a matching request handler/.test(
+      text,
+    )
+  })
+
+  expect(unhandledRequestWarning).not.toBeDefined()
 })


### PR DESCRIPTION
## GitHub

- Fixes #655
- Closes #662

## Changes

- setupServer: Request is considered unhandled only when it has no corresponding request handler. 
- No matter what the corresponding request handler returns or not, the request is still considered handled. 