### PR TITLE
Bumps "strict-event-emitter" to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "node-fetch": "^2.6.1",
     "node-match-path": "^0.6.1",
     "statuses": "^2.0.0",
-    "strict-event-emitter": "^0.1.0",
+    "strict-event-emitter": "^0.2.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7184,11 +7184,6 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-strict-event-emitter@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz#fd742c1fb7e3852f0b964ecdae2d7666a6fb7ef8"
-  integrity sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==
-
 strict-event-emitter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz#78e2f75dc6ea502e5d8a877661065a1e2deedecd"


### PR DESCRIPTION
Dedupes the dependency as its also used in @mswjs/interceptors. 