### PR TITLE
fix: empty request parameters to be object

### DIFF
--- a/src/handlers/RestHandler.test.ts
+++ b/src/handlers/RestHandler.test.ts
@@ -163,4 +163,16 @@ describe('run', () => {
 
     expect(result).toBeNull()
   })
+
+  test('request params defaults to empty object', async () => {
+    const handler = new RestHandler('GET', '/users', (req, res, ctx) => {
+      res(ctx.status(200))
+    })
+    const request = createMockedRequest({
+      url: new URL('/users', location.href),
+    })
+    const result = await handler.run(request)
+
+    expect(result?.request.params).toEqual({})
+  })
 })

--- a/src/handlers/RestHandler.test.ts
+++ b/src/handlers/RestHandler.test.ts
@@ -164,14 +164,13 @@ describe('run', () => {
     expect(result).toBeNull()
   })
 
-  test('request params defaults to empty object', async () => {
-    const handler = new RestHandler('GET', '/users', (req, res, ctx) => {
-      res(ctx.status(200))
-    })
-    const request = createMockedRequest({
-      url: new URL('/users', location.href),
-    })
-    const result = await handler.run(request)
+  test('returns an empty object as "req.params" given request with no URL parameters', async () => {
+    const handler = new RestHandler('GET', '/users', resolver)
+    const result = await handler.run(
+      createMockedRequest({
+        url: new URL('/users', location.href),
+      }),
+    )
 
     expect(result?.request.params).toEqual({})
   })

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -150,7 +150,7 @@ ${queryParams
   ): RestRequest<any, RequestParams> {
     return {
       ...request,
-      params: parsedResult.params,
+      params: parsedResult.params || {},
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/mswjs/msw/issues/682.

### What

When matched URL does not contain path parameters the `req.params` is `null`. It should always hold a value.

### How

Applied https://github.com/mswjs/node-match-path/pull/39 locally and fixed errors reported by typescript. 

### Testing

- Added a simple unit test to validate `req.params` is an empty object. 
- I don't think integration test is required for this but I'm ready to add one if wanted. 
- Manually verified the fix by applying it locally with repro of the bug issue. 

