### PR TITLE
Move lint ignore comments to top of file

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -1,11 +1,12 @@
+/* eslint-disable */
+/* tslint:disable */
+
 /**
  * Mock Service Worker.
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.
  */
-/* eslint-disable */
-/* tslint:disable */
 
 const INTEGRITY_CHECKSUM = '<INTEGRITY_CHECKSUM>'
 const bypassHeaderName = 'x-msw-bypass'

--- a/test/msw-api/cli/init.test.ts
+++ b/test/msw-api/cli/init.test.ts
@@ -157,14 +157,11 @@ test('does not cause ESLint errors or warnings', async () => {
     exec(`node cli/index.js init ${getPath('public')} --no-save`),
   )
   expect(initStderr).toBe('')
-  expect(fs.existsSync(getPath('public/mockServiceWorker.js'))).toBe(true)
-
-  console.log(fs.readFileSync(getPath('public/mockServiceWorker.js'), 'utf-8'))
 
   const {
     stdout: eslintStdout,
     stderr: eslintStderr,
-  } = await promisifyChildProcess(exec(`npx --no-install eslint ${getPath()}`))
+  } = await promisifyChildProcess(exec(`node_modules/.bin/eslint ${getPath()}`))
   expect(eslintStdout).toBe('')
   expect(eslintStderr).toBe('')
 


### PR DESCRIPTION
At my company, there are lint rules for JSDoc formatted comments. In this particular case, they're requesting a blank line somewhere in the description. Since it seems like the intent is for this file to be completely ignored by linters, I moved the linter disable comments to the very top of the file so that the whole thing will be ignored.