### PR TITLE
setupWorker: Removes "console.log" from the "use" method

### DIFF
--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -144,7 +144,6 @@ export function setupWorker(
     stop: createStop(context),
 
     use(...handlers) {
-      console.log('adding new handlers', handlers)
       requestHandlerUtils.use(context.requestHandlers, ...handlers)
     },
 


### PR DESCRIPTION
Discovered a left-over `console.log` statement called on each `worker.use()` function call. Removes it.