### PR TITLE
Updates "@mswjs/cookies" to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   ],
   "sideEffects": false,
   "dependencies": {
-    "@mswjs/cookies": "^0.1.4",
+    "@mswjs/cookies": "^0.1.5",
     "@mswjs/interceptors": "^0.9.0",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,10 +1163,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mswjs/cookies@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.1.4.tgz#85ef872997eea2acd888f21af0b2067224dac244"
-  integrity sha512-gdtmSv21D4wHTnqF4rrZVX6ye7mQ4nRCTIHYnHBr4SkgoXaiqe3sMvUzXm43+H4PnL0EAKvUTxRVSSXz2xebeg==
+"@mswjs/cookies@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.1.5.tgz#4631f69a1a5c0c7db2b944004081ce35d4255ea9"
+  integrity sha512-sUPoK1JriT0XGGh9j060lsXl4iRlvPfgEU4qc3thGtVYXlKN8G3Xrc7wBgfJy51NOrtLrDwcmpriB8ppHXgAXw==
   dependencies:
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"


### PR DESCRIPTION
Propagates the @mswjs/cookies update to fix #708 ([release notes](https://github.com/mswjs/cookies/releases/tag/v0.1.5)).