### PR TITLE
Adds integration tests for all bundle formats

### DIFF
--- a/test/msw-api/distribution/esm.mocks.ts
+++ b/test/msw-api/distribution/esm.mocks.ts
@@ -1,0 +1,9 @@
+import { setupWorker, rest } from 'msw/lib/esm'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start()

--- a/test/msw-api/distribution/esm.test.ts
+++ b/test/msw-api/distribution/esm.test.ts
@@ -1,0 +1,18 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+
+it('supports the import of the ESM bundle in a browser', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'esm.mocks.ts'),
+  })
+
+  expect(runtime.consoleSpy.get('error')).toBeUndefined()
+
+  const response = await runtime.request('/user')
+
+  expect(response.status()).toEqual(200)
+  expect(response.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await response.json()).toEqual({
+    firstName: 'John',
+  })
+})

--- a/test/msw-api/distribution/iife.mocks.js
+++ b/test/msw-api/distribution/iife.mocks.js
@@ -1,0 +1,9 @@
+const { setupWorker, rest } = MockServiceWorker
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start()

--- a/test/msw-api/distribution/iife.test.ts
+++ b/test/msw-api/distribution/iife.test.ts
@@ -1,0 +1,22 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+
+it('supports the usage of the IIFE bundle in a <script> tag', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'iife.mocks.js'),
+    markup: `
+<script src="/iife/index.js"></script>
+    `,
+    contentBase: path.resolve(process.cwd(), 'lib'),
+  })
+
+  expect(runtime.consoleSpy.get('error')).toBeUndefined()
+
+  const response = await runtime.request('/user')
+
+  expect(response.status()).toEqual(200)
+  expect(response.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await response.json()).toEqual({
+    firstName: 'John',
+  })
+})

--- a/test/msw-api/distribution/umd.mocks.ts
+++ b/test/msw-api/distribution/umd.mocks.ts
@@ -1,0 +1,9 @@
+import { setupWorker, rest } from 'msw/lib/umd'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+
+worker.start()

--- a/test/msw-api/distribution/umd.test.ts
+++ b/test/msw-api/distribution/umd.test.ts
@@ -1,0 +1,18 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+
+it('supports the import of the UMD bundle in a browser', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'umd.mocks.ts'),
+  })
+
+  expect(runtime.consoleSpy.get('error')).toBeUndefined()
+
+  const response = await runtime.request('/user')
+
+  expect(response.status()).toEqual(200)
+  expect(response.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await response.json()).toEqual({
+    firstName: 'John',
+  })
+})


### PR DESCRIPTION
## GitHub

- Pre-requisite for #688 to ensure that the `debug` dependency is bundled properly now when `@mswjs/interceptors` can also run in a browser.

## Changes

- Adds integration tests for all the build formats (UMD/ESM/IIFE) to ensure they work in a browser.

The ESM bundle still remains the main test target, meaning that all the tests are run against the ESM bundle. This set of tests ensures that other bundle formats are also operational by importing/including them directly and setting up a simple request handler. 