### PR TITLE
Allow returning a narrowed BodyType in ResponseTransformer

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -14,8 +14,11 @@ export interface MockedResponse<BodyType = any> {
   delay?: number
 }
 
-export type ResponseTransformer<BodyType = any> = (
-  res: MockedResponse<BodyType>,
+export type ResponseTransformer<
+  BodyType extends TransformerBodyType = any,
+  TransformerBodyType = any
+> = (
+  res: MockedResponse<TransformerBodyType>,
 ) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
 
 export type ResponseFunction<BodyType = any> = (

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -37,3 +37,13 @@ rest.get<
   // @ts-expect-error `null` is not a valid response body type.
   null
 >('/user', () => null)
+
+rest.get<any, { label: boolean }>('/user', (req, res, ctx) =>
+  // allow ResponseTransformer to contain a more specific type
+  res(ctx.json({ label: true })),
+)
+
+rest.get<any, string | string[]>('/user', (req, res, ctx) =>
+  // allow ResponseTransformer to return a narrower type than a given union
+  res(ctx.json('hello')),
+)


### PR DESCRIPTION
It's cumbersome only being able to send the exact BodyType generic to `ctx.json`

```typescript
rest.get<any, { result: boolean }>('/user', (req, res, ctx) =>
  res(ctx.json({ result: true })), // This will error: Type '{ result: boolean; }' is not assignable to type '{ result: true; }'
)
```

Being able to return a narrowed type is also helpful when dealing with union response types

```typescript
rest.get<any, string | string[]>('/user', (req, res, ctx) =>
  res(ctx.json('hello')), // This will error: Type 'string | string[]' is not assignable to type 'string'
)
```