### PR TITLE
chore: add .husky folder required by husky 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp
 stats.html
 .vscode
 msw-*.tgz
+.husky/_

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -20,12 +20,8 @@
     "test:ts": "tsc -p test/typings/tsconfig.json",
     "test:focused": "node node_modules/ts-node/dist/bin.js --project=test/tsconfig.json test/focusedTest.ts",
     "prepublishOnly": "yarn lint && yarn test:unit && yarn build && yarn test:integration",
+    "prepare": "husky install",
     "postinstall": "node -e \"try{require('./config/scripts/postinstall')}catch(e){}\""
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
Using husky 5 all hooks have been moved to `.husky` folder. 

I have also added a `prepare` script that will add a new bash script inside .husky that is used for running hooks

https://typicode.github.io/husky/#/?id=features