### PR TITLE
onUnhandledRequest: Suppress exceptions when parsing potential GraphQL requests

### DIFF
--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -23,6 +23,7 @@ import {
   parseGraphQLRequest,
 } from '../utils/internal/parseGraphQLRequest'
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
+import { tryCatch } from '../utils/internal/tryCatch'
 
 export type ExpectedOperationTypeNode = OperationTypeNode | 'all'
 export type GraphQLHandlerNameSelector = RegExp | string
@@ -108,7 +109,10 @@ export class GraphQLHandler<
   }
 
   parse(request: MockedRequest) {
-    return parseGraphQLRequest(request)
+    return tryCatch(
+      () => parseGraphQLRequest(request),
+      (error) => console.error(error.message),
+    )
   }
 
   protected getPublicRequest(

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -157,11 +157,9 @@ export function parseGraphQLRequest(
 
     // Encountered a matching GraphQL request that is syntactically invalid.
     // We may consider getting the parsing error and propagating it to the user.
-    console.error(
+    throw new Error(
       `[MSW] Failed to intercept a GraphQL request to "${request.method} ${requestPublicUrl}": cannot parse query. See the error message from the parser below.`,
     )
-    console.error(parsedResult)
-    return undefined
   }
 
   return {

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -155,10 +155,8 @@ export function parseGraphQLRequest(
   if (parsedResult instanceof Error) {
     const requestPublicUrl = getPublicUrlFromRequest(request)
 
-    // Encountered a matching GraphQL request that is syntactically invalid.
-    // We may consider getting the parsing error and propagating it to the user.
     throw new Error(
-      `[MSW] Failed to intercept a GraphQL request to "${request.method} ${requestPublicUrl}": cannot parse query. See the error message from the parser below.`,
+      `[MSW] Failed to intercept a GraphQL request to "${request.method} ${requestPublicUrl}": cannot parse query. See the error message from the parser below.\n\n${parsedResult}`,
     )
   }
 

--- a/src/utils/internal/tryCatch.test.ts
+++ b/src/utils/internal/tryCatch.test.ts
@@ -1,0 +1,27 @@
+import { tryCatch } from './tryCatch'
+
+test('returns the function payload', () => {
+  const result = tryCatch(() => 'hello')
+  expect(result).toEqual('hello')
+})
+
+test('silences exceptions by default', () => {
+  const result = tryCatch(() => {
+    throw new Error('Exception')
+  })
+
+  expect(result).toBeUndefined()
+})
+
+test('executes a custom callback function when an exception occurs', (done) => {
+  tryCatch(
+    () => {
+      throw new Error('Exception')
+    },
+    (error) => {
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message).toEqual('Exception')
+      done()
+    },
+  )
+})

--- a/src/utils/internal/tryCatch.ts
+++ b/src/utils/internal/tryCatch.ts
@@ -1,0 +1,11 @@
+export function tryCatch<Fn extends (...args: any[]) => any>(
+  fn: Fn,
+  onException?: (error: Error) => void,
+): ReturnType<Fn> | undefined {
+  try {
+    const result = fn()
+    return result
+  } catch (error) {
+    onException?.(error)
+  }
+}

--- a/src/utils/request/onUnhandledRequest.ts
+++ b/src/utils/request/onUnhandledRequest.ts
@@ -116,6 +116,17 @@ ${handlers.map((handler) => `  • ${handler.info.header}`).join('\n')}`
   return `Did you mean to request "${handlers[0].info.header}" instead?`
 }
 
+export function tryAndSilenceIfThrows<Payload>(
+  fn: () => Payload,
+): Payload | null {
+  try {
+    const payload = fn()
+    return payload
+  } catch (error) {
+    return null
+  }
+}
+
 export function onUnhandledRequest(
   request: MockedRequest,
   handlers: RequestHandler[],
@@ -126,7 +137,10 @@ export function onUnhandledRequest(
     return
   }
 
-  const parsedGraphQLQuery = parseGraphQLRequest(request)
+  // TODO: comment and exlain why we don't want to ignore the error if parsing fails here
+  const parsedGraphQLQuery = tryAndSilenceIfThrows(() =>
+    parseGraphQLRequest(request),
+  )
   const handlerGroups = groupHandlersByType(handlers)
   const relevantHandlers = parsedGraphQLQuery
     ? handlerGroups.graphql


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/732

Tries and apply what @kettanaito suggested to avoid logging an error when an unhandled rest request containing a _query_ param would result in a confusing error message in the console

@kettanaito  please let me know if this is what you meant and/or how this can be improved

thanks