### PR TITLE
Sets Codesandbox "node" version to 12

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
+  "node": "12",
   "sandboxes": ["msw-react-xx1c8"]
 }


### PR DESCRIPTION
Fixes the broken Codesandbox integration. 

Sets an explicit `node` version in `ci.json` for Codesandbox to prevent this error during the sandbox installation:

```
error yargs@17.0.1: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.24.1"
error Found incompatible module.
```

It appears that Codesandbox uses node@10 by default, which renders certain dependencies incompatible. 