### PR TITLE
Add `ctx.cookie` to GraphQL context

### DIFF
--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -6,6 +6,7 @@ import { delay } from '../context/delay'
 import { fetch } from '../context/fetch'
 import { data, DataContext } from '../context/data'
 import { errors } from '../context/errors'
+import { cookie } from '../context/cookie'
 import {
   MockedRequest,
   RequestHandler,
@@ -36,6 +37,7 @@ export type GraphQLContext<QueryType> = {
   fetch: typeof fetch
   data: DataContext<QueryType>
   errors: typeof errors
+  cookie: typeof cookie
 }
 
 export const graphqlContext: GraphQLContext<any> = {
@@ -45,6 +47,7 @@ export const graphqlContext: GraphQLContext<any> = {
   fetch,
   data,
   errors,
+  cookie,
 }
 
 export type GraphQLVariables = Record<string, any>

--- a/test/graphql-api/cookies.mocks.ts
+++ b/test/graphql-api/cookies.mocks.ts
@@ -1,11 +1,11 @@
 import { setupWorker, graphql } from 'msw'
 
 const worker = setupWorker(
-  graphql.query('me', (req, res, ctx) => {
+  graphql.query('GetUser', (req, res, ctx) => {
     return res(
       ctx.cookie('test-cookie', 'value'),
       ctx.data({
-        id: '00000000-0000-0000-0000-000000000000',
+        firstName: 'John',
       }),
     )
   }),

--- a/test/graphql-api/cookies.mocks.ts
+++ b/test/graphql-api/cookies.mocks.ts
@@ -1,0 +1,14 @@
+import { setupWorker, graphql } from 'msw'
+
+const worker = setupWorker(
+  graphql.query('me', (req, res, ctx) => {
+    return res(
+      ctx.cookie('test-cookie', 'value'),
+      ctx.data({
+        id: '00000000-0000-0000-0000-000000000000',
+      }),
+    )
+  }),
+)
+
+worker.start()

--- a/test/graphql-api/cookies.node.test.ts
+++ b/test/graphql-api/cookies.node.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import fetch from 'cross-fetch'
+import { graphql as executeGraphql } from 'graphql'
+import { buildSchema } from 'graphql/utilities'
+import * as cookieUtils from 'cookie'
+import { gql } from '../support/graphql'
+
+const schema = gql`
+  type User {
+    id: String!
+  }
+
+  type Query {
+    me: User!
+  }
+`
+
+const server = setupServer(
+  graphql.query('Me', async (req, res, ctx) => {
+    const executionResult = await executeGraphql({
+      schema: buildSchema(schema),
+      source: req.body.query,
+      rootValue: {
+        me: {
+          id: '00000000-0000-0000-0000-000000000000',
+        },
+      },
+    })
+
+    return res(
+      ctx.cookie('test-cookie', 'value'),
+      ctx.data(executionResult.data),
+      ctx.errors(executionResult.errors),
+    )
+  }),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+test('sets cookie on the mocked response', async () => {
+  const res = await fetch('https://api.mswjs.io', {
+    method: 'POST',
+    headers: {
+      accept: '*/*',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: gql`
+        query Me {
+          me {
+            id
+          }
+        }
+      `,
+    }),
+  })
+  const body = await res.json()
+  const cookieString = res.headers.get('set-cookie')
+  const allCookies = cookieUtils.parse(cookieString)
+
+  expect(cookieString).toBe('test-cookie=value')
+  expect(body).toEqual({
+    data: {
+      me: {
+        id: '00000000-0000-0000-0000-000000000000',
+      },
+    },
+  })
+  expect(allCookies).toHaveProperty('test-cookie', 'value')
+  expect(body.errors).toBeUndefined()
+})

--- a/test/graphql-api/cookies.test.ts
+++ b/test/graphql-api/cookies.test.ts
@@ -2,18 +2,19 @@ import * as path from 'path'
 import * as cookieUtils from 'cookie'
 import { pageWith } from 'page-with'
 import { executeGraphQLQuery } from './utils/executeGraphQLQuery'
+import { gql } from '../support/graphql'
 
 function createRuntime() {
   return pageWith({ example: path.resolve(__dirname, 'cookies.mocks.ts') })
 }
 
-test('sets cookie on the mocked response', async () => {
+test('sets cookie on the mocked GraphQL response', async () => {
   const runtime = await createRuntime()
 
   const res = await executeGraphQLQuery(runtime.page, {
-    query: `
-      query me {
-        id
+    query: gql`
+      query GetUser {
+        firstName
       }
     `,
   })
@@ -25,7 +26,7 @@ test('sets cookie on the mocked response', async () => {
   expect(headers).not.toHaveProperty('set-cookie')
   expect(body).toEqual({
     data: {
-      id: '00000000-0000-0000-0000-000000000000',
+      firstName: 'John',
     },
   })
 

--- a/test/graphql-api/cookies.test.ts
+++ b/test/graphql-api/cookies.test.ts
@@ -1,0 +1,38 @@
+import * as path from 'path'
+import * as cookieUtils from 'cookie'
+import { pageWith } from 'page-with'
+import { executeGraphQLQuery } from './utils/executeGraphQLQuery'
+
+function createRuntime() {
+  return pageWith({ example: path.resolve(__dirname, 'cookies.mocks.ts') })
+}
+
+test('sets cookie on the mocked response', async () => {
+  const runtime = await createRuntime()
+
+  const res = await executeGraphQLQuery(runtime.page, {
+    query: `
+      query me {
+        id
+      }
+    `,
+  })
+
+  const headers = res.headers()
+  const body = await res.json()
+
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(headers).not.toHaveProperty('set-cookie')
+  expect(body).toEqual({
+    data: {
+      id: '00000000-0000-0000-0000-000000000000',
+    },
+  })
+
+  // Should be able to access the response cookies.
+  const cookieString = await runtime.page.evaluate(() => {
+    return document.cookie
+  })
+  const allCookies = cookieUtils.parse(cookieString)
+  expect(allCookies).toHaveProperty('test-cookie', 'value')
+})


### PR DESCRIPTION
As per #755, this adds the `ctx.cookie` method to the context provided to GraphQL handlers. If you have recommendations for other test cases, or improvements to the ones I added, I'd be very happy to hear them.

- Fixes #755 

Cheers!