### PR TITLE
chore: codesandbox preview never updates the worker

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -17,6 +17,7 @@ self.addEventListener('install', function () {
 })
 
 self.addEventListener('activate', async function (event) {
+  console.log('worker activated!')
   return self.clients.claim()
 })
 

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -17,7 +17,7 @@ self.addEventListener('install', function () {
 })
 
 self.addEventListener('activate', async function (event) {
-  console.log('worker activated!')
+  console.log('worker activated! should see this')
   return self.clients.claim()
 })
 

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -17,7 +17,7 @@ self.addEventListener('install', function () {
 })
 
 self.addEventListener('activate', async function (event) {
-  console.log('worker activated! should see this')
+  console.log('THIS MUST BE SEEN!')
   return self.clients.claim()
 })
 


### PR DESCRIPTION
## Context

- #545 

We have a [CodeSandbox template](https://codesandbox.io/s/msw-react-xx1c8) used for all our opened pull requests:

https://github.com/mswjs/msw/blob/9373ccf5e699fd46406aadbb55580b4a833e4541/.codesandbox/ci.json#L1-L4

That template contains the `mockServiceWorker.js` file that's a part of the library but is not installed directly (needs to be placed in a public directory manually, or automatically by including the path in `packageJson.msw.workerDirectory`). 

## Expected behavior

The sandbox has the `packageJson.msw.workerDirectory` property set, which triggers MSW to copy the worker script from the currently installed library version (in this case a pull request preview's built) into the specified public directory. 

https://github.com/mswjs/msw/blob/9373ccf5e699fd46406aadbb55580b4a833e4541/config/scripts/postinstall.js#L34-L36

## Current behavior

The worker script is never updated, regardless of the sandbox configuration. This results in a pull request built being out of sync with the worker script changes.

## Steps to reproduce

1. Go to the preview sandbox of this pull request (link in the comment below).
2. Open the `public/mockServiceWorker.js` file.
3. See that it has no changes done to this file in this pull request.

## Things we've tried

1. Setting `"template": "node"` in our `sandbox.config.json` (seems to be applied when editing the config file in the editor, the UI shows "Angular" as the selected option for some reason).