### PR TITLE
Spies on console in tests

### DIFF
--- a/test/msw-api/setup-server/resetHandlers.test.ts
+++ b/test/msw-api/setup-server/resetHandlers.test.ts
@@ -11,8 +11,15 @@ const server = setupServer(
   }),
 )
 
-beforeAll(() => server.listen())
-afterAll(() => server.close())
+beforeAll(() => {
+  jest.spyOn(global.console, 'warn').mockImplementation()
+  server.listen()
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+  server.close()
+})
 
 test('removes all runtime request handlers when resetting without explicit next handlers', async () => {
   server.use(

--- a/test/msw-api/setup-server/scenarios/fall-through.node.test.ts
+++ b/test/msw-api/setup-server/scenarios/fall-through.node.test.ts
@@ -20,10 +20,12 @@ const server = setupServer(
 )
 
 beforeAll(() => {
+  jest.spyOn(global.console, 'warn').mockImplementation()
   server.listen()
 })
 
 afterAll(() => {
+  jest.restoreAllMocks()
   server.close()
 })
 


### PR DESCRIPTION
## Changes

- Adds `jest.spyOn` on `console.warn` to silence the unhandled requests warning in irrelevant tests. 