### PR TITLE
feat(gql): support DocumentNode and TypedDocumentNode

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,3 +1,4 @@
+import { DocumentNode } from 'graphql'
 import { Path } from 'node-match-path'
 import { ResponseResolver } from './handlers/RequestHandler'
 import {
@@ -9,6 +10,14 @@ import {
   GraphQLHandlerNameSelector,
 } from './handlers/GraphQLHandler'
 
+export interface TypedDocumentNode<
+  Result = { [key: string]: any },
+  Variables = { [key: string]: any },
+> extends DocumentNode {
+  __resultType?: Result
+  __variablesType?: Variables
+}
+
 function createScopedGraphQLHandler(
   operationType: ExpectedOperationTypeNode,
   url: Path,
@@ -17,7 +26,10 @@ function createScopedGraphQLHandler(
     Query extends Record<string, any>,
     Variables extends GraphQLVariables = GraphQLVariables,
   >(
-    operationName: GraphQLHandlerNameSelector,
+    operationName:
+      | GraphQLHandlerNameSelector
+      | DocumentNode
+      | TypedDocumentNode<Query, Variables>,
     resolver: ResponseResolver<
       GraphQLRequest<Variables>,
       GraphQLContext<Query>

--- a/src/handlers/GraphQLHandler.test.ts
+++ b/src/handlers/GraphQLHandler.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { parse } from 'graphql'
 import { Headers } from 'headers-utils/lib'
 import { context } from '..'
 import { createMockedRequest } from '../../test/support/utils'
@@ -10,6 +11,7 @@ import {
   GraphQLHandler,
   GraphQLRequest,
   GraphQLRequestBody,
+  isDocumentNode,
 } from './GraphQLHandler'
 import { MockedRequest, ResponseResolver } from './RequestHandler'
 
@@ -81,6 +83,51 @@ describe('info', () => {
     expect(handler.info.header).toEqual('mutation Login (origin: *)')
     expect(handler.info.operationType).toEqual('mutation')
     expect(handler.info.operationName).toEqual('Login')
+  })
+
+  test('parses a query operation name from a given DocumentNode', () => {
+    const node = parse(`
+      query GetUser {
+        user {
+          firstName
+        }
+      }
+    `)
+
+    const handler = new GraphQLHandler('query', node, '*', resolver)
+
+    expect(handler.info).toHaveProperty('header', 'query GetUser (origin: *)')
+    expect(handler.info).toHaveProperty('operationType', 'query')
+    expect(handler.info).toHaveProperty('operationName', 'GetUser')
+  })
+
+  test('parses a mutation operation name from a given DocumentNode', () => {
+    const node = parse(`
+      mutation Login {
+        user {
+          id
+        }
+      }
+    `)
+    const handler = new GraphQLHandler('mutation', node, '*', resolver)
+
+    expect(handler.info).toHaveProperty('header', 'mutation Login (origin: *)')
+    expect(handler.info).toHaveProperty('operationType', 'mutation')
+    expect(handler.info).toHaveProperty('operationName', 'Login')
+  })
+
+  test('throws an exception given a DocumentNode with a mismatched operation type', () => {
+    const node = parse(`
+      mutation CreateUser {
+        user {
+          firstName
+        }
+      }
+    `)
+
+    expect(() => new GraphQLHandler('query', node, '*', resolver)).toThrow(
+      'Failed to create a GraphQL handler: provided a DocumentNode with a mismatched operation type (expected "query", but got "mutation").',
+    )
   })
 })
 
@@ -372,5 +419,27 @@ describe('run', () => {
     const result = await handler.run(request)
 
     expect(result).toBeNull()
+  })
+})
+
+describe('isDocumentNode', () => {
+  it('returns true given a valid DocumentNode', () => {
+    const node = parse(`
+      query GetUser {
+        user {
+          login
+        }
+      }
+    `)
+
+    expect(isDocumentNode(node)).toEqual(true)
+  })
+
+  it('returns false given an arbitrary input', () => {
+    expect(isDocumentNode(null)).toEqual(false)
+    expect(isDocumentNode(undefined)).toEqual(false)
+    expect(isDocumentNode('')).toEqual(false)
+    expect(isDocumentNode('value')).toEqual(false)
+    expect(isDocumentNode(/value/)).toEqual(false)
   })
 })

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -1,4 +1,9 @@
-import { OperationDefinitionNode, OperationTypeNode, parse } from 'graphql'
+import {
+  DocumentNode,
+  OperationDefinitionNode,
+  OperationTypeNode,
+  parse,
+} from 'graphql'
 import { GraphQLVariables } from '../../handlers/GraphQLHandler'
 import { MockedRequest } from '../../handlers/RequestHandler'
 import { getPublicUrlFromRequest } from '../request/getPublicUrlFromRequest'
@@ -23,18 +28,21 @@ export type ParsedGraphQLRequest<
     })
   | undefined
 
+export function parseDocumentNode(node: DocumentNode): ParsedGraphQLQuery {
+  const operationDef = node.definitions.find((def) => {
+    return def.kind === 'OperationDefinition'
+  }) as OperationDefinitionNode
+
+  return {
+    operationType: operationDef?.operation,
+    operationName: operationDef?.name?.value,
+  }
+}
+
 function parseQuery(query: string): ParsedGraphQLQuery | Error {
   try {
     const ast = parse(query)
-
-    const operationDef = ast.definitions.find((def) => {
-      return def.kind === 'OperationDefinition'
-    }) as OperationDefinitionNode
-
-    return {
-      operationType: operationDef?.operation,
-      operationName: operationDef?.name?.value,
-    }
+    return parseDocumentNode(ast)
   } catch (error) {
     return error
   }

--- a/test/graphql-api/document-node.mocks.ts
+++ b/test/graphql-api/document-node.mocks.ts
@@ -1,0 +1,70 @@
+import { parse } from 'graphql'
+import { setupWorker, graphql } from 'msw'
+
+const GetUser = parse(`
+  query GetUser {
+    user {
+      firstName
+    }
+  }
+`)
+
+const Login = parse(`
+  mutation Login($username: String!) {
+    session {
+      id
+    }
+    user {
+      username
+    }
+  }
+`)
+
+const GetSubscription = parse(`
+  query GetSubscription {
+    subscription {
+      id
+    }
+  }
+`)
+
+const github = graphql.link('https://api.github.com/graphql')
+
+const worker = setupWorker(
+  // "DocumentNode" can be used as the expected query/mutation.
+  graphql.query(GetUser, (req, res, ctx) => {
+    return res(
+      ctx.data({
+        // Note that inferring the query body and variables
+        // is impossible with the native "DocumentNode".
+        // Consider using tools like GraphQL Code Generator.
+        user: {
+          firstName: 'John',
+        },
+      }),
+    )
+  }),
+  graphql.mutation(Login, (req, res, ctx) => {
+    return res(
+      ctx.data({
+        session: {
+          id: 'abc-123',
+        },
+        user: {
+          username: req.variables.username,
+        },
+      }),
+    )
+  }),
+  github.query(GetSubscription, (req, res, ctx) => {
+    return res(
+      ctx.data({
+        subscription: {
+          id: 123,
+        },
+      }),
+    )
+  }),
+)
+
+worker.start()

--- a/test/graphql-api/document-node.test.ts
+++ b/test/graphql-api/document-node.test.ts
@@ -1,0 +1,100 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { executeGraphQLQuery } from './utils/executeGraphQLQuery'
+import { gql } from '../support/graphql'
+
+function prepareRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'document-node.mocks.ts'),
+  })
+}
+
+test('intercepts a GraphQL query based on its DocumentNode', async () => {
+  const runtime = await prepareRuntime()
+
+  const res = await executeGraphQLQuery(runtime.page, {
+    query: gql`
+      query GetUser {
+        user {
+          firstName
+        }
+      }
+    `,
+  })
+
+  expect(res.status()).toEqual(200)
+  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+
+  const json = await res.json()
+  expect(json).toEqual({
+    data: {
+      user: {
+        firstName: 'John',
+      },
+    },
+  })
+})
+
+test('intercepts a GraphQL mutation based on its DocumentNode', async () => {
+  const runtime = await prepareRuntime()
+
+  const res = await executeGraphQLQuery(runtime.page, {
+    query: gql`
+      mutation Login {
+        session {
+          id
+        }
+      }
+    `,
+    variables: {
+      username: 'octocat',
+    },
+  })
+
+  expect(res.status()).toEqual(200)
+  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+
+  const json = await res.json()
+  expect(json).toEqual({
+    data: {
+      session: {
+        id: 'abc-123',
+      },
+      user: {
+        username: 'octocat',
+      },
+    },
+  })
+})
+
+test('intercepts a scoped GraphQL query based on its DocumentNode', async () => {
+  const runtime = await prepareRuntime()
+
+  const res = await executeGraphQLQuery(
+    runtime.page,
+    {
+      query: gql`
+        query GetSubscription {
+          subscription {
+            id
+          }
+        }
+      `,
+    },
+    {
+      uri: 'https://api.github.com/graphql',
+    },
+  )
+
+  expect(res.status()).toEqual(200)
+  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+
+  const json = await res.json()
+  expect(json).toEqual({
+    data: {
+      subscription: {
+        id: 123,
+      },
+    },
+  })
+})

--- a/test/typings/graphql.test-d.ts
+++ b/test/typings/graphql.test-d.ts
@@ -1,3 +1,4 @@
+import { parse } from 'graphql'
 import { graphql } from 'msw'
 
 graphql.query<{ key: string }>('', (req, res, ctx) => {
@@ -50,3 +51,61 @@ graphql.operation<
 >((req, res, ctx) => {
   return res(ctx.data({ key: 'pass' }))
 })
+
+/**
+ * Supports `DocumentNode` as the GraphQL operation name.
+ */
+const getUser = parse(`
+  query GetUser {
+    user {
+      firstName
+    }
+  }
+`)
+graphql.query(getUser, (req, res, ctx) =>
+  res(
+    ctx.data({
+      // Cannot extract query type from the runtime `DocumentNode`.
+      arbitrary: true,
+    }),
+  ),
+)
+
+const getUserById = parse(`
+  query GetUserById($userId: String!) {
+    user(id: $userId) {
+      firstName
+    }
+  }
+`)
+graphql.query(getUserById, (req, res, ctx) => {
+  req.variables.userId
+
+  // Extracting variables from the native "DocumentNode" is impossible.
+  req.variables.foo
+
+  return res(
+    ctx.data({
+      user: {
+        firstName: 'John',
+        // Extracting a query body type from the "DocumentNode" is impossible.
+        lastName: 'Maverick',
+      },
+    }),
+  )
+})
+
+const createUser = parse(`
+  mutation CreateUser {
+    user {
+      id
+    }
+  }
+`)
+graphql.mutation(createUser, (req, res, ctx) =>
+  res(
+    ctx.data({
+      arbitrary: true,
+    }),
+  ),
+)


### PR DESCRIPTION
Allows consistent usage of `TypedDocumentNode` between graphQL use and mocking.

References to `TypedDocumentNode` 
- https://the-guild.dev/blog/typed-document-node
- https://the-guild.dev/blog/graphql-with-typescript-done-right

closes #773 