### PR TITLE
Injects the built package version into the worker script

### DIFF
--- a/config/plugins/rollup-integrity-check-plugin/index.js
+++ b/config/plugins/rollup-integrity-check-plugin/index.js
@@ -3,15 +3,21 @@ const path = require('path')
 const chalk = require('chalk')
 const replace = require('@rollup/plugin-replace')
 const getChecksum = require('./getChecksum')
+const packageJson = require('../../../package.json')
 
-module.exports = function integrityCheck(options) {
-  const { input, output, checksumPlaceholder } = options
-
-  function injectChecksum(checksum) {
-    return {
-      SERVICE_WORKER_CHECKSUM: JSON.stringify(checksum),
-    }
+function injectChecksum(checksum) {
+  return {
+    SERVICE_WORKER_CHECKSUM: JSON.stringify(checksum),
   }
+}
+
+module.exports = function integrityCheckPlugin(options) {
+  const {
+    input,
+    output,
+    checksumPlaceholder,
+    packageVersionPlaceholder,
+  } = options
 
   return {
     name: 'integrity-check',
@@ -29,10 +35,9 @@ module.exports = function integrityCheck(options) {
       this.checksum = getChecksum(input)
 
       const workerContent = fs.readFileSync(input, 'utf8')
-      const publicWorkerContent = workerContent.replace(
-        checksumPlaceholder,
-        this.checksum,
-      )
+      const publicWorkerContent = workerContent
+        .replace(checksumPlaceholder, this.checksum)
+        .replace(packageVersionPlaceholder, packageJson.version)
 
       this.emitFile({
         type: 'asset',

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -16,8 +16,9 @@ const {
 
 const extensions = ['.js', '.ts']
 
-const integrityOptions = {
+const integrityPluginOptions = {
   checksumPlaceholder: '<INTEGRITY_CHECKSUM>',
+  packageVersionPlaceholder: '<PACKAGE_VERSION>',
   input: SERVICE_WORKER_SOURCE_PATH,
   output: SERVICE_WORKER_BUILD_PATH,
 }
@@ -51,7 +52,7 @@ const buildEsm = {
       preventAssignment: true,
       'process.env.NODE_ENV': JSON.stringify('development'),
     }),
-    integrityCheck(integrityOptions),
+    integrityCheck(integrityPluginOptions),
     typescript({
       useTsconfigDeclarationDir: true,
     }),
@@ -82,7 +83,7 @@ const buildUmd = {
       mainFields: ['browser', 'main', 'module'],
       extensions,
     }),
-    integrityCheck(integrityOptions),
+    integrityCheck(integrityPluginOptions),
     typescript({
       useTsconfigDeclarationDir: true,
     }),
@@ -197,7 +198,7 @@ const buildIife = {
       mainFields: ['browser', 'module', 'main', 'jsnext:main'],
       extensions,
     }),
-    integrityCheck(integrityOptions),
+    integrityCheck(integrityPluginOptions),
     typescript({
       useTsconfigDeclarationDir: true,
     }),

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker.
+ * Mock Service Worker (<PACKAGE_VERSION>).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.


### PR DESCRIPTION
## Changes

- The built package version is now injected into the worker script (`mockServiceWorker.js`).

## Motivation

- Makes it easier to review code that commits changes to the worker script (i.e. library updates).
- Makes it easier to support the library users if the package version is directly included in the script, as opposed to figuring out the package version from the script's hash sum.

## GitHub

- Closes #779 