### PR TITLE
Warns on pages that are outside of the worker's scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "jest": "^26.6.3",
     "json-bigint": "^1.0.0",
     "lint-staged": "^11.0.0",
-    "page-with": "^0.3.6",
+    "page-with": "^0.4.0",
     "prettier": "^2.2.1",
     "regenerator-runtime": "^0.13.7",
     "rimraf": "^3.0.2",

--- a/src/setupWorker/start/createStartHandler.ts
+++ b/src/setupWorker/start/createStartHandler.ts
@@ -6,6 +6,7 @@ import { createRequestListener } from '../../utils/worker/createRequestListener'
 import { requestIntegrityCheck } from '../../utils/internal/requestIntegrityCheck'
 import { deferNetworkRequestsUntil } from '../../utils/deferNetworkRequestsUntil'
 import { createResponseListener } from '../../utils/worker/createResponseListener'
+import { validateWorkerScope } from './utils/validateWorkerScope'
 
 export const createStartHandler = (
   context: SetupWorkerInternalContext,
@@ -91,6 +92,10 @@ If this message still persists after updating, please report an issue: https://g
         () => context.workerChannel.send('KEEPALIVE_REQUEST'),
         5000,
       )
+
+      // Warn the user when loading the page that lies outside
+      // of the worker's scope.
+      validateWorkerScope(registration, context.startOptions)
 
       return registration
     }

--- a/src/setupWorker/start/utils/validateWorkerScope.ts
+++ b/src/setupWorker/start/utils/validateWorkerScope.ts
@@ -1,0 +1,17 @@
+import { StartOptions } from '../../glossary'
+
+export function validateWorkerScope(
+  registration: ServiceWorkerRegistration,
+  options?: StartOptions,
+): void {
+  if (!options?.quiet && !location.href.startsWith(registration.scope)) {
+    console.warn(
+      `\
+[MSW] Cannot intercept requests on this page because it's outside of the worker's scope ("${registration.scope}"). If you wish to mock API requests on this page, you must resolve this scope issue.
+
+- (Recommended) Register the worker at the root level ("/") of your application.
+- Set the "Service-Worker-Allowed" response header to allow out-of-scope workers.\
+`,
+    )
+  }
+}

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -8,6 +8,9 @@ beforeAll(async () => {
   browser = await createBrowser({
     serverOptions: {
       router(app) {
+        // Prevent Express from responding with cached 304 responses.
+        app.set('etag', false)
+
         app.get('/mockServiceWorker.js', (req, res) => {
           res.sendFile(SERVICE_WORKER_BUILD_PATH)
         })

--- a/test/msw-api/setup-worker/scenarios/iframe/iframe.test.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe/iframe.test.ts
@@ -10,6 +10,14 @@ function findFrame(frame: Frame) {
   return frame.name() === ''
 }
 
+beforeAll(() => {
+  jest.spyOn(global.console, 'warn')
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
 test('intercepts a request from an iframe (nested client)', async () => {
   const { page } = await pageWith({
     example: path.resolve(__dirname, 'iframe.mocks.ts'),
@@ -24,6 +32,7 @@ test('intercepts a request from an iframe (nested client)', async () => {
   const firstName = await firstNameElement.evaluate((node) => node.textContent)
 
   expect(firstName).toBe('John')
+  expect(console.warn).not.toHaveBeenCalled()
 })
 
 test('intercepts a request from a deeply nested iframe', async () => {
@@ -45,6 +54,7 @@ test('intercepts a request from a deeply nested iframe', async () => {
   const firstName = await firstNameElement.evaluate((node) => node.textContent)
 
   expect(firstName).toBe('John')
+  expect(console.warn).not.toHaveBeenCalled()
 })
 
 test('intercepts a request from a deeply nested iframe given MSW is registered in a parent nested iframe', async () => {
@@ -67,6 +77,7 @@ test('intercepts a request from a deeply nested iframe given MSW is registered i
   const firstName = await firstNameElement.evaluate((node) => node.textContent)
 
   expect(firstName).toBe('John')
+  expect(console.warn).not.toHaveBeenCalled()
 })
 
 test('intercepts a request from an iframe given MSW is registered in a sibling iframe', async () => {
@@ -109,4 +120,5 @@ test('intercepts a request from an iframe given MSW is registered in a sibling i
   const firstName = await firstNameElement.evaluate((node) => node.textContent)
 
   expect(firstName).toBe('John')
+  expect(console.warn).not.toHaveBeenCalled()
 })

--- a/test/msw-api/setup-worker/scenarios/scope/scope-nested-quiet.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/scope/scope-nested-quiet.mocks.ts
@@ -1,0 +1,10 @@
+import { setupWorker } from 'msw'
+
+const worker = setupWorker()
+
+worker.start({
+  quiet: true,
+  serviceWorker: {
+    url: '/public/mockServiceWorker.js',
+  },
+})

--- a/test/msw-api/setup-worker/scenarios/scope/scope-nested.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/scope/scope-nested.mocks.ts
@@ -1,0 +1,9 @@
+import { setupWorker } from 'msw'
+
+const worker = setupWorker()
+
+worker.start({
+  serviceWorker: {
+    url: '/public/mockServiceWorker.js',
+  },
+})

--- a/test/msw-api/setup-worker/scenarios/scope/scope-root.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/scope/scope-root.mocks.ts
@@ -1,0 +1,9 @@
+import { setupWorker } from 'msw'
+
+const worker = setupWorker()
+
+worker.start({
+  serviceWorker: {
+    url: '/mockServiceWorker.js',
+  },
+})

--- a/test/msw-api/setup-worker/scenarios/scope/scope-validation.test.ts
+++ b/test/msw-api/setup-worker/scenarios/scope/scope-validation.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { SERVICE_WORKER_BUILD_PATH } from '../../../../../config/constants'
+
+it('warns when visiting to the page outside of the worker scope', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'scope-nested.mocks.ts'),
+    routes(app) {
+      // Create a proxy to the worker script located under a nested ("/public") path.
+      app.get('/public/mockServiceWorker.js', (req, res) => {
+        res.sendFile(SERVICE_WORKER_BUILD_PATH)
+      })
+    },
+  })
+
+  // Should display the out-of-scope warning.
+  const workerScope = runtime.makeUrl('/public/')
+
+  expect(runtime.consoleSpy.get('warning')).toContain(
+    `[MSW] Cannot intercept requests on this page because it's outside of the worker's scope ("${workerScope}"). If you wish to mock API requests on this page, you must resolve this scope issue.
+
+- (Recommended) Register the worker at the root level ("/") of your application.
+- Set the "Service-Worker-Allowed" response header to allow out-of-scope workers.`,
+  )
+  expect(runtime.consoleSpy.get('error')).toEqual(undefined)
+})
+
+it('does not print the scope warning when the page is within the worker scope', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'scope-root.mocks.ts'),
+  })
+
+  expect(runtime.consoleSpy.get('warning')).toEqual(undefined)
+  expect(runtime.consoleSpy.get('error')).toEqual(undefined)
+})
+
+it('does not print the scope warning when the "quiet" option is enabled', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'scope-nested-quiet.mocks.ts'),
+    routes(app) {
+      app.get('/public/mockServiceWorker.js', (req, res) => {
+        res.sendFile(SERVICE_WORKER_BUILD_PATH)
+      })
+    },
+  })
+
+  // Although the page is out of the worker's scope,
+  // the "quiet" option is set to true.
+  expect(runtime.consoleSpy.get('warning')).toEqual(undefined)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,7 +1549,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^0.0.46":
+"@types/estree@*":
   version "0.0.46"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
   integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
@@ -2014,11 +2014,6 @@ acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn@^8.0.4:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.5.tgz#a3bfb872a74a6a7f661bc81b9849d9cac12601b7"
-  integrity sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==
 
 acorn@^8.2.1:
   version "8.2.4"
@@ -3492,14 +3487,6 @@ enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enhanced-resolve@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz#525c5d856680fbd5052de453ac83e32049958b5c"
-  integrity sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
-
 enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -3604,7 +3591,7 @@ eslint-plugin-prettier@^3.4.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@5.1.1, eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -4158,10 +4145,10 @@ fs-extra@^9.0.1:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-monkey@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.1.tgz#4a82f36944365e619f4454d9fff106553067b781"
-  integrity sha512-fcSa+wyTqZa46iWweI7/ZiUfegOZl0SG8+dltIwFXo7+zYU9J9kpS3NB6pZcSlJdhvIwp81Adx2XhZorncxiaA==
+fs-monkey@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
+  integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
 
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
@@ -4412,7 +4399,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-headers-utils@^3.0.0, headers-utils@^3.0.2:
+headers-utils@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-3.0.2.tgz#dfc65feae4b0e34357308aefbcafa99c895e59ef"
   integrity sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==
@@ -5764,12 +5751,12 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-memfs@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.0.tgz#f9438e622b5acd1daa8a4ae160c496fdd1325b26"
-  integrity sha512-f/xxz2TpdKv6uDn6GtHee8ivFyxwxmPuXatBb1FBwxYNuVpbM3k/Y1Z+vC0mH/dIXXrukYfe3qe5J32Dfjg93A==
+memfs@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.2.tgz#5de461389d596e3f23d48bb7c2afb6161f4df40e"
+  integrity sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==
   dependencies:
-    fs-monkey "1.0.1"
+    fs-monkey "1.0.3"
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -6287,10 +6274,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-page-with@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/page-with/-/page-with-0.3.6.tgz#9fc8313745745aa0012e39ef2d3351988383f393"
-  integrity sha512-5/Mo8GDSSEqnltpLNTo9+FzNizM+D3aPbSCcds0lmsXcBbQCkgUSLAWnuSpj8dJk/J6vHC7xW4Q5VsJ6uYgGkA==
+page-with@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/page-with/-/page-with-0.4.0.tgz#f7e17469da35e328d5f08a8fd296a10fc3cf7975"
+  integrity sha512-jgLoc4F1I821FYh/Az+rAbN5C2YWd251GwVhCxjIhPPEL5RMsjFMxU/FauvSBeyRY75W7hY5JOaTS2H13Vgxkw==
   dependencies:
     "@open-draft/until" "^1.0.3"
     "@types/debug" "^4.1.5"
@@ -6299,12 +6286,12 @@ page-with@^0.3.6:
     "@types/uuid" "^8.3.0"
     debug "^4.3.1"
     express "^4.17.1"
-    headers-utils "^3.0.0"
-    memfs "^3.2.0"
+    headers-utils "^3.0.2"
+    memfs "^3.2.2"
     mustache "^4.1.0"
-    playwright "^1.8.0"
+    playwright "^1.12.1"
     uuid "^8.3.2"
-    webpack "^5.24.2"
+    webpack "^5.38.1"
     webpack-merge "^5.7.3"
 
 parent-module@^1.0.0:
@@ -6447,10 +6434,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright@^1.8.0:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.8.1.tgz#0a26035d1b5f2c31d9a4da09d649b4992f989d1e"
-  integrity sha512-nmuiDEDwB/SdAxiZQS5pLqPS3XXN8OJ1LKvTSiAbJvu+AUf7f0RD7nuq9xB0C08Emd6stx9yBMhANvD12k/+GQ==
+playwright@^1.12.1:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.12.2.tgz#a484447177b061dd76247734fe65d77e3fb139fa"
+  integrity sha512-tSZGeILY70T4imhCMCsvzhoaDm9baosIG5fQncSWprpjVc/X4yYdBQCLBMvOi98H50hvu9fhgy2hpsgFKCsUaw==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"
@@ -6463,7 +6450,9 @@ playwright@^1.8.0:
     proper-lockfile "^4.1.1"
     proxy-from-env "^1.1.0"
     rimraf "^3.0.2"
-    ws "^7.3.1"
+    stack-utils "^2.0.3"
+    ws "^7.4.6"
+    yazl "^2.5.1"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -7423,7 +7412,7 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-stack-utils@^2.0.2:
+stack-utils@^2.0.2, stack-utils@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
@@ -8083,6 +8072,14 @@ watchpack@^2.0.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+watchpack@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.2.0.tgz#47d78f5415fe550ecd740f99fe2882323a58b1ce"
+  integrity sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -8181,34 +8178,13 @@ webpack-sources@^2.1.1:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack@^5.24.2:
-  version "5.24.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.24.2.tgz#33790dad631e8b639f4246d762e257720875fe54"
-  integrity sha512-uxxKYEY4kMNjP+D2Y+8aw5Vd7ar4pMuKCNemxV26ysr1nk0YDiQTylg9U3VZIdkmI0YHa0uC8ABxL+uGxGWWJg==
+webpack-sources@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.0.tgz#9ed2de69b25143a4c18847586ad9eccb19278cfa"
+  integrity sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==
   dependencies:
-    "@types/eslint-scope" "^3.7.0"
-    "@types/estree" "^0.0.46"
-    "@webassemblyjs/ast" "1.11.0"
-    "@webassemblyjs/wasm-edit" "1.11.0"
-    "@webassemblyjs/wasm-parser" "1.11.0"
-    acorn "^8.0.4"
-    browserslist "^4.14.5"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.7.0"
-    es-module-lexer "^0.4.0"
-    eslint-scope "^5.1.1"
-    events "^3.2.0"
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.4"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^4.2.0"
-    mime-types "^2.1.27"
-    neo-async "^2.6.2"
-    schema-utils "^3.0.0"
-    tapable "^2.1.1"
-    terser-webpack-plugin "^5.1.1"
-    watchpack "^2.0.0"
-    webpack-sources "^2.1.1"
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack@^5.37.1:
   version "5.37.1"
@@ -8238,6 +8214,35 @@ webpack@^5.37.1:
     terser-webpack-plugin "^5.1.1"
     watchpack "^2.0.0"
     webpack-sources "^2.1.1"
+
+webpack@^5.38.1:
+  version "5.39.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.39.1.tgz#d1e014b6d71e1aef385316ad528f21cd5b1f9784"
+  integrity sha512-ulOvoNCh2PvTUa+zbpRuEb1VPeQnhxpnHleMPVVCq3QqnaFogjsLyps+o42OviQFoaGtTQYrUqDXu1QNkvUPzw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.47"
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/wasm-edit" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+    acorn "^8.2.1"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.0"
+    es-module-lexer "^0.4.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.1"
+    watchpack "^2.2.0"
+    webpack-sources "^2.3.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"
@@ -8352,10 +8357,15 @@ ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.2.3, ws@^7.3.1:
+ws@^7.2.3:
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
   integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
+
+ws@^7.4.6:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.0.tgz#0033bafea031fb9df041b2026fc72a571ca44691"
+  integrity sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"
@@ -8473,6 +8483,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Changes

- Calling `worker.start()` will now validate the registered worker's scope against the current page's URL. 

## Motivation

Requests issued by a page that lies outside of the worker's scope will not be intercepted. This is an expected behavior according to the Service Worker specification. However, such scenarios are currently difficult to debug, as the library will active the worker just fine, but all the requests will be bypassed. 