### PR TITLE
fix: prevent GraphQLHandler from parsing queries sent to different enpoint

### DIFF
--- a/src/handlers/GraphQLHandler.test.ts
+++ b/src/handlers/GraphQLHandler.test.ts
@@ -325,6 +325,29 @@ describe('test', () => {
     expect(handler.test(request)).toBe(true)
     expect(handler.test(alienRequest)).toBe(false)
   })
+
+  test('does not parse requests sent to the different endpoints', () => {
+    jest.spyOn(console, 'error')
+
+    const handler = new GraphQLHandler(
+      'query',
+      'GetUser',
+      'https://api.github.com/graphql',
+      resolver,
+    )
+
+    const request = createMockedRequest({
+      method: 'POST',
+      url: new URL('/some-other-endpoint', location.href),
+      body: {
+        query: { message: 'I gonna cause troubles!' },
+      },
+    })
+
+    handler.test(request)
+
+    expect(console.error).not.toHaveBeenCalled()
+  })
 })
 
 describe('run', () => {

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -125,6 +125,11 @@ export class GraphQLHandler<
     }
   }
 
+  public test(request: MockedRequest): boolean {
+    const hasMatchingUrl = matchRequestUrl(request.url, this.endpoint)
+    return hasMatchingUrl.matches && super.test(request)
+  }
+
   predicate(request: MockedRequest, parsedResult: ParsedGraphQLRequest) {
     if (!parsedResult) {
       return false


### PR DESCRIPTION
## What's wrong?

At the moment `GraphQLHandler` tries to parse any query which leads to very misleading `console.errors` being show if query parsing fails. One scenario for that is having REST request with an `req.body.query` being a JSON. (see more here: https://github.com/mswjs/msw/issues/559) The proposed solution from this to happen is to use `graphql.link`, but that does not prevent errors in console, as `msw` tries to figure out if it deals with the matching endpoint after parsing the query.

## Expected behavior

`GraphQLHandler` checks if request being handled is actually matching the endpoint specified by `graphql.link` _before_ trying to parse the request, so that non-matching requests would be rejected nicely and silently.
