### PR TITLE
Bumps "@mswjs/interceptors" to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "sideEffects": false,
   "dependencies": {
     "@mswjs/cookies": "^0.1.5",
-    "@mswjs/interceptors": "^0.11.0",
+    "@mswjs/interceptors": "^0.11.1",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.0",
     "@types/inquirer": "^7.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"
 
-"@mswjs/interceptors@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.11.0.tgz#2ce28962782315ebc4b8afbf8fe120b3c6988827"
-  integrity sha512-FNXjInEvCn0+1XYLhOvBDp2dCzkdE9NDtxWIuCox4JlUnhhiaaWmeFbLElUyoci8nI/zkiPfscS+uyyFjGIaOg==
+"@mswjs/interceptors@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.11.1.tgz#a8806f9f245d605d02dae6d20e18bd6b867872bf"
+  integrity sha512-ReZg+Pp5GbSrDrVZTXeV4pHC385ImHTZ7he/n3f+uRiuB9eLifdLU0xvBl9NPuy7qrMgFGvrs6k2QsiB204xaQ==
   dependencies:
     "@open-draft/until" "^1.0.3"
     debug "^4.3.0"


### PR DESCRIPTION
## GitHub

- Fixes #700
  - https://github.com/mswjs/interceptors/pull/132)