### PR TITLE
fix: use external chalk library to stop os/tty import errors on React Native

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -142,8 +142,7 @@ const buildNode = {
 const buildNative = {
   input: 'src/native/index.ts',
   external: [
-    'tty',
-    'os',
+    'chalk',
     'util',
     'events',
     '@mswjs/interceptors',


### PR DESCRIPTION
Without configuring chalk as an external dependency in the React Native configuration, rollup will try to import os and tty which don't exist in the React Native environment.

In conjunction with #810 and #809, this fixes React Native support.

See https://github.com/mswjs/msw/issues/622 for more details.