### PR TITLE
fix: use WHATWG url for formatting url to fix React Native importing url package

### DIFF
--- a/src/utils/request/getPublicUrlFromRequest.ts
+++ b/src/utils/request/getPublicUrlFromRequest.ts
@@ -1,4 +1,3 @@
-import { format } from 'url'
 import { MockedRequest } from '../../handlers/RequestHandler'
 
 /**
@@ -8,9 +7,8 @@ import { MockedRequest } from '../../handlers/RequestHandler'
 export const getPublicUrlFromRequest = (request: MockedRequest) => {
   return request.referrer.startsWith(request.url.origin)
     ? request.url.pathname
-    : format({
-        protocol: request.url.protocol,
-        host: request.url.host,
-        pathname: request.url.pathname,
-      })
+    : new URL(
+        request.url.pathname,
+        `${request.url.protocol}//${request.url.host}`,
+      ).href
 }


### PR DESCRIPTION
This PR removes the legacy format function in favour of using the WHATWG implementation, as suggested by the node.js docs (https://nodejs.org/api/url.html#url_url_format_urlobject). This has the side effect for React Native that it no longer imports the non-existent url library.

In conjunction with #810 and #808, this fixes React Native support.

See #622 for more details.