### PR TITLE
chore: update @mswjs/cookies package to fix React Native incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "sideEffects": false,
   "dependencies": {
-    "@mswjs/cookies": "^0.1.5",
+    "@mswjs/cookies": "^0.1.6",
     "@mswjs/interceptors": "^0.11.1",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,10 +1333,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mswjs/cookies@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.1.5.tgz#4631f69a1a5c0c7db2b944004081ce35d4255ea9"
-  integrity sha512-sUPoK1JriT0XGGh9j060lsXl4iRlvPfgEU4qc3thGtVYXlKN8G3Xrc7wBgfJy51NOrtLrDwcmpriB8ppHXgAXw==
+"@mswjs/cookies@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.1.6.tgz#176f77034ab6d7373ae5c94bcbac36fee8869249"
+  integrity sha512-A53XD5TOfwhpqAmwKdPtg1dva5wrng2gH5xMvklzbd9WLTSVU953eCRa8rtrrm6G7Cy60BOGsBRN89YQK0mlKA==
   dependencies:
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"


### PR DESCRIPTION
The 0.1.6 version of @mswjs/cookies changes the way it checks whether localStorage is available on the host, which is compatible with React Native.

In conjunction with https://github.com/mswjs/msw/pull/809 and https://github.com/mswjs/msw/pull/808, this fixes React Native support.

See #622 for more details.