### PR TITLE
set: Type-validates the forbidden "cookie"/"set-cookie" response headers

### DIFF
--- a/src/context/set.ts
+++ b/src/context/set.ts
@@ -1,12 +1,43 @@
 import { objectToHeaders } from 'headers-utils'
 import { ResponseTransformer } from '../response'
 
+export type HeadersObject<KeyType extends string = string> = Record<
+  KeyType,
+  string | string[]
+>
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+ */
+export type ForbiddenHeaderNames =
+  | 'cookie'
+  | 'cookie2'
+  | 'set-cookie'
+  | 'set-cookie2'
+
+export type ForbiddenHeaderError<HeaderName extends string> =
+  `SafeResponseHeader: the '${HeaderName}' header cannot be set on the response. Please use the 'ctx.cookie()' function instead.`
+
 /**
  * Sets one or multiple response headers.
+ * @example
+ * ctx.set('Content-Type', 'text/plain')
+ * ctx.set({
+ *   'Accept': 'application/javascript',
+ *   'Content-Type': "text/plain"
+ * })
  * @see {@link https://mswjs.io/docs/api/context/set `ctx.set()`}
  */
-export function set<N extends string | Record<string, string | string[]>>(
-  ...args: N extends string ? [N, string] : [N]
+export function set<N extends string | HeadersObject>(
+  ...args: N extends string
+    ? Lowercase<N> extends ForbiddenHeaderNames
+      ? ForbiddenHeaderError<N>
+      : [N, string]
+    : N extends HeadersObject<infer CookieName>
+    ? Lowercase<CookieName> extends ForbiddenHeaderNames
+      ? ForbiddenHeaderError<CookieName>
+      : [N]
+    : [N]
 ): ResponseTransformer {
   return (res) => {
     const [name, value] = args

--- a/test/typings/set.test-d.ts
+++ b/test/typings/set.test-d.ts
@@ -1,0 +1,41 @@
+import { set } from '../../src/context/set'
+
+set('header', 'value')
+set({
+  one: 'value',
+  two: 'value',
+})
+
+// @ts-expect-error Forbidden response header.
+set('cookie', 'secret')
+// @ts-expect-error Forbidden response header.
+set('Cookie', 'secret')
+// @ts-expect-error Forbidden response header.
+set('cookie2', 'secret')
+// @ts-expect-error Forbidden response header.
+set('Cookie2', 'secret')
+// @ts-expect-error Forbidden response header.
+set('set-cookie', 'secret')
+// @ts-expect-error Forbidden response header.
+set('Set-Cookie', 'secret')
+// @ts-expect-error Forbidden response header.
+set('set-cookie2', 'secret')
+// @ts-expect-error Forbidden response header.
+set('Set-Cookie2', 'secret')
+
+// @ts-expect-error Forbidden response header.
+set({ cookie: 'secret' })
+// @ts-expect-error Forbidden response header.
+set({ Cookie: 'secret' })
+// @ts-expect-error Forbidden response header.
+set({ cookie2: 'secret' })
+// @ts-expect-error Forbidden response header.
+set({ Cookie2: 'secret' })
+// @ts-expect-error Forbidden response header.
+set({ 'set-cookie': 'secret' })
+// @ts-expect-error Forbidden response header.
+set({ 'Set-Cookie': 'secret' })
+// @ts-expect-error Forbidden response header.
+set({ 'set-cookie2': 'secret' })
+// @ts-expect-error Forbidden response header.
+set({ 'Set-Cookie2': 'secret' })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,7 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationDir": "lib/types",
-    "lib": [
-      "es2017",
-      "ESNext.AsyncIterable",
-      "dom",
-      "webworker"
-    ]
+    "lib": ["es2017", "ESNext.AsyncIterable", "dom", "webworker"]
   },
   "include": ["global.d.ts", "src/**/*.ts"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
## GitHub

- Originates from #818 

## Changes

- Setting forbidden cookie headers with the `ctx.set` utility now produces a TypeScript violation.
- Forbidden cookie headers include (case-insensitive):
  - `cookie`
  - `cookie2`
  - `set-cookie`
  - `set-cookie2`

We are not including [all forbidden header names](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) for now, starting with the `cookie` ones.

## Motivation

We should fail fast in preventing the developer from setting forbidden response cookies. Setting such cookies will raise a runtime exception anyway. 

## Experience

```ts
set({ cookie: 'secret' })

// Argument of type '[{ cookie: string; }]' is not assignable to parameter of type
// '"SafeResponseHeader: the 'cookie' header cannot be set on the response. Please use the 'ctx.cookie()' function instead."'.ts(2345)
```

> Utilizes [this technique](https://github.com/microsoft/TypeScript/pull/40468#issuecomment-808311132) to have custom type violation messages until https://github.com/microsoft/TypeScript/pull/40468 is merged.