### PR TITLE
Bumps "@mswjs/interceptors" to 0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "sideEffects": false,
   "dependencies": {
     "@mswjs/cookies": "^0.1.6",
-    "@mswjs/interceptors": "^0.12.1",
+    "@mswjs/interceptors": "^0.12.3",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.1",
     "@types/inquirer": "^7.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"
 
-"@mswjs/interceptors@^0.12.1":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.2.tgz#c4c9695ff54feffed93f03db371dd508a104cc0b"
-  integrity sha512-JHo5Gvm1Oy2jucYP+kXj9dHRelE3gbYrgAFmpgIzIyjTavYsHO5OTW3IxY3uSHKaDnGrddlEbSHdHIvw4JOZUw==
+"@mswjs/interceptors@^0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.3.tgz#8d4dc08042dc749a314bd31d363ddac3a0458e26"
+  integrity sha512-qHLEvukC8hHtECKwRpe8q2Y83J91+ckDN6PzHta3tL5X5VIjet062tvvv3ZStHHsm3Xo04TMbm7WyM0RQUpnNA==
   dependencies:
     "@open-draft/until" "^1.0.3"
     debug "^4.3.0"


### PR DESCRIPTION
## GitHub

- Related to #785 

## Changes

- [Release notes](https://github.com/mswjs/interceptors/releases/tag/v0.12.3)