### PR TITLE
Adds "devUtils" to standardize library warnings and errors

### DIFF
--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -24,6 +24,7 @@ import {
 } from '../utils/internal/parseGraphQLRequest'
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
 import { tryCatch } from '../utils/internal/tryCatch'
+import { devUtils } from '../utils/internal/devUtils'
 
 export type ExpectedOperationTypeNode = OperationTypeNode | 'all'
 export type GraphQLHandlerNameSelector = RegExp | string
@@ -132,8 +133,8 @@ export class GraphQLHandler<
 
     if (!parsedResult.operationName) {
       const publicUrl = getPublicUrlFromRequest(request)
-      console.warn(`\
-[MSW] Failed to intercept a GraphQL request at "${request.method} ${publicUrl}": unnamed GraphQL operations are not supported.
+      devUtils.warn(`\
+Failed to intercept a GraphQL request at "${request.method} ${publicUrl}": unnamed GraphQL operations are not supported.
 
 Consider naming this operation or using "graphql.operation" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation\
       `)
@@ -161,7 +162,7 @@ Consider naming this operation or using "graphql.operation" request handler to i
     const loggedResponse = prepareResponse(response)
 
     console.groupCollapsed(
-      '[MSW] %s %s (%c%s%c)',
+      devUtils.formatMessage('%s %s (%c%s%c)'),
       getTimestamp(),
       this.info.operationName,
       `color:${getStatusCodeColor(response.status)}`,

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -11,6 +11,7 @@ import {
   xml,
 } from '../context'
 import { Mask, SerializedResponse } from '../setupWorker/glossary'
+import { devUtils } from '../utils/internal/devUtils'
 import { isStringEqual } from '../utils/internal/isStringEqual'
 import { getStatusCodeColor } from '../utils/logging/getStatusCodeColor'
 import { getTimestamp } from '../utils/logging/getTimestamp'
@@ -124,8 +125,8 @@ export class RestHandler<
         queryParams.push(paramName)
       })
 
-      console.warn(`\
-[MSW] Found a redundant usage of query parameters in the request handler URL for "${method} ${mask}". Please match against a path instead, and access query parameters in the response resolver function:
+      devUtils.warn(`\
+Found a redundant usage of query parameters in the request handler URL for "${method} ${mask}". Please match against a path instead, and access query parameters in the response resolver function:
 
 rest.${method.toLowerCase()}("${resolvedMask.pathname}", (req, res, ctx) => {
   const query = req.url.searchParams
@@ -166,7 +167,7 @@ ${queryParams
     const loggedResponse = prepareResponse(response)
 
     console.groupCollapsed(
-      '[MSW] %s %s %s (%c%s%c)',
+      devUtils.formatMessage('%s %s %s (%c%s%c)'),
       getTimestamp(),
       request.method,
       publicUrl,

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -13,6 +13,7 @@ import { RequestHandler } from '../handlers/RequestHandler'
 import { parseIsomorphicRequest } from '../utils/request/parseIsomorphicRequest'
 import { handleRequest } from '../utils/handleRequest'
 import { mergeRight } from '../utils/internal/mergeRight'
+import { devUtils } from '../utils/internal/devUtils'
 
 const DEFAULT_LISTEN_OPTIONS: SharedOptions = {
   onUnhandledRequest: 'warn',
@@ -31,7 +32,9 @@ export function createSetupServer(...interceptors: Interceptor[]) {
     requestHandlers.forEach((handler) => {
       if (Array.isArray(handler))
         throw new Error(
-          `[MSW] Failed to call "setupServer" given an Array of request handlers (setupServer([a, b])), expected to receive each handler individually: setupServer(a, b).`,
+          devUtils.formatMessage(
+            'Failed to call "setupServer" given an Array of request handlers (setupServer([a, b])), expected to receive each handler individually: setupServer(a, b).',
+          ),
         )
     })
 
@@ -42,7 +45,9 @@ export function createSetupServer(...interceptors: Interceptor[]) {
     // Error when attempting to run this function in a browser environment.
     if (!isNodeProcess()) {
       throw new Error(
-        '[MSW] Failed to execute `setupServer` in the environment that is not Node.js (i.e. a browser). Consider using `setupWorker` instead.',
+        devUtils.formatMessage(
+          'Failed to execute `setupServer` in the environment that is not Node.js (i.e. a browser). Consider using `setupWorker` instead.',
+        ),
       )
     }
 

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -15,6 +15,7 @@ import { RestHandler } from '../handlers/RestHandler'
 import { prepareStartHandler } from './start/utils/prepareStartHandler'
 import { createFallbackStart } from './start/createFallbackStart'
 import { createFallbackStop } from './stop/createFallbackStop'
+import { devUtils } from '../utils/internal/devUtils'
 
 interface Listener {
   target: EventTarget
@@ -38,14 +39,18 @@ export function setupWorker(
   requestHandlers.forEach((handler) => {
     if (Array.isArray(handler))
       throw new Error(
-        `[MSW] Failed to call "setupWorker" given an Array of request handlers (setupWorker([a, b])), expected to receive each handler individually: setupWorker(a, b).`,
+        devUtils.formatMessage(
+          'Failed to call "setupWorker" given an Array of request handlers (setupWorker([a, b])), expected to receive each handler individually: setupWorker(a, b).',
+        ),
       )
   })
 
   // Error when attempting to run this function in a Node.js environment.
   if (isNodeProcess()) {
     throw new Error(
-      '[MSW] Failed to execute `setupWorker` in a non-browser environment. Consider using `setupServer` for Node.js environment instead.',
+      devUtils.formatMessage(
+        'Failed to execute `setupWorker` in a non-browser environment. Consider using `setupServer` for Node.js environment instead.',
+      ),
     )
   }
 

--- a/src/setupWorker/start/createStartHandler.ts
+++ b/src/setupWorker/start/createStartHandler.ts
@@ -7,6 +7,7 @@ import { requestIntegrityCheck } from '../../utils/internal/requestIntegrityChec
 import { deferNetworkRequestsUntil } from '../../utils/deferNetworkRequestsUntil'
 import { createResponseListener } from '../../utils/worker/createResponseListener'
 import { validateWorkerScope } from './utils/validateWorkerScope'
+import { devUtils } from '../../utils/internal/devUtils'
 
 export const createStartHandler = (
   context: SetupWorkerInternalContext,
@@ -36,16 +37,23 @@ export const createStartHandler = (
 
       if (!worker) {
         const missingWorkerMessage = customOptions?.findWorker
-          ? `[MSW] Failed to locate the Service Worker registration using a custom "findWorker" predicate.
+          ? devUtils.formatMessage(
+              `Failed to locate the Service Worker registration using a custom "findWorker" predicate.
 
-Please ensure that the custom predicate properly locates the Service Worker registration at "${options.serviceWorker.url}".
+Please ensure that the custom predicate properly locates the Service Worker registration at "%s".
 More details: https://mswjs.io/docs/api/setup-worker/start#findworker
-`
-          : `[MSW] Failed to locate the Service Worker registration.
+`,
+              options.serviceWorker.url,
+            )
+          : devUtils.formatMessage(
+              `Failed to locate the Service Worker registration.
 
-This most likely means that the worker script URL "${options.serviceWorker.url}" cannot resolve against the actual public hostname (${location.host}). This may happen if your application runs behind a proxy, or has a dynamic hostname.
+This most likely means that the worker script URL "%s" cannot resolve against the actual public hostname (%s). This may happen if your application runs behind a proxy, or has a dynamic hostname.
 
-Please consider using a custom "serviceWorker.url" option to point to the actual worker script location, or a custom "findWorker" option to resolve the Service Worker registration manually. More details: https://mswjs.io/docs/api/setup-worker/start`
+Please consider using a custom "serviceWorker.url" option to point to the actual worker script location, or a custom "findWorker" option to resolve the Service Worker registration manually. More details: https://mswjs.io/docs/api/setup-worker/start`,
+              options.serviceWorker.url,
+              location.host,
+            )
 
         throw new Error(missingWorkerMessage)
       }
@@ -72,8 +80,8 @@ Please consider using a custom "serviceWorker.url" option to point to the actual
       )
 
       if (integrityError) {
-        console.error(`\
-[MSW] Detected outdated Service Worker: ${integrityError.message}
+        devUtils.error(`\
+Detected outdated Service Worker: ${integrityError.message}
 
 The mocking is still enabled, but it's highly recommended that you update your Service Worker by running:
 

--- a/src/setupWorker/start/utils/getWorkerInstance.ts
+++ b/src/setupWorker/start/utils/getWorkerInstance.ts
@@ -2,6 +2,7 @@ import { until } from '@open-draft/until'
 import { getWorkerByRegistration } from './getWorkerByRegistration'
 import { ServiceWorkerInstanceTuple, FindWorker } from '../../glossary'
 import { getAbsoluteWorkerUrl } from '../../../utils/url/getAbsoluteWorkerUrl'
+import { devUtils } from '../../../utils/internal/devUtils'
 
 /**
  * Returns an active Service Worker instance.
@@ -70,16 +71,22 @@ export const getWorkerInstance = async (
     if (isWorkerMissing) {
       const scopeUrl = new URL(options?.scope || '/', location.href)
 
-      throw new Error(`[MSW] Failed to register a Service Worker for scope ('${scopeUrl.href}') with script ('${absoluteWorkerUrl}'): Service Worker script does not exist at the given path.
+      throw new Error(
+        devUtils.formatMessage(`\
+Failed to register a Service Worker for scope ('${scopeUrl.href}') with script ('${absoluteWorkerUrl}'): Service Worker script does not exist at the given path.
 
 Did you forget to run "npx msw init <PUBLIC_DIR>"?
 
-Learn more about creating the Service Worker script: https://mswjs.io/docs/cli/init`)
+Learn more about creating the Service Worker script: https://mswjs.io/docs/cli/init`),
+      )
     }
 
     // Fallback error message for any other registration errors.
     throw new Error(
-      `[MSW] Failed to register a Service Worker:\n\n${error.message}`,
+      devUtils.formatMessage(
+        'Failed to register the Service Worker:\n\n%s',
+        error.message,
+      ),
     )
   }
 

--- a/src/setupWorker/start/utils/printStartMessage.ts
+++ b/src/setupWorker/start/utils/printStartMessage.ts
@@ -1,9 +1,14 @@
+import { devUtils } from '../../../utils/internal/devUtils'
+
+interface PrintStartMessageArgs {
+  quiet?: boolean
+  message?: string
+}
+
 /**
  * Prints a worker activation message in the browser's console.
  */
-export function printStartMessage(
-  args: { quiet?: boolean; message?: string } = {},
-) {
+export function printStartMessage(args: PrintStartMessageArgs = {}) {
   if (args.quiet) {
     return
   }
@@ -11,7 +16,7 @@ export function printStartMessage(
   const message = args.message || 'Mocking enabled.'
 
   console.groupCollapsed(
-    `%c[MSW] ${message}`,
+    `%c${devUtils.formatMessage(message)}`,
     'color:orangered;font-weight:bold;',
   )
   console.log(

--- a/src/setupWorker/start/utils/validateWorkerScope.ts
+++ b/src/setupWorker/start/utils/validateWorkerScope.ts
@@ -1,3 +1,4 @@
+import { devUtils } from '../../../utils/internal/devUtils'
 import { StartOptions } from '../../glossary'
 
 export function validateWorkerScope(
@@ -5,9 +6,9 @@ export function validateWorkerScope(
   options?: StartOptions,
 ): void {
   if (!options?.quiet && !location.href.startsWith(registration.scope)) {
-    console.warn(
+    devUtils.warn(
       `\
-[MSW] Cannot intercept requests on this page because it's outside of the worker's scope ("${registration.scope}"). If you wish to mock API requests on this page, you must resolve this scope issue.
+Cannot intercept requests on this page because it's outside of the worker's scope ("${registration.scope}"). If you wish to mock API requests on this page, you must resolve this scope issue.
 
 - (Recommended) Register the worker at the root level ("/") of your application.
 - Set the "Service-Worker-Allowed" response header to allow out-of-scope workers.\

--- a/src/setupWorker/stop/utils/printStopMessage.ts
+++ b/src/setupWorker/stop/utils/printStopMessage.ts
@@ -1,7 +1,12 @@
+import { devUtils } from '../../../utils/internal/devUtils'
+
 export function printStopMessage(args: { quiet?: boolean } = {}): void {
   if (args.quiet) {
     return
   }
 
-  console.log('%c[MSW] Mocking disabled.', 'color:orangered;font-weight:bold;')
+  console.log(
+    `%c${devUtils.formatMessage('Mocking disabled.')}`,
+    'color:orangered;font-weight:bold;',
+  )
 }

--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -5,6 +5,7 @@ import { MockedResponse } from '../response'
 import { SharedOptions } from '../sharedOptions'
 import { DeepRequired } from '../typeUtils'
 import { ResponseLookupResult, getResponse } from './getResponse'
+import { devUtils } from './internal/devUtils'
 import { onUnhandledRequest } from './request/onUnhandledRequest'
 import { readResponseCookies } from './request/readResponseCookies'
 
@@ -73,8 +74,8 @@ export async function handleRequest<
   // When the handled request returned no mocked response, warn the developer,
   // as it may be an oversight on their part. Perform the request as-is.
   if (!response) {
-    console.warn(
-      '[MSW] Expected a mocking resolver function to return a mocked response Object, but got: %s. Original response is going to be used instead.',
+    devUtils.warn(
+      'Expected a mocking resolver function to return a mocked response Object, but got: %s. Original response is going to be used instead.',
       response,
     )
 

--- a/src/utils/internal/devUtils.ts
+++ b/src/utils/internal/devUtils.ts
@@ -1,0 +1,31 @@
+import { interpolate } from 'outvariant'
+
+const LIBRARY_PREFIX = '[MSW]'
+
+/**
+ * Formats a given message by appending the library's prefix string.
+ */
+function formatMessage(message: string, ...positionals: any[]): string {
+  const interpolatedMessage = interpolate(message, ...positionals)
+  return `${LIBRARY_PREFIX} ${interpolatedMessage}`
+}
+
+/**
+ * Prints a library-specific warning.
+ */
+function warn(message: string, ...positionals: any[]): void {
+  console.warn(formatMessage(message, ...positionals))
+}
+
+/**
+ * Prints a library-specific error.
+ */
+function error(message: string, ...positionals: any[]): void {
+  console.error(formatMessage(message, ...positionals))
+}
+
+export const devUtils = {
+  formatMessage,
+  warn,
+  error,
+}

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -2,6 +2,7 @@ import { OperationDefinitionNode, OperationTypeNode, parse } from 'graphql'
 import { GraphQLVariables } from '../../handlers/GraphQLHandler'
 import { MockedRequest } from '../../handlers/RequestHandler'
 import { getPublicUrlFromRequest } from '../request/getPublicUrlFromRequest'
+import { devUtils } from './devUtils'
 import { jsonParse } from './jsonParse'
 
 interface GraphQLInput {
@@ -153,7 +154,12 @@ export function parseGraphQLRequest(
     const requestPublicUrl = getPublicUrlFromRequest(request)
 
     throw new Error(
-      `[MSW] Failed to intercept a GraphQL request to "${request.method} ${requestPublicUrl}": cannot parse query. See the error message from the parser below.\n\n${parsedResult}`,
+      devUtils.formatMessage(
+        'Failed to intercept a GraphQL request to "%s %s": cannot parse query. See the error message from the parser below.\n\n%o',
+        request.method,
+        requestPublicUrl,
+        parsedResult.message,
+      ),
     )
   }
 

--- a/src/utils/request/onUnhandledRequest.ts
+++ b/src/utils/request/onUnhandledRequest.ts
@@ -9,6 +9,7 @@ import { RestHandler } from '../../handlers/RestHandler'
 import { GraphQLHandler } from '../../handlers/GraphQLHandler'
 import { MockedRequest, RequestHandler } from '../../handlers/RequestHandler'
 import { tryCatch } from '../internal/tryCatch'
+import { devUtils } from '../internal/devUtils'
 
 const MAX_MATCH_SCORE = 3
 const MAX_SUGGESTION_COUNT = 4
@@ -169,12 +170,12 @@ Read more: https://mswjs.io/docs/getting-started/mocks\
 
   switch (strategy) {
     case 'error': {
-      console.error(`[MSW] Error: ${message}`)
+      devUtils.error('Error: %s', message)
       break
     }
 
     case 'warn': {
-      console.warn(`[MSW] Warning: ${message}`)
+      devUtils.warn('Warning: %s', message)
       break
     }
 
@@ -183,7 +184,10 @@ Read more: https://mswjs.io/docs/getting-started/mocks\
 
     default:
       throw new Error(
-        `[MSW] Failed to react to an unhandled request: unknown strategy "${strategy}". Please provide one of the supported strategies ("bypass", "warn", "error") or a custom callback function.`,
+        devUtils.formatMessage(
+          'Failed to react to an unhandled request: unknown strategy "%s". Please provide one of the supported strategies ("bypass", "warn", "error") or a custom callback function as the value of the "onUnhandledRequest" option.',
+          strategy,
+        ),
       )
   }
 }


### PR DESCRIPTION
An internal improvement that's been on my mind for some time. No user-facing changes. 

## Changes

- Introduces a `devUtils` object that contains often-used utilities like `warn` and `error`. Prepends the library's prefix `"[MSW"]` to each message. Enables interpolation via `outvariant`.