### PR TITLE
Bumps "is-node-process" to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "graphql": "^15.5.1",
     "headers-utils": "^3.0.2",
     "inquirer": "^8.1.1",
-    "is-node-process": "^1.0.0",
+    "is-node-process": "^1.0.1",
     "js-levenshtein": "^1.1.6",
     "node-fetch": "^2.6.1",
     "node-match-path": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4938,10 +4938,10 @@ is-negative-zero@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
 
-is-node-process@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.0.0.tgz#7e3f833139aac65d31d21aca81587d6ccda80a10"
-  integrity sha512-m9HTvEwmJx2rf2c8QM26jGVK865A/tYWz+GORRB0ehitPPF/Ajm8yImTRwkEJC7giteusNdgtMEPIeY4alf9Lg==
+is-node-process@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.0.1.tgz#4fc7ac3a91e8aac58175fe0578abbc56f2831b23"
+  integrity sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==
 
 is-number@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## GitHub

- Fixes #827 

## Changes

- Updates the `is-node-process` dependency that reverts the `navigator.product` dependency to determine a React Native runtime (https://github.com/mswjs/is-node-process/pull/2).