### PR TITLE
Uses the "SerializedResponse" type consistently

### DIFF
--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -160,7 +160,7 @@ Consider naming this operation or using "graphql.operation" request handler to i
 
   log(
     request: Request,
-    response: SerializedResponse<any>,
+    response: SerializedResponse,
     handler: this,
     parsedRequest: ParsedGraphQLRequest,
   ) {

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -7,6 +7,7 @@ import { set } from '../context/set'
 import { delay } from '../context/delay'
 import { fetch } from '../context/fetch'
 import { ResponseResolutionContext } from '../utils/getResponse'
+import { SerializedResponse } from '../setupWorker/glossary'
 
 export const defaultContext = {
   status,
@@ -141,7 +142,7 @@ export abstract class RequestHandler<
    */
   abstract log(
     request: Request,
-    response: any,
+    response: SerializedResponse<any>,
     handler: this,
     parsedResult: ParsedResult,
   ): void

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -176,7 +176,7 @@ ${queryParams
     )
   }
 
-  log(request: RequestType, response: SerializedResponse<any>) {
+  log(request: RequestType, response: SerializedResponse) {
     const publicUrl = getPublicUrlFromRequest(request)
     const loggedRequest = prepareRequest(request)
     const loggedResponse = prepareResponse(response)

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -2,7 +2,6 @@ import { Path } from 'node-match-path'
 import { PartialDeep } from 'type-fest'
 import { FlatHeadersObject } from 'headers-utils'
 import { StrictEventEmitter } from 'strict-event-emitter'
-import { MockedResponse } from '../response'
 import { SharedOptions } from '../sharedOptions'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
 import { MockedRequest, RequestHandler } from '../handlers/RequestHandler'
@@ -178,11 +177,11 @@ export interface StartOptions extends SharedOptions {
   findWorker: FindWorker
 }
 
-export type SerializedResponse<BodyType = any> = Omit<
-  MockedResponse<BodyType>,
-  'headers'
-> & {
+export interface SerializedResponse<BodyType = any> {
+  status: number
+  statusText: string
   headers: FlatHeadersObject
+  body: BodyType
 }
 
 export type StartReturnType = Promise<ServiceWorkerRegistration | undefined>

--- a/src/utils/logging/prepareResponse.test.ts
+++ b/src/utils/logging/prepareResponse.test.ts
@@ -8,19 +8,15 @@ test('parses a JSON response body given a "Content-Type:*/json" header', () => {
       'Content-Type': 'application/json',
     },
     body: `{"property":2}`,
-    once: false,
-    delay: 0,
   })
 
   // Preserves all the properties
-  expect(res).toHaveProperty('status', 200)
-  expect(res).toHaveProperty('statusText', 'OK')
-  expect(res).toHaveProperty('headers', { 'Content-Type': 'application/json' })
-  expect(res).toHaveProperty('once', false)
-  expect(res).toHaveProperty('delay', 0)
+  expect(res.status).toEqual(200)
+  expect(res.statusText).toEqual('OK')
+  expect(res.headers).toEqual({ 'Content-Type': 'application/json' })
 
   // Parses a JSON response body
-  expect(res).toHaveProperty('body', { property: 2 })
+  expect(res.body).toEqual({ property: 2 })
 })
 
 test('returns a stringified valid JSON body given a non-JSON "Content-Type" header', () => {
@@ -29,18 +25,14 @@ test('returns a stringified valid JSON body given a non-JSON "Content-Type" head
     statusText: 'OK',
     headers: {},
     body: `{"property":2}`,
-    once: false,
-    delay: 0,
   })
 
-  expect(res).toHaveProperty('status', 200)
-  expect(res).toHaveProperty('statusText', 'OK')
-  expect(res).toHaveProperty('headers', {})
-  expect(res).toHaveProperty('once', false)
-  expect(res).toHaveProperty('delay', 0)
+  expect(res.status).toEqual(200)
+  expect(res.statusText).toEqual('OK')
+  expect(res.headers).toEqual({})
 
   // Returns a non-JSON response body as-is
-  expect(res).toHaveProperty('body', `{"property":2}`)
+  expect(res.body).toEqual(`{"property":2}`)
 })
 
 test('returns a non-JSON response body as-is', () => {
@@ -49,16 +41,12 @@ test('returns a non-JSON response body as-is', () => {
     statusText: 'OK',
     headers: {},
     body: `text-body`,
-    once: false,
-    delay: 0,
   })
 
-  expect(res).toHaveProperty('status', 200)
-  expect(res).toHaveProperty('statusText', 'OK')
-  expect(res).toHaveProperty('headers', {})
-  expect(res).toHaveProperty('once', false)
-  expect(res).toHaveProperty('delay', 0)
+  expect(res.status).toEqual(200)
+  expect(res.statusText).toEqual('OK')
+  expect(res.headers).toEqual({})
 
   // Returns a non-JSON response body as-is
-  expect(res).toHaveProperty('body', 'text-body')
+  expect(res.body).toEqual('text-body')
 })

--- a/src/utils/logging/prepareResponse.ts
+++ b/src/utils/logging/prepareResponse.ts
@@ -3,7 +3,7 @@ import { SerializedResponse } from '../../setupWorker/glossary'
 import { parseBody } from '../request/parseBody'
 
 /**
- * Formats a mocked response for introspection in browser's console.
+ * Formats a mocked response for introspection in the browser's console.
  */
 export function prepareResponse(res: SerializedResponse<any>) {
   const responseHeaders = objectToHeaders(res.headers)

--- a/src/utils/worker/createFallbackRequestListener.ts
+++ b/src/utils/worker/createFallbackRequestListener.ts
@@ -7,6 +7,7 @@ import { interceptFetch } from '@mswjs/interceptors/lib/interceptors/fetch'
 import { interceptXMLHttpRequest } from '@mswjs/interceptors/lib/interceptors/XMLHttpRequest'
 import { RequestHandler } from '../../handlers/RequestHandler'
 import {
+  SerializedResponse,
   SetupWorkerInternalContext,
   StartOptions,
 } from '../../setupWorker/glossary'
@@ -21,7 +22,7 @@ export function createFallbackRequestListener(
     modules: [interceptFetch, interceptXMLHttpRequest],
     async resolver(request) {
       const mockedRequest = parseIsomorphicRequest(request)
-      return handleRequest<MockedResponse>(
+      return handleRequest<SerializedResponse>(
         mockedRequest,
         context.requestHandlers,
         options,


### PR DESCRIPTION
- `SerializedResponse` type cannot be inferred from the `MockedResponse` because the latter contains a bunch of internal properties (`once`, `delay`, etc.). Re-declare the type instead.
- Use the `SerializedResponse` type in the `RequestHandler` methods appropriately. 