### PR TITLE
GraphQLHandler: Print operation type/name in the log message

### DIFF
--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -158,16 +158,22 @@ Consider naming this operation or using "graphql.operation" request handler to i
     )
   }
 
-  log(request: Request, response: SerializedResponse<any>) {
+  log(
+    request: Request,
+    response: SerializedResponse<any>,
+    handler: this,
+    parsedRequest: ParsedGraphQLRequest,
+  ) {
     const loggedRequest = prepareRequest(request)
     const loggedResponse = prepareResponse(response)
 
     console.groupCollapsed(
       devUtils.formatMessage('%s %s (%c%s%c)'),
       getTimestamp(),
-      this.info.operationName,
-      `color:${getStatusCodeColor(response.status)}`,
+      `${parsedRequest?.operationType} ${parsedRequest?.operationName}`,
+      `color:${getStatusCodeColor(response.status)} %s`,
       response.status,
+      response.statusText,
       'color:inherit',
     )
     console.log('Request:', loggedRequest)

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -186,8 +186,9 @@ ${queryParams
       getTimestamp(),
       request.method,
       publicUrl,
-      `color:${getStatusCodeColor(response.status)}`,
+      `color:${getStatusCodeColor(response.status)} %s`,
       response.status,
+      response.statusText,
       'color:inherit',
     )
     console.log('Request', loggedRequest)

--- a/src/utils/logging/getTimestamp.ts
+++ b/src/utils/logging/getTimestamp.ts
@@ -1,4 +1,7 @@
-export function getTimestamp() {
+/**
+ * Returns a timestamp string in a "HH:MM:SS" format.
+ */
+export function getTimestamp(): string {
   const now = new Date()
 
   return [now.getHours(), now.getMinutes(), now.getSeconds()]

--- a/test/graphql-api/logging.mocks.ts
+++ b/test/graphql-api/logging.mocks.ts
@@ -33,6 +33,14 @@ const worker = setupWorker(
       }),
     )
   }),
+  graphql.operation((req, res, ctx) => {
+    return res(
+      ctx.status(301),
+      ctx.data({
+        ok: true,
+      }),
+    )
+  }),
 )
 
 worker.start()

--- a/test/msw-api/integrity-check.test.ts
+++ b/test/msw-api/integrity-check.test.ts
@@ -55,11 +55,11 @@ test('errors when activating the worker with an outdated integrity', async () =>
   })
 
   // Produces a meaningful error in the browser's console.
-  const integrityError = consoleSpy.get('error').find((text) => {
-    return text.includes('[MSW] Detected outdated Service Worker')
-  })
-
-  expect(integrityError).toBeTruthy()
+  expect(consoleSpy.get('error')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining('[MSW] Detected outdated Service Worker'),
+    ]),
+  )
 
   // Should still keep the mocking enabled.
   const res = await request('https://api.github.com/users/octocat')

--- a/test/msw-api/setup-worker/fallback-mode/fallback-mode.test.ts
+++ b/test/msw-api/setup-worker/fallback-mode/fallback-mode.test.ts
@@ -81,13 +81,12 @@ test('responds with a mocked response to a handled request', async () => {
   const response = await request('https://api.github.com/users/octocat')
 
   // Prints the request message group in the console.
-  const requestMessage = runtime.consoleSpy
-    .get('startGroupCollapsed')
-    .find((message) => {
-      return message.includes('GET https://api.github.com/users/octocat')
-    })
-  expect(requestMessage).toMatch(
-    /\[MSW\] \d{2}:\d{2}:\d{2} GET https:\/\/api\.github\.com\/users\/octocat 200/,
+  expect(runtime.consoleSpy.get('startGroupCollapsed')).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(
+        /\[MSW\] \d{2}:\d{2}:\d{2} GET https:\/\/api\.github\.com\/users\/octocat 200 OK/,
+      ),
+    ]),
   )
 
   // Responds with a mocked response.
@@ -104,13 +103,17 @@ test('warns on the unhandled request by default', async () => {
   const request = createRequestHelper(runtime.page)
   await request('https://example.com')
 
-  expect(runtime.consoleSpy.get('warning')).toContain(`\
+  expect(runtime.consoleSpy.get('warning')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • GET https://example.com/
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+    ]),
+  )
 })
 
 test('stops the fallback interceptor when called "worker.stop()"', async () => {

--- a/test/msw-api/setup-worker/input-validation.test.ts
+++ b/test/msw-api/setup-worker/input-validation.test.ts
@@ -13,11 +13,11 @@ test('throws an error given an Array of request handlers to "setupWorker"', asyn
   })
   await page.reload({ waitUntil: 'networkidle' })
 
-  const nodeMessage = exceptions.find((message) => {
-    return message.startsWith(
-      `[MSW] Failed to call "setupWorker" given an Array of request handlers (setupWorker([a, b])), expected to receive each handler individually: setupWorker(a, b).`,
-    )
-  })
-
-  expect(nodeMessage).toBeTruthy()
+  expect(exceptions).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        '[MSW] Failed to call "setupWorker" given an Array of request handlers (setupWorker([a, b])), expected to receive each handler individually: setupWorker(a, b).',
+      ),
+    ]),
+  )
 })

--- a/test/msw-api/setup-worker/start/on-unhandled-request/default.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/default.test.ts
@@ -9,14 +9,15 @@ test('warns on unhandled requests by default', async () => {
   const res = await request('https://mswjs.io/non-existing-page')
   const status = res.status()
 
-  const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-    return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-      text,
-    )
-  })
+  expect(consoleSpy.get('warning')).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(
+        /\[MSW\] Warning: captured a request without a matching request handler/,
+      ),
+    ]),
+  )
 
   expect(consoleSpy.get('error')).toBeUndefined()
-  expect(unhandledRequestWarning).toBeDefined()
 
   // Performs the request as-is.
   expect(status).toBe(404)

--- a/test/msw-api/setup-worker/start/on-unhandled-request/suggestions.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/suggestions.test.ts
@@ -30,19 +30,17 @@ describe('REST API', () => {
 
     await request('/user-details')
 
-    const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-      return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-        text,
-      )
-    })
-
-    expect(unhandledRequestWarning).toMatch(`\
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • GET /user-details
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+      ]),
+    )
   })
 
   test('suggests a similar request handler of the same method', async () => {
@@ -55,13 +53,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
 
     await request('/users')
 
-    const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-      return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-        text,
-      )
-    })
-
-    expect(unhandledRequestWarning).toMatch(`\
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • GET /users
@@ -69,7 +63,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
 Did you mean to request "GET /user" instead?
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+      ]),
+    )
   })
 
   test('suggest a handler of a different method if its URL is similar', async () => {
@@ -87,13 +83,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
       method: 'POST',
     })
 
-    const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-      return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-        text,
-      )
-    })
-
-    expect(unhandledRequestWarning).toMatch(`\
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • POST /users
@@ -101,7 +93,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
 Did you mean to request "GET /user" instead?
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+      ]),
+    )
   })
 
   test('suggests multiple similar handlers regardless of their method', async () => {
@@ -117,13 +111,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
 
     await request('/pamyents')
 
-    const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-      return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-        text,
-      )
-    })
-
-    expect(unhandledRequestWarning).toMatch(`\
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • GET /pamyents
@@ -134,7 +124,9 @@ Did you mean to request one of the following resources instead?
   • POST /payment
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+      ]),
+    )
   })
 })
 
@@ -166,19 +158,17 @@ describe('GraphQL API', () => {
       }),
     })
 
-    const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-      return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-        text,
-      )
-    })
-
-    expect(unhandledRequestWarning).toMatch(`\
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • query PaymentHistory (POST /graphql)
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+      ]),
+    )
   })
 
   test('suggests a similar request handler of the same operation type', async () => {
@@ -208,13 +198,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
       }),
     })
 
-    const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-      return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-        text,
-      )
-    })
-
-    expect(unhandledRequestWarning).toMatch(`\
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • query GetUsers (POST /graphql)
@@ -222,7 +208,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
 Did you mean to request "query GetUser (origin: *)" instead?
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+      ]),
+    )
   })
 
   test('suggests a handler of a different operation type if its name is similar', async () => {
@@ -252,13 +240,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
       }),
     })
 
-    const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-      return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-        text,
-      )
-    })
-
-    expect(unhandledRequestWarning).toMatch(`\
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • query SubmitCheckout (POST /graphql)
@@ -266,7 +250,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
 Did you mean to request "mutation SubmitCheckout (origin: *)" instead?
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+      ]),
+    )
   })
 
   test('suggests multiple similar handlers regardless of their operation type', async () => {
@@ -296,13 +282,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
       }),
     })
 
-    const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-      return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-        text,
-      )
-    })
-
-    expect(unhandledRequestWarning).toMatch(`\
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • query ActiveUsers (POST /graphql)
@@ -313,6 +295,8 @@ Did you mean to request one of the following resources instead?
   • mutation ActivateUser (origin: *)
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+      ]),
+    )
   })
 })

--- a/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
+++ b/test/msw-api/setup-worker/start/on-unhandled-request/warn.test.ts
@@ -13,13 +13,17 @@ test('warns on an unhandled REST API request with an absolute URL', async () => 
   const status = res.status()
 
   expect(status).toBe(404)
-  expect(consoleSpy.get('warning')).toContain(`\
+  expect(consoleSpy.get('warning')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • GET https://mswjs.io/non-existing-page
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+    ]),
+  )
 })
 
 test('warns on an unhandled REST API request with a relative URL', async () => {
@@ -28,13 +32,17 @@ test('warns on an unhandled REST API request with a relative URL', async () => {
   const status = res.status()
 
   expect(status).toBe(404)
-  expect(consoleSpy.get('warning')).toContain(`\
+  expect(consoleSpy.get('warning')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(`\
 [MSW] Warning: captured a request without a matching request handler:
 
   • GET /user-details
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
-Read more: https://mswjs.io/docs/getting-started/mocks`)
+Read more: https://mswjs.io/docs/getting-started/mocks`),
+    ]),
+  )
 })
 
 test('does not warn on request which handler explicitly returns no mocked response', async () => {
@@ -43,14 +51,13 @@ test('does not warn on request which handler explicitly returns no mocked respon
   const status = res.status()
 
   expect(status).toBe(404)
-
-  const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-    return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-      text,
-    )
-  })
-
-  expect(unhandledRequestWarning).not.toBeDefined()
+  expect(consoleSpy.get('warning')).toEqual(
+    expect.not.arrayContaining([
+      expect.stringContaining(
+        '[MSW] Warning: captured a request without a matching request handler',
+      ),
+    ]),
+  )
 })
 
 test('does not warn on request which handler implicitly returns no mocked response', async () => {
@@ -59,12 +66,11 @@ test('does not warn on request which handler implicitly returns no mocked respon
   const status = res.status()
 
   expect(status).toBe(404)
-
-  const unhandledRequestWarning = consoleSpy.get('warning').find((text) => {
-    return /\[MSW\] Warning: captured a request without a matching request handler/.test(
-      text,
-    )
-  })
-
-  expect(unhandledRequestWarning).not.toBeDefined()
+  expect(consoleSpy.get('warning')).toEqual(
+    expect.not.arrayContaining([
+      expect.stringContaining(
+        '[MSW] Warning: captured a request without a matching request handler',
+      ),
+    ]),
+  )
 })

--- a/test/msw-api/setup-worker/start/options-sw-scope.test.ts
+++ b/test/msw-api/setup-worker/start/options-sw-scope.test.ts
@@ -6,12 +6,9 @@ test('respects a custom "scope" Service Worker option', async () => {
     example: path.resolve(__dirname, 'options-sw-scope.mocks.ts'),
   })
 
-  const activationMessage = consoleSpy
-    .get('startGroupCollapsed')
-    .find((text) => {
-      return text.includes('[MSW] Mocking enabled.')
-    })
-  expect(activationMessage).toBeTruthy()
+  expect(consoleSpy.get('startGroupCollapsed')).toEqual(
+    expect.arrayContaining([expect.stringContaining('[MSW] Mocking enabled.')]),
+  )
 
   const res = await request('/user')
   const status = res.status()

--- a/test/rest-api/logging.test.ts
+++ b/test/rest-api/logging.test.ts
@@ -7,24 +7,13 @@ function createRuntime() {
 
 test('prints a captured request info into browser console', async () => {
   const runtime = await createRuntime()
-
   await runtime.request('https://api.github.com/users/octocat')
 
-  const requestLog = runtime.consoleSpy
-    .get('startGroupCollapsed')
-    .find((text) => {
-      // No way to assert the entire format of the log entry,
-      // because Playwright intercepts `console.log` calls,
-      // which contain unformatted strings (with %s, %c, styles).
-      return text.includes('https://api.github.com/users/octocat')
-    })
-
-  // Request log must include a timestamp.
-  expect(requestLog).toMatch(/\d{2}:\d{2}:\d{2}/)
-
-  // Request log must include the request method.
-  expect(requestLog).toContain('GET')
-
-  // Request log must include the response status code.
-  expect(requestLog).toContain('200')
+  expect(runtime.consoleSpy.get('startGroupCollapsed')).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(
+        /\[MSW\] \d{2}:\d{2}:\d{2} GET https:\/\/api\.github\.com\/users\/octocat 200 OK/,
+      ),
+    ]),
+  )
 })


### PR DESCRIPTION
## GitHub

- Fixes #833 

## Changes

- All request handlers now contain the `response.statusText` in the log message. This changes the log message's structure:

```
[MSW] 00:00:00 GET /user 200 OK
[MSW] 00:00:00 POST https://api.com/resource 301 Moved Permanently

[MSW] 00:00:00 query GetUser 200 OK
[MSW] 00:00:00 mutation Login 500 Internal Server Error
```

- Tests now consistently use `expect.arrayContaining`/`expect.stringContaining` Jest's utilities for a more concise matching of strings nested in lists (i.e. when asserting `runtime.consoleSpy`).