### PR TITLE
mockServiceWorker: Bypasses the SSE (text/event-stream) requests

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -243,6 +243,11 @@ If you wish to mock an error response, please refer to this guide: https://mswjs
 self.addEventListener('fetch', function (event) {
   const { request } = event
 
+  // Bypass server-sent events.
+  if (request.headers.get('accept') === 'text/event-stream') {
+    return
+  }
+
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
     return

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -242,9 +242,10 @@ If you wish to mock an error response, please refer to this guide: https://mswjs
 
 self.addEventListener('fetch', function (event) {
   const { request } = event
+  const accept = request.headers.get('accept') || ''
 
   // Bypass server-sent events.
-  if (request.headers.get('accept') === 'text/event-stream') {
+  if (accept.includes('text/event-stream')) {
     return
   }
 

--- a/test/msw-api/setup-worker/scenarios/text-event-stream.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/text-event-stream.mocks.ts
@@ -1,0 +1,9 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res()
+  }),
+)
+
+worker.start()

--- a/test/msw-api/setup-worker/scenarios/text-event-stream.test.ts
+++ b/test/msw-api/setup-worker/scenarios/text-event-stream.test.ts
@@ -1,0 +1,50 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { createServer, ServerApi } from '@open-draft/test-server'
+import { sleep } from '../../../support/utils'
+
+let httpServer: ServerApi
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.get('/user', async (req, res) => {
+      res.set({
+        'Content-Type': 'text/event-stream',
+        Connection: 'keep-alive',
+      })
+      res.flushHeaders()
+
+      const chunks = ['hello', 'beautiful', 'world']
+
+      for (const chunk of chunks) {
+        res.write(`data: ${chunk}\n\n`)
+        await sleep(150)
+      }
+    })
+  })
+})
+
+afterAll(async () => {
+  await httpServer.close()
+})
+
+test('bypasses the unhandled request with the "Accept" header containing "text/event-stream"', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'text-event-stream.mocks.ts'),
+  })
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const source = new EventSource(endpointUrl)
+    source.addEventListener('message', (message) => {
+      console.log(message.data)
+    })
+  }, httpServer.http.makeUrl('/user'))
+
+  // Await before the client receives all the events.
+  await sleep(450)
+
+  expect(runtime.consoleSpy.get('error')).toBeUndefined()
+  expect(runtime.consoleSpy.get('log')).toEqual(
+    expect.arrayContaining(['hello', 'beautiful', 'world']),
+  )
+})


### PR DESCRIPTION
Fixes #834

## Changes

Requests whose `Accept` header contains `text/event-stream` are not explicitly bypassed by the worker script. 