### PR TITLE
Fixes the request log status code/text colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "jest": "26",
     "json-bigint": "^1.0.0",
     "lint-staged": "^11.0.1",
-    "page-with": "^0.4.0",
+    "page-with": "^0.4.1",
     "prettier": "^2.3.2",
     "regenerator-runtime": "^0.13.7",
     "rimraf": "^3.0.2",

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -197,14 +197,14 @@ Consider naming this operation or using "graphql.operation" request handler to i
   ) {
     const loggedRequest = prepareRequest(request)
     const loggedResponse = prepareResponse(response)
+    const statusColor = getStatusCodeColor(response.status)
 
     console.groupCollapsed(
       devUtils.formatMessage('%s %s (%c%s%c)'),
       getTimestamp(),
       `${parsedRequest?.operationType} ${parsedRequest?.operationName}`,
-      `color:${getStatusCodeColor(response.status)} %s`,
-      response.status,
-      response.statusText,
+      `color:${statusColor}`,
+      `${response.status} ${response.statusText}`,
       'color:inherit',
     )
     console.log('Request:', loggedRequest)

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -180,15 +180,15 @@ ${queryParams
     const publicUrl = getPublicUrlFromRequest(request)
     const loggedRequest = prepareRequest(request)
     const loggedResponse = prepareResponse(response)
+    const statusColor = getStatusCodeColor(response.status)
 
     console.groupCollapsed(
       devUtils.formatMessage('%s %s %s (%c%s%c)'),
       getTimestamp(),
       request.method,
       publicUrl,
-      `color:${getStatusCodeColor(response.status)} %s`,
-      response.status,
-      response.statusText,
+      `color:${statusColor}`,
+      `${response.status} ${response.statusText}`,
       'color:inherit',
     )
     console.log('Request', loggedRequest)

--- a/src/utils/logging/getStatusCodeColor.ts
+++ b/src/utils/logging/getStatusCodeColor.ts
@@ -1,14 +1,20 @@
+export enum StatusCodeColor {
+  Success = '#69AB32',
+  Warning = '#F0BB4B',
+  Danger = '#E95F5D',
+}
+
 /**
  * Returns a HEX color for a given response status code number.
  */
-export function getStatusCodeColor(status: number) {
+export function getStatusCodeColor(status: number): StatusCodeColor {
   if (status < 300) {
-    return '#69AB32'
+    return StatusCodeColor.Success
   }
 
   if (status < 400) {
-    return '#F0BB4B'
+    return StatusCodeColor.Warning
   }
 
-  return '#E95F5D'
+  return StatusCodeColor.Danger
 }

--- a/src/utils/worker/createFallbackRequestListener.ts
+++ b/src/utils/worker/createFallbackRequestListener.ts
@@ -1,8 +1,4 @@
-import {
-  MockedResponse,
-  createInterceptor,
-  InterceptorApi,
-} from '@mswjs/interceptors'
+import { createInterceptor, InterceptorApi } from '@mswjs/interceptors'
 import { interceptFetch } from '@mswjs/interceptors/lib/interceptors/fetch'
 import { interceptXMLHttpRequest } from '@mswjs/interceptors/lib/interceptors/XMLHttpRequest'
 import { RequestHandler } from '../../handlers/RequestHandler'

--- a/test/graphql-api/logging.test.ts
+++ b/test/graphql-api/logging.test.ts
@@ -2,6 +2,7 @@ import * as path from 'path'
 import { executeGraphQLQuery } from './utils/executeGraphQLQuery'
 import { pageWith } from 'page-with'
 import { gql } from '../support/graphql'
+import { StatusCodeColor } from '../../src/utils/logging/getStatusCodeColor'
 
 function createRuntime() {
   return pageWith({
@@ -22,10 +23,12 @@ test('prints a log for a GraphQL query', async () => {
     `,
   })
 
-  expect(consoleSpy.get('startGroupCollapsed')).toEqual(
+  expect(consoleSpy.get('raw').get('startGroupCollapsed')).toEqual(
     expect.arrayContaining([
       expect.stringMatching(
-        /\[MSW\] \d{2}:\d{2}:\d{2} query GetUserDetail 200 OK/,
+        new RegExp(
+          `^\\[MSW\\] %s %s \\(%c%s%c\\) \\d{2}:\\d{2}:\\d{2} query GetUserDetail color:${StatusCodeColor.Success} 200 OK color:inherit$`,
+        ),
       ),
     ]),
   )
@@ -43,9 +46,13 @@ test('prints a log for a GraphQL mutation', async () => {
     `,
   })
 
-  expect(consoleSpy.get('startGroupCollapsed')).toEqual(
+  expect(consoleSpy.get('raw').get('startGroupCollapsed')).toEqual(
     expect.arrayContaining([
-      expect.stringMatching(/\[MSW\] \d{2}:\d{2}:\d{2} mutation Login 200 OK/),
+      expect.stringMatching(
+        new RegExp(
+          `\\[MSW\\] %s %s \\(%c%s%c\\) \\d{2}:\\d{2}:\\d{2} mutation Login color:${StatusCodeColor.Success} 200 OK color:inherit$`,
+        ),
+      ),
     ]),
   )
 })
@@ -62,10 +69,12 @@ test('prints a log for a GraphQL query intercepted via "graphql.operation"', asy
     `,
   })
 
-  expect(consoleSpy.get('startGroupCollapsed')).toEqual(
+  expect(consoleSpy.get('raw').get('startGroupCollapsed')).toEqual(
     expect.arrayContaining([
       expect.stringMatching(
-        /\[MSW\] \d{2}:\d{2}:\d{2} query GetLatestPosts 301 Moved Permanently/,
+        new RegExp(
+          `\\[MSW\\] %s %s \\(%c%s%c\\) \\d{2}:\\d{2}:\\d{2} query GetLatestPosts color:${StatusCodeColor.Warning} 301 Moved Permanently color:inherit$`,
+        ),
       ),
     ]),
   )
@@ -83,10 +92,12 @@ test('prints a log for a GraphQL mutation intercepted via "graphql.operation"', 
     `,
   })
 
-  expect(runtime.consoleSpy.get('startGroupCollapsed')).toEqual(
+  expect(runtime.consoleSpy.get('raw').get('startGroupCollapsed')).toEqual(
     expect.arrayContaining([
       expect.stringMatching(
-        /^\[MSW\] \d{2}:\d{2}:\d{2} mutation CreatePost 301 Moved Permanently$/,
+        new RegExp(
+          `\\[MSW\\] %s %s \\(%c%s%c\\) \\d{2}:\\d{2}:\\d{2} mutation CreatePost color:${StatusCodeColor.Warning} 301 Moved Permanently color:inherit$`,
+        ),
       ),
     ]),
   )

--- a/test/graphql-api/logging.test.ts
+++ b/test/graphql-api/logging.test.ts
@@ -72,8 +72,8 @@ test('prints a log for a GraphQL query intercepted via "graphql.operation"', asy
 })
 
 test('prints a log for a GraphQL mutation intercepted via "graphql.operation"', async () => {
-  const { page, consoleSpy } = await createRuntime()
-  await executeGraphQLQuery(page, {
+  const runtime = await createRuntime()
+  await executeGraphQLQuery(runtime.page, {
     query: gql`
       mutation CreatePost {
         post {
@@ -83,10 +83,10 @@ test('prints a log for a GraphQL mutation intercepted via "graphql.operation"', 
     `,
   })
 
-  expect(consoleSpy.get('startGroupCollapsed')).toEqual(
+  expect(runtime.consoleSpy.get('startGroupCollapsed')).toEqual(
     expect.arrayContaining([
       expect.stringMatching(
-        /\[MSW\] \d{2}:\d{2}:\d{2} mutation CreatePost 301 Moved Permanently/,
+        /^\[MSW\] \d{2}:\d{2}:\d{2} mutation CreatePost 301 Moved Permanently$/,
       ),
     ]),
   )

--- a/test/rest-api/logging.test.ts
+++ b/test/rest-api/logging.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import { pageWith } from 'page-with'
+import { StatusCodeColor } from '../../src/utils/logging/getStatusCodeColor'
 
 function createRuntime() {
   return pageWith({ example: path.resolve(__dirname, 'basic.mocks.ts') })
@@ -9,10 +10,12 @@ test('prints a captured request info into browser console', async () => {
   const runtime = await createRuntime()
   await runtime.request('https://api.github.com/users/octocat')
 
-  expect(runtime.consoleSpy.get('startGroupCollapsed')).toEqual(
+  expect(runtime.consoleSpy.get('raw').get('startGroupCollapsed')).toEqual(
     expect.arrayContaining([
       expect.stringMatching(
-        /^\[MSW\] \d{2}:\d{2}:\d{2} GET https:\/\/api\.github\.com\/users\/octocat 200 OK$/,
+        new RegExp(
+          `^\\[MSW\\] %s %s %s \\(%c%s%c\\) \\d{2}:\\d{2}:\\d{2} GET https://api.github.com/users/octocat color:${StatusCodeColor.Success} 200 OK color:inherit$`,
+        ),
       ),
     ]),
   )

--- a/test/rest-api/logging.test.ts
+++ b/test/rest-api/logging.test.ts
@@ -12,7 +12,7 @@ test('prints a captured request info into browser console', async () => {
   expect(runtime.consoleSpy.get('startGroupCollapsed')).toEqual(
     expect.arrayContaining([
       expect.stringMatching(
-        /\[MSW\] \d{2}:\d{2}:\d{2} GET https:\/\/api\.github\.com\/users\/octocat 200 OK/,
+        /^\[MSW\] \d{2}:\d{2}:\d{2} GET https:\/\/api\.github\.com\/users\/octocat 200 OK$/,
       ),
     ]),
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -6393,10 +6393,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-page-with@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/page-with/-/page-with-0.4.0.tgz#f7e17469da35e328d5f08a8fd296a10fc3cf7975"
-  integrity sha512-jgLoc4F1I821FYh/Az+rAbN5C2YWd251GwVhCxjIhPPEL5RMsjFMxU/FauvSBeyRY75W7hY5JOaTS2H13Vgxkw==
+page-with@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/page-with/-/page-with-0.4.1.tgz#7ee139ce70fabcda0d6f9bf0537f964ae838ff57"
+  integrity sha512-Z+ABO4XFzksPRbLrfI07lFCx99G7l98NZdK06angIojZm6pNn166pUbBENDoRhdabJeSGw1mB4f4JXAanpk9ow==
   dependencies:
     "@open-draft/until" "^1.0.3"
     "@types/debug" "^4.1.5"


### PR DESCRIPTION
## GitHub

- Fixes #842 

## Changes

- Fixes a wrongly terminated console message dynamic string.
- Asserts request logs for exact console message styles in integration tests. 

> Unfortunately, even an unterminated styling string is identical to the correct one. The difference is only in how the browser renders it, as the unterminated string includes the styles in it (i.e. "foo color:inherit" as opposed to colored "foo"). I haven't found a reliable way how to get exactly what the browser renders (user sees) using Playwright. 