### PR TITLE
Improves internal/network error messages from the worker

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -221,13 +221,11 @@ async function getResponse(event, client, requestId) {
 
       console.error(
         `\
-[MSW] Request handler function for "%s %s" has thrown the following exception:
+[MSW] Uncaught exception in the request handler for "%s %s":
 
-${parsedBody.errorType}: ${parsedBody.message}
-(see more detailed error stack trace in the mocked response body)
+${parsedBody.location}
 
-This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error.
-If you wish to mock an error response, please refer to this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
+This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
 `,
         request.method,
         request.url,
@@ -271,11 +269,22 @@ self.addEventListener('fetch', function (event) {
 
   return event.respondWith(
     handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
       console.error(
-        '[MSW] Failed to mock a "%s" request to "%s": %s',
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
         request.method,
         request.url,
-        error,
+        `${error.name}: ${error.message}`,
       )
     }),
   )

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,10 +1,19 @@
+import * as fs from 'fs'
 import * as path from 'path'
 import { CreateBrowserApi, createBrowser } from 'page-with'
+import { ServerApi } from '@open-draft/test-server'
 import { SERVICE_WORKER_BUILD_PATH } from '../config/constants'
+import {
+  createWorkerConsoleServer,
+  workerConsoleSpy,
+} from './support/workerConsole'
 
 let browser: CreateBrowserApi
+let workerConsoleServer: ServerApi
 
 beforeAll(async () => {
+  workerConsoleServer = await createWorkerConsoleServer()
+
   browser = await createBrowser({
     serverOptions: {
       router(app) {
@@ -12,7 +21,35 @@ beforeAll(async () => {
         app.set('etag', false)
 
         app.get('/mockServiceWorker.js', (req, res) => {
-          res.sendFile(SERVICE_WORKER_BUILD_PATH)
+          const workerScript = fs.readFileSync(
+            SERVICE_WORKER_BUILD_PATH,
+            'utf8',
+          )
+
+          // Edit the worker script to signal any console messages
+          // to the standalone server. This way tests can spy on the
+          // console messages from the worker.
+          res.set('Content-Type', 'application/javascript').send(`
+${workerScript}
+
+// EVERYTHING BELOW THIS LINE IS APPENDED TO THE WORKER SCRIPT
+// ONLY DURING THE TEST RUN.
+const originals = {}
+Object.keys(console).forEach((methodName) => {
+  originals[methodName] = console[methodName]
+  console[methodName] = (...args) => {
+    fetch('${workerConsoleServer.http.makeUrl('/console/')}' + methodName, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(args)
+    })
+
+    originals[methodName](...args)
+  }
+})
+`)
         })
       },
       webpackConfig: {
@@ -44,6 +81,11 @@ beforeAll(async () => {
   })
 })
 
+afterEach(() => {
+  workerConsoleSpy.clear()
+})
+
 afterAll(async () => {
   await browser.cleanup()
+  await workerConsoleServer.close()
 })

--- a/test/msw-api/res/network-error.test.ts
+++ b/test/msw-api/res/network-error.test.ts
@@ -20,7 +20,7 @@ test('throws a network error', async () => {
 
   // Assert a network error message printed into the console
   // before `fetch` rejects.
-  expect(consoleSpy.get('error')).toContain(
+  expect(consoleSpy.get('error')).toEqual([
     'Failed to load resource: net::ERR_FAILED',
-  )
+  ])
 })

--- a/test/msw-api/setup-worker/scenarios/errors/internal-error.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/errors/internal-error.mocks.ts
@@ -1,0 +1,9 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', () => {
+    throw new Error('Custom error message')
+  }),
+)
+
+worker.start()

--- a/test/msw-api/setup-worker/scenarios/errors/internal-error.test.ts
+++ b/test/msw-api/setup-worker/scenarios/errors/internal-error.test.ts
@@ -1,0 +1,44 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { waitFor } from '../../../../support/waitFor'
+import { workerConsoleSpy } from '../../../../support/workerConsole'
+
+test('propagates the exception originating from a handled request', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'internal-error.mocks.ts'),
+  })
+
+  const endpointUrl = runtime.makeUrl('/user')
+  const res = await runtime.request(endpointUrl)
+  const json = await res.json()
+
+  // Expect the exception to be handled as a 500 error response.
+  expect(res.status()).toEqual(500)
+  expect(json).toEqual({
+    errorType: 'Error',
+    message: 'Custom error message',
+    location: expect.stringContaining('Error: Custom error message'),
+  })
+
+  // Expect standard request failure message from the browser.
+  await waitFor(() => {
+    expect(runtime.consoleSpy.get('error')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'Failed to load resource: the server responded with a status of 500',
+        ),
+      ]),
+    )
+  })
+
+  //
+  expect(workerConsoleSpy.get('error')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(`\
+[MSW] Uncaught exception in the request handler for "GET ${endpointUrl}":
+
+Error: Custom error message
+`),
+    ]),
+  )
+})

--- a/test/msw-api/setup-worker/scenarios/errors/network-error.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/errors/network-error.mocks.ts
@@ -1,0 +1,9 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.get('/user', (req, res, ctx) => {
+    return res.networkError('Custom network error message')
+  }),
+)
+
+worker.start()

--- a/test/msw-api/setup-worker/scenarios/errors/network-error.test.ts
+++ b/test/msw-api/setup-worker/scenarios/errors/network-error.test.ts
@@ -1,0 +1,81 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { until } from '@open-draft/until'
+import { workerConsoleSpy } from '../../../../support/workerConsole'
+import { waitFor } from '../../../../support/waitFor'
+import { createServer, ServerApi } from '@open-draft/test-server'
+
+let httpServer: ServerApi
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.use((req, res, next) => {
+      // Configure CORS to fail all requests issued from the test.
+      res.setHeader('Access-Control-Allow-Origin', 'https://mswjs.io')
+      next()
+    })
+
+    app.get('/resource', (req, res) => {
+      res.send('ok').end()
+    })
+  })
+})
+
+afterAll(async () => {
+  await httpServer.close()
+})
+
+test('propagates a mocked network error', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'network-error.mocks.ts'),
+  })
+
+  const endpointUrl = runtime.makeUrl('/user')
+  await until(() => runtime.page.evaluate((url) => fetch(url), endpointUrl))
+
+  // Expect the fetch error message.
+  expect(runtime.consoleSpy.get('error')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining('Failed to load resource: net::ERR_FAILED'),
+    ]),
+  )
+
+  // Expect a notification warning from the library.
+  await waitFor(() => {
+    expect(workerConsoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          `[MSW] Successfully emulated a network error for the "GET ${endpointUrl}" request.`,
+        ),
+      ]),
+    )
+  })
+
+  // The worker must not produce any errors.
+  expect(workerConsoleSpy.get('error')).toBeUndefined()
+})
+
+test('propagates an original network error', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'network-error.mocks.ts'),
+  })
+
+  const endpointUrl = httpServer.http.makeUrl('/resource')
+  await until(() => runtime.page.evaluate((url) => fetch(url), endpointUrl))
+
+  // Expect the default fetch error message.
+  await waitFor(() => {
+    expect(runtime.consoleSpy.get('error')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Failed to load resource: net::ERR_FAILED'),
+      ]),
+    )
+  })
+
+  // Expect the explanatory error message from the library.
+  await waitFor(() => {
+    expect(workerConsoleSpy.get('error')).toEqual([
+      `[MSW] Caught an exception from the "GET ${endpointUrl}" request (TypeError: Failed to fetch). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+    ])
+  })
+})

--- a/test/support/waitFor.ts
+++ b/test/support/waitFor.ts
@@ -5,8 +5,6 @@ const MAX_RETRIES = 5
 
 export async function waitFor(fn: () => unknown): Promise<void> {
   for (let retryCount = 1; retryCount <= MAX_RETRIES; retryCount++) {
-    await sleep(RETRY_INTERVAL)
-
     try {
       await fn()
       return
@@ -14,6 +12,8 @@ export async function waitFor(fn: () => unknown): Promise<void> {
       if (retryCount === MAX_RETRIES) {
         throw error
       }
+
+      await sleep(RETRY_INTERVAL)
     }
   }
 }

--- a/test/support/waitFor.ts
+++ b/test/support/waitFor.ts
@@ -1,0 +1,19 @@
+import { sleep } from './utils'
+
+const RETRY_INTERVAL = 500
+const MAX_RETRIES = 5
+
+export async function waitFor(fn: () => unknown): Promise<void> {
+  for (let retryCount = 1; retryCount <= MAX_RETRIES; retryCount++) {
+    await sleep(RETRY_INTERVAL)
+
+    try {
+      await fn()
+      return
+    } catch (error) {
+      if (retryCount === MAX_RETRIES) {
+        throw error
+      }
+    }
+  }
+}

--- a/test/support/workerConsole.ts
+++ b/test/support/workerConsole.ts
@@ -1,6 +1,6 @@
 import { ConsoleMessageType } from 'page-with/lib/utils/spyOnConsole'
 import { ServerApi, createServer } from '@open-draft/test-server'
-import { interpolate } from 'outvariant'
+import { format } from 'outvariant'
 
 let workerConsoleServer: ServerApi
 export const workerConsoleSpy = new Map<ConsoleMessageType, string[]>()
@@ -35,7 +35,7 @@ export async function createWorkerConsoleServer() {
       const resolvedMessageType =
         consoleMessageTypeOverrides[messageType] || messageType
       const [template, ...positionals] = req.body
-      const resolvedMessage = interpolate(template, ...positionals)
+      const resolvedMessage = format(template, ...positionals)
 
       workerConsoleSpy.set(
         resolvedMessageType,

--- a/test/support/workerConsole.ts
+++ b/test/support/workerConsole.ts
@@ -1,0 +1,52 @@
+import { ConsoleMessageType } from 'page-with/lib/utils/spyOnConsole'
+import { ServerApi, createServer } from '@open-draft/test-server'
+import { interpolate } from 'outvariant'
+
+let workerConsoleServer: ServerApi
+export const workerConsoleSpy = new Map<ConsoleMessageType, string[]>()
+export const workerConsoleIdle = Promise.resolve()
+
+// Map certain console methods to "ConsoleMessageType".
+const consoleMessageTypeOverrides = {
+  warn: 'warning',
+}
+
+/**
+ * Create a designated HTTP server to propagate "console" calls from the worker script
+ * to the test runtime. This allows assertions on the console messages from the worker.
+ *
+ * @why Service Worker lives in a separate thread and doesn't trigger
+ * the Playwright's page console events. No way to access console events
+ * issues in the worker.
+ * @see https://github.com/microsoft/playwright/issues/6559
+ * @see https://stackoverflow.com/questions/54339039/puppeteer-can-not-listen-service-workers-console
+ */
+export async function createWorkerConsoleServer() {
+  workerConsoleServer = await createServer((app) => {
+    app.use((req, res, next) => {
+      // Configure CORS so that localhost can issue cross-port requests
+      // during the test runs.
+      res.setHeader('Access-Control-Allow-Origin', '*')
+      next()
+    })
+
+    app.post('/console/:messageType', (req, res) => {
+      const { messageType } = req.params
+      const resolvedMessageType =
+        consoleMessageTypeOverrides[messageType] || messageType
+      const [template, ...positionals] = req.body
+      const resolvedMessage = interpolate(template, ...positionals)
+
+      workerConsoleSpy.set(
+        resolvedMessageType,
+        (workerConsoleSpy.get(resolvedMessageType) || []).concat(
+          resolvedMessage,
+        ),
+      )
+
+      return res.status(200).end()
+    })
+  })
+
+  return workerConsoleServer
+}


### PR DESCRIPTION
## GitHub

- Fixes #841 

## Changes

- A mocked network error **does not** produce an additional console error. Instead, it now produces a warning confirming that MSW has successfully emulated a network error.

- An unhandled exception during the `handleRequest` in the worker now has a changed wording:

<img width="1140" alt="Screen Shot 2021-08-02 at 14 22 46" src="https://user-images.githubusercontent.com/14984911/127861285-82adac2f-1f6f-433a-894d-5ce162866e6d.png">

> Once the `NETWORK_ERROR` is handled in the `handlRequest`'s "catch" block, the only remaining exceptions are likely to be request/response related, and are not an issue with MSW but rather with how the request is made.

- Adds missing integration tests for the worker messages in the case of network/internal errors.
- **Adds support for the assertion of the console messages originating from the worker script**. Since the worker executes in a separate thread, tools like Puppeteer/Playwright cannot access its `console` usage, making it impossible to assert the messages that the worker produces. To solve this, I'm adding 2-step setup:

1. Spawn a standalone HTTP server that can accept a message and stores all messages grouped by their type on runtime, similar to the `consoleSpy` from `page-with`.
1. Modify the worker script in tests only to patch the `console.*` methods and make them send a POST request to the said server. 