### PR TITLE
Fixes an issue with ill-formatted "devUtils" output (interpolation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "sideEffects": false,
   "dependencies": {
     "@mswjs/cookies": "^0.1.6",
-    "@mswjs/interceptors": "^0.12.3",
+    "@mswjs/interceptors": "^0.12.5",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.1",
     "@types/inquirer": "^7.3.3",

--- a/src/utils/handleRequest.test.ts
+++ b/src/utils/handleRequest.test.ts
@@ -1,0 +1,223 @@
+import { Headers } from 'headers-utils'
+import { StrictEventEmitter } from 'strict-event-emitter'
+import { ServerLifecycleEventsMap } from '../node/glossary'
+import { createMockedRequest } from '../../test/support/utils'
+import { SharedOptions } from '../sharedOptions'
+import { RequestHandler } from '../handlers/RequestHandler'
+import { rest } from '../rest'
+import { handleRequest } from './handleRequest'
+import { response } from '../response'
+import { context } from '..'
+
+const emitter = new StrictEventEmitter<ServerLifecycleEventsMap>()
+const listener = jest.fn()
+function createMockListener(name: string) {
+  return (...args: any) => {
+    listener(name, ...args)
+  }
+}
+function getEmittedEvents() {
+  return listener.mock.calls
+}
+
+const options: SharedOptions = {
+  onUnhandledRequest: jest.fn(),
+}
+const callbacks = {
+  onBypassResponse: jest.fn(),
+  onMockedResponse: jest.fn(),
+  onMockedResponseSent: jest.fn(),
+}
+
+beforeEach(() => {
+  jest.spyOn(global.console, 'warn').mockImplementation()
+
+  emitter.on('request:start', createMockListener('request:start'))
+  emitter.on('request:match', createMockListener('request:match'))
+  emitter.on('request:unhandled', createMockListener('request:unhandled'))
+  emitter.on('request:end', createMockListener('request:end'))
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+  emitter.removeAllListeners()
+})
+
+test('returns undefined for a request with the "x-msw-bypass" header', async () => {
+  const request = createMockedRequest({
+    url: new URL('http://localhost/user'),
+    headers: new Headers({
+      'x-msw-bypass': 'true',
+    }),
+  })
+  const handlers: RequestHandler[] = []
+
+  const result = await handleRequest(
+    request,
+    handlers,
+    options,
+    emitter,
+    callbacks,
+  )
+
+  expect(result).toBeUndefined()
+  expect(getEmittedEvents()).toEqual([
+    ['request:start', request],
+    ['request:end', request],
+  ])
+  expect(options.onUnhandledRequest).not.toHaveBeenCalled()
+  expect(callbacks.onBypassResponse).toHaveBeenNthCalledWith(1, request)
+  expect(callbacks.onMockedResponse).not.toHaveBeenCalled()
+  expect(callbacks.onMockedResponseSent).not.toHaveBeenCalled()
+})
+
+test('reports request as unhandled when it has no matching request handlers', async () => {
+  const request = createMockedRequest({
+    url: new URL('http://localhost/user'),
+  })
+  const handlers: RequestHandler[] = []
+
+  const result = await handleRequest(
+    request,
+    handlers,
+    options,
+    emitter,
+    callbacks,
+  )
+
+  expect(result).toBeUndefined()
+  expect(getEmittedEvents()).toEqual([
+    ['request:start', request],
+    ['request:unhandled', request],
+    ['request:end', request],
+  ])
+  expect(options.onUnhandledRequest).toHaveBeenNthCalledWith(1, request)
+  expect(callbacks.onBypassResponse).toHaveBeenNthCalledWith(1, request)
+  expect(callbacks.onMockedResponse).not.toHaveBeenCalled()
+  expect(callbacks.onMockedResponseSent).not.toHaveBeenCalled()
+})
+
+test('returns undefined and warns on a request handler that returns no response', async () => {
+  const request = createMockedRequest({
+    url: new URL('http://localhost/user'),
+  })
+  const handlers: RequestHandler[] = [
+    rest.get('/user', () => {
+      // Intentionally blank response resolver.
+      return
+    }),
+  ]
+
+  const result = await handleRequest(
+    request,
+    handlers,
+    options,
+    emitter,
+    callbacks,
+  )
+
+  expect(result).toBeUndefined()
+  expect(getEmittedEvents()).toEqual([
+    ['request:start', request],
+    ['request:end', request],
+  ])
+  expect(options.onUnhandledRequest).not.toHaveBeenCalled()
+  expect(callbacks.onBypassResponse).toHaveBeenNthCalledWith(1, request)
+  expect(callbacks.onMockedResponse).not.toHaveBeenCalled()
+  expect(callbacks.onMockedResponseSent).not.toHaveBeenCalled()
+
+  expect(console.warn).toHaveBeenNthCalledWith(
+    1,
+    '[MSW] Expected a mocking resolver function to return a mocked response Object, but got: undefined. Original response is going to be used instead.',
+  )
+})
+
+test('returns the mocked response for a request with a matching request handler', async () => {
+  const request = createMockedRequest({
+    url: new URL('http://localhost/user'),
+  })
+  const mockedResponse = await response(context.json({ firstName: 'John' }))
+  const handlers: RequestHandler[] = [
+    rest.get('/user', () => {
+      return mockedResponse
+    }),
+  ]
+  const lookupResult = {
+    handler: handlers[0],
+    response: mockedResponse,
+    publicRequest: { ...request, params: {} },
+    parsedRequest: { matches: true, params: null },
+  }
+
+  const result = await handleRequest(
+    request,
+    handlers,
+    options,
+    emitter,
+    callbacks,
+  )
+
+  expect(result).toEqual(mockedResponse)
+  expect(getEmittedEvents()).toEqual([
+    ['request:start', request],
+    ['request:match', request],
+    ['request:end', request],
+  ])
+  expect(callbacks.onBypassResponse).not.toHaveBeenCalled()
+  expect(callbacks.onMockedResponse).toHaveBeenNthCalledWith(
+    1,
+    mockedResponse,
+    lookupResult,
+  )
+  expect(callbacks.onMockedResponseSent).toHaveBeenNthCalledWith(
+    1,
+    mockedResponse,
+    lookupResult,
+  )
+})
+
+test('returns a transformed response if the "transformResponse" option is provided', async () => {
+  const request = createMockedRequest({
+    url: new URL('http://localhost/user'),
+  })
+  const mockedResponse = await response(context.json({ firstName: 'John' }))
+  const handlers: RequestHandler[] = [
+    rest.get('/user', () => {
+      return mockedResponse
+    }),
+  ]
+  const transformResponse = jest.fn().mockImplementation((response) => ({
+    body: response.body,
+  }))
+  const finalResponse = transformResponse(mockedResponse)
+  const lookupResult = {
+    handler: handlers[0],
+    response: mockedResponse,
+    publicRequest: { ...request, params: {} },
+    parsedRequest: { matches: true, params: null },
+  }
+
+  const result = await handleRequest(request, handlers, options, emitter, {
+    ...callbacks,
+    transformResponse,
+  })
+
+  expect(result).toEqual(finalResponse)
+  expect(getEmittedEvents()).toEqual([
+    ['request:start', request],
+    ['request:match', request],
+    ['request:end', request],
+  ])
+  expect(callbacks.onBypassResponse).not.toHaveBeenCalled()
+  expect(transformResponse).toHaveBeenNthCalledWith(1, mockedResponse)
+  expect(callbacks.onMockedResponse).toHaveBeenNthCalledWith(
+    1,
+    finalResponse,
+    lookupResult,
+  )
+  expect(callbacks.onMockedResponseSent).toHaveBeenNthCalledWith(
+    1,
+    finalResponse,
+    lookupResult,
+  )
+})

--- a/src/utils/internal/devUtils.ts
+++ b/src/utils/internal/devUtils.ts
@@ -1,4 +1,4 @@
-import { interpolate } from 'outvariant'
+import { format } from 'outvariant'
 
 const LIBRARY_PREFIX = '[MSW]'
 
@@ -6,7 +6,7 @@ const LIBRARY_PREFIX = '[MSW]'
  * Formats a given message by appending the library's prefix string.
  */
 function formatMessage(message: string, ...positionals: any[]): string {
-  const interpolatedMessage = interpolate(message, ...positionals)
+  const interpolatedMessage = format(message, ...positionals)
   return `${LIBRARY_PREFIX} ${interpolatedMessage}`
 }
 

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -163,7 +163,7 @@ export function parseGraphQLRequest(
 
     throw new Error(
       devUtils.formatMessage(
-        'Failed to intercept a GraphQL request to "%s %s": cannot parse query. See the error message from the parser below.\n\n%o',
+        'Failed to intercept a GraphQL request to "%s %s": cannot parse query. See the error message from the parser below.\n\n%s',
         request.method,
         requestPublicUrl,
         parsedResult.message,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,15 +1411,15 @@
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"
 
-"@mswjs/interceptors@^0.12.3":
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.3.tgz#8d4dc08042dc749a314bd31d363ddac3a0458e26"
-  integrity sha512-qHLEvukC8hHtECKwRpe8q2Y83J91+ckDN6PzHta3tL5X5VIjet062tvvv3ZStHHsm3Xo04TMbm7WyM0RQUpnNA==
+"@mswjs/interceptors@^0.12.5":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.5.tgz#9d01ed8946aacc68723efdf7fd8926711b72b199"
+  integrity sha512-wlLHZgrFPxU5P0HQuUGyl0mQdwo/IFKEe4Pocg4xEj53m9gghsem8YdVzwJYMqxbQv1eMrEHgilvTdc36Vpr/Q==
   dependencies:
     "@open-draft/until" "^1.0.3"
     debug "^4.3.0"
     headers-utils "^3.0.2"
-    outvariant "^1.0.4"
+    outvariant "^1.2.0"
     strict-event-emitter "^0.2.0"
     xmldom "^0.6.0"
 
@@ -6326,10 +6326,10 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-outvariant@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.0.4.tgz#d33d7fa70922e9488dfffd27d1451a8124c2bfec"
-  integrity sha512-2+ax7EEnAxi+g+HN4VrFE5qfLnCb7OQJiJ2LS4K+PQ6lTeHbLpF/AvVTilt7FnTCQuXksQI7lPV1C91oOKeKXg==
+outvariant@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.2.0.tgz#c904d30dc36d70d93902b13641aa1fda69ae8c0c"
+  integrity sha512-OKEOPXtvIeSohFl9avZwm1BL/awT49PV/HQHyc0RHcdICkvj5XP+j+IHhsSoV7nT5gDtMJTlWXqVpA/F8yoi2A==
 
 p-each-series@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
## GitHub

- Fixes #844

## Changes

- Updates `@mswjs/interceptors` to `0.12.5` (see [release notes](https://github.com/mswjs/interceptors/releases/tag/v0.12.5)).
- Adds missing unit tests for the `handleRequest` function so we catch any formatting-related regressions when processing a request.