### PR TITLE
onUnhandledRequest: Throws an exception when using the "error" strategy

### DIFF
--- a/src/utils/request/onUnhandledRequest.ts
+++ b/src/utils/request/onUnhandledRequest.ts
@@ -170,8 +170,13 @@ Read more: https://mswjs.io/docs/getting-started/mocks\
 
   switch (strategy) {
     case 'error': {
+      // Print a developer-friendly error.
       devUtils.error('Error: %s', message)
-      break
+
+      // Throw an exception to halt request processing and not perform the original request.
+      throw new Error(
+        'Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.',
+      )
     }
 
     case 'warn': {

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
@@ -2,25 +2,40 @@
  * @jest-environment node
  */
 import fetch from 'node-fetch'
-import { setupServer } from 'msw/node'
+import { createServer, ServerApi } from '@open-draft/test-server'
 import { rest } from 'msw'
+import { setupServer } from 'msw/node'
 
-const server = setupServer(
-  rest.get('https://test.mswjs.io/user', (req, res, ctx) => {
-    return res(ctx.json({ mocked: true }))
-  }),
-  rest.post('https://test.mswjs.io/explicit-return', () => {
-    // Short-circuiting in a handler makes it perform the request as-is,
-    // but still treats this request as handled.
-    return
-  }),
-  rest.post('https://test.mswjs.io/implicit-return', () => {
-    // The handler that has no return also performs the request as-is,
-    // still treating this request as handled.
-  }),
-)
+let httpServer: ServerApi
+const server = setupServer()
 
-beforeAll(() => {
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.get('/user', (req, res) => {
+      res.status(200).json({ original: true })
+    })
+    app.post('/explicit-return', (req, res) => {
+      res.status(500).end()
+    })
+    app.post('/implicit-return', (req, res) => {
+      res.status(500).end()
+    })
+  })
+
+  server.use(
+    rest.get(httpServer.http.makeUrl('/user'), (req, res, ctx) => {
+      return res(ctx.json({ mocked: true }))
+    }),
+    rest.post(httpServer.http.makeUrl('/explicit-return'), () => {
+      // Short-circuiting in a handler makes it perform the request as-is,
+      // but still treats this request as handled.
+      return
+    }),
+    rest.post(httpServer.http.makeUrl('/implicit-return'), () => {
+      // The handler that has no return also performs the request as-is,
+      // still treating this request as handled.
+    }),
+  )
   server.listen({ onUnhandledRequest: 'error' })
 })
 
@@ -33,21 +48,23 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-afterAll(() => {
+afterAll(async () => {
   jest.restoreAllMocks()
   server.close()
+  await httpServer.close()
 })
 
 test('errors on unhandled request when using the "error" value', async () => {
-  const makeRequest = () => fetch('https://test.mswjs.io')
+  const endpointUrl = httpServer.http.makeUrl('/')
+  const makeRequest = () => fetch(endpointUrl)
 
   await expect(() => makeRequest()).rejects.toThrow(
-    'request to https://test.mswjs.io/ failed, reason: Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.',
+    `request to ${endpointUrl} failed, reason: Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.`,
   )
   expect(console.error)
     .toHaveBeenCalledWith(`[MSW] Error: captured a request without a matching request handler:
 
-  • GET https://test.mswjs.io/
+  • GET ${endpointUrl}
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
 Read more: https://mswjs.io/docs/getting-started/mocks`)
@@ -56,7 +73,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
 
 test('does not error on request which handler explicitly returns no mocked response', async () => {
   const makeRequest = () => {
-    return fetch('https://test.mswjs.io/explicit-return', { method: 'POST' })
+    return fetch(httpServer.http.makeUrl('/explicit-return'), {
+      method: 'POST',
+    })
   }
   await makeRequest()
 
@@ -65,7 +84,9 @@ test('does not error on request which handler explicitly returns no mocked respo
 
 test('does not error on request which handler implicitly returns no mocked response', async () => {
   const makeRequest = () => {
-    return fetch('https://test.mswjs.io/implicit-return', { method: 'POST' })
+    return fetch(httpServer.http.makeUrl('/implicit-return'), {
+      method: 'POST',
+    })
   }
   await makeRequest()
 

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
@@ -40,8 +40,10 @@ afterAll(() => {
 
 test('errors on unhandled request when using the "error" value', async () => {
   const makeRequest = () => fetch('https://test.mswjs.io')
-  await makeRequest()
 
+  await expect(() => makeRequest()).rejects.toThrow(
+    'request to https://test.mswjs.io/ failed, reason: Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.',
+  )
   expect(console.error)
     .toHaveBeenCalledWith(`[MSW] Error: captured a request without a matching request handler:
 
@@ -53,16 +55,18 @@ Read more: https://mswjs.io/docs/getting-started/mocks`)
 })
 
 test('does not error on request which handler explicitly returns no mocked response', async () => {
-  const makeRequest = () =>
-    fetch('https://test.mswjs.io/explicit-return', { method: 'POST' })
+  const makeRequest = () => {
+    return fetch('https://test.mswjs.io/explicit-return', { method: 'POST' })
+  }
   await makeRequest()
 
   expect(console.error).not.toHaveBeenCalled()
 })
 
 test('does not error on request which handler implicitly returns no mocked response', async () => {
-  const makeRequest = () =>
-    fetch('https://test.mswjs.io/implicit-return', { method: 'POST' })
+  const makeRequest = () => {
+    return fetch('https://test.mswjs.io/implicit-return', { method: 'POST' })
+  }
   await makeRequest()
 
   expect(console.error).not.toHaveBeenCalled()


### PR DESCRIPTION
## GitHub

- Fixes #855 
- Related to #539 

## Changes

- When the "error" strategy of the `onUnhandledRequest` option is used, any request that has no matching request handler will _throw an exception_ to halt request processing and fail any code dependant on it:

```js
await fetch('https://api.com/unhandled')
// FethError: ...
```

- The developer-friendly `console.error` is preserved because the message is too verbose to be used as the `FetchError` reason. Instead, the fetch error reason is a compact summary of why the request failed (cannot be performed as-is).