### PR TITLE
Cleanup emitter listeners

### DIFF
--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -112,7 +112,6 @@ export function createSetupServer(...interceptors: Interceptor[]) {
           requestHandlers,
           ...nextHandlers,
         )
-        emitter.removeAllListeners()
       },
 
       printHandlers() {
@@ -129,9 +128,7 @@ ${bold(`${pragma} ${header}`)}
         })
       },
 
-      on(eventType, listener) {
-        emitter.addListener(eventType, listener)
-      },
+      events: emitter,
 
       close() {
         emitter.removeAllListeners()

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -112,6 +112,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
           requestHandlers,
           ...nextHandlers,
         )
+        emitter.removeAllListeners()
       },
 
       printHandlers() {

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -2,6 +2,7 @@ import { PartialDeep } from 'type-fest'
 import { IsomorphicResponse } from '@mswjs/interceptors'
 import { MockedRequest, RequestHandler } from '../handlers/RequestHandler'
 import { SharedOptions } from '../sharedOptions'
+import { StrictEventEmitter } from 'strict-event-emitter'
 
 export interface ServerLifecycleEventsMap {
   'request:start': (request: MockedRequest) => void
@@ -49,11 +50,5 @@ export interface SetupServerApi {
    */
   printHandlers(): void
 
-  /**
-   * Attaches a listener to one of the life-cycle events.
-   */
-  on<EventType extends keyof ServerLifecycleEventsMap>(
-    eventType: EventType,
-    listener: ServerLifecycleEventsMap[EventType],
-  ): void
+  events: StrictEventEmitter<ServerLifecycleEventsMap>
 }

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -230,11 +230,15 @@ export interface SetupWorkerApi {
    */
   printHandlers: () => void
 
-  /**
-   * Attaches a listener to one of the life-cycle events.
-   */
-  on<EventType extends keyof WorkerLifecycleEventsMap>(
-    eventType: EventType,
-    listener: WorkerLifecycleEventsMap[EventType],
-  ): void
+  events: StrictEventEmitter<WorkerLifecycleEventsMap>
+
+  // events: {
+  //   /**
+  //    * Attaches a listener to one of the life-cycle events.
+  //    */
+  //   on<EventType extends keyof WorkerLifecycleEventsMap>(
+  //     eventType: EventType,
+  //     listener: WorkerLifecycleEventsMap[EventType],
+  //   ): void
+  // }
 }

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -174,6 +174,7 @@ export function setupWorker(
         requestHandlers,
         ...nextHandlers,
       )
+      context.emitter.removeAllListeners()
     },
 
     printHandlers() {

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -174,7 +174,6 @@ export function setupWorker(
         requestHandlers,
         ...nextHandlers,
       )
-      context.emitter.removeAllListeners()
     },
 
     printHandlers() {
@@ -203,8 +202,6 @@ export function setupWorker(
       })
     },
 
-    on(eventType, listener) {
-      context.emitter.addListener(eventType, listener)
-    },
+    events: context.emitter,
   }
 }

--- a/test/msw-api/life-cycle-events/life-cycle-events.mocks.ts
+++ b/test/msw-api/life-cycle-events/life-cycle-events.mocks.ts
@@ -9,28 +9,28 @@ const worker = setupWorker(
   }),
 )
 
-worker.on('request:start', (req) => {
+worker.events.on('request:start', (req) => {
   console.warn(`[request:start] ${req.method} ${req.url.href} ${req.id}`)
 })
 
-worker.on('request:match', (req) => {
+worker.events.on('request:match', (req) => {
   console.warn(`[request:match] ${req.method} ${req.url.href} ${req.id}`)
 })
 
-worker.on('request:unhandled', (req) => {
+worker.events.on('request:unhandled', (req) => {
   console.warn(`[request:unhandled] ${req.method} ${req.url.href} ${req.id}`)
 })
 
-worker.on('request:end', (req) => {
+worker.events.on('request:end', (req) => {
   console.warn(`[request:end] ${req.method} ${req.url.href} ${req.id}`)
 })
 
-worker.on('response:mocked', async (res, reqId) => {
+worker.events.on('response:mocked', async (res, reqId) => {
   const body = await res.text()
   console.warn(`[response:mocked] ${body} ${reqId}`)
 })
 
-worker.on('response:bypass', (res, reqId) => {
+worker.events.on('response:bypass', (res, reqId) => {
   console.warn(`[response:bypass] ${reqId}`)
 })
 

--- a/test/msw-api/life-cycle-events/life-cycle-events.node.test.ts
+++ b/test/msw-api/life-cycle-events/life-cycle-events.node.test.ts
@@ -29,27 +29,27 @@ function getRequestId(requestStartListener: jest.Mock) {
 beforeAll(() => {
   server.listen()
 
-  server.on('request:start', (req) => {
+  server.events.on('request:start', (req) => {
     listener(`[request:start] ${req.method} ${req.url.href} ${req.id}`)
   })
 
-  server.on('request:match', (req) => {
+  server.events.on('request:match', (req) => {
     listener(`[request:match] ${req.method} ${req.url.href} ${req.id}`)
   })
 
-  server.on('request:unhandled', (req) => {
+  server.events.on('request:unhandled', (req) => {
     listener(`[request:unhandled] ${req.method} ${req.url.href} ${req.id}`)
   })
 
-  server.on('request:end', (req) => {
+  server.events.on('request:end', (req) => {
     listener(`[request:end] ${req.method} ${req.url.href} ${req.id}`)
   })
 
-  server.on('response:mocked', (res, reqId) => {
+  server.events.on('response:mocked', (res, reqId) => {
     listener(`[response:mocked] ${res.body} ${reqId}`)
   })
 
-  server.on('response:bypass', (res, reqId) => {
+  server.events.on('response:bypass', (res, reqId) => {
     listener(`[response:bypass] ${res.headers.get('server')} ${reqId}`)
   })
 

--- a/test/msw-api/life-cycle-events/regression/handle-stream.mocks.ts
+++ b/test/msw-api/life-cycle-events/regression/handle-stream.mocks.ts
@@ -2,7 +2,7 @@ import { setupWorker } from 'msw'
 
 const worker = setupWorker()
 
-worker.on('response:bypass', async (res) => {
+worker.events.on('response:bypass', async (res) => {
   const textResponse = await res.text()
   console.warn(`[response:bypass] ${textResponse}`)
 })


### PR DESCRIPTION
## GitHub
- Fixes #858 

## Changes

- Exposes the Life-cycle events under the `.events` property of the worker/server:
```diff
-server.on('request:start', cb)
+server.events.on('request:start', cb)
```

- Exposes the entire `EventEmitter` under `.events` so that developers could interact with it as a regular event emitter (incl. removing listeners).

```js
worker.events.removeAllListeners()
```