### PR TITLE
Bumps "@mswjs/interceptors" to 0.12.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "sideEffects": false,
   "dependencies": {
     "@mswjs/cookies": "^0.1.6",
-    "@mswjs/interceptors": "^0.12.5",
+    "@mswjs/interceptors": "^0.12.6",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.1",
     "@types/inquirer": "^7.3.3",

--- a/test/rest-api/logging.test.ts
+++ b/test/rest-api/logging.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 import { pageWith } from 'page-with'
 import { StatusCodeColor } from '../../src/utils/logging/getStatusCodeColor'
+import { waitFor } from '../support/waitFor'
 
 function createRuntime() {
   return pageWith({ example: path.resolve(__dirname, 'basic.mocks.ts') })
@@ -10,13 +11,15 @@ test('prints a captured request info into browser console', async () => {
   const runtime = await createRuntime()
   await runtime.request('https://api.github.com/users/octocat')
 
-  expect(runtime.consoleSpy.get('raw').get('startGroupCollapsed')).toEqual(
-    expect.arrayContaining([
-      expect.stringMatching(
-        new RegExp(
-          `^\\[MSW\\] %s %s %s \\(%c%s%c\\) \\d{2}:\\d{2}:\\d{2} GET https://api.github.com/users/octocat color:${StatusCodeColor.Success} 200 OK color:inherit$`,
+  await waitFor(() => {
+    expect(runtime.consoleSpy.get('raw').get('startGroupCollapsed')).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          new RegExp(
+            `^\\[MSW\\] %s %s %s \\(%c%s%c\\) \\d{2}:\\d{2}:\\d{2} GET https://api.github.com/users/octocat color:${StatusCodeColor.Success} 200 OK color:inherit$`,
+          ),
         ),
-      ),
-    ]),
-  )
+      ]),
+    )
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,17 +1411,17 @@
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"
 
-"@mswjs/interceptors@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.5.tgz#9d01ed8946aacc68723efdf7fd8926711b72b199"
-  integrity sha512-wlLHZgrFPxU5P0HQuUGyl0mQdwo/IFKEe4Pocg4xEj53m9gghsem8YdVzwJYMqxbQv1eMrEHgilvTdc36Vpr/Q==
+"@mswjs/interceptors@^0.12.6":
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.6.tgz#0afb7c91e14875a1127ae5181d0eae31d50a9276"
+  integrity sha512-+1jaUpKEWXP4Yed4Lj9RftroZStw0NsEvEFjwJgc941xcaiTDYyBON4kpBY32RWd7UsW/xGE1piy8qt0Gfiqyw==
   dependencies:
     "@open-draft/until" "^1.0.3"
-    debug "^4.3.0"
+    "@xmldom/xmldom" "^0.7.2"
+    debug "^4.3.2"
     headers-utils "^3.0.2"
     outvariant "^1.2.0"
     strict-event-emitter "^0.2.0"
-    xmldom "^0.6.0"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -2205,6 +2205,11 @@
   dependencies:
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
+
+"@xmldom/xmldom@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.2.tgz#d920079e66806b2626b5311955f6a7c4bed1cba8"
+  integrity sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -3428,7 +3433,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.0, debug@^4.3.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -3441,6 +3446,13 @@ debug@^3.1.1, debug@^3.2.6:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -8440,11 +8452,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xmldom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
-  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
 
 y18n@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
- https://github.com/mswjs/interceptors/releases/tag/v0.12.6
- #861 