### PR TITLE
Uses "path-to-regexp" instead of "node-match-path"

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "is-node-process": "^1.0.1",
     "js-levenshtein": "^1.1.6",
     "node-fetch": "^2.6.1",
-    "node-match-path": "^0.6.3",
+    "path-to-regexp": "^6.2.0",
     "statuses": "^2.0.0",
     "strict-event-emitter": "^0.2.0",
     "type-fest": "^1.2.2",

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,5 +1,4 @@
 import { DocumentNode } from 'graphql'
-import { Path } from 'node-match-path'
 import { ResponseResolver } from './handlers/RequestHandler'
 import {
   GraphQLHandler,
@@ -9,6 +8,7 @@ import {
   ExpectedOperationTypeNode,
   GraphQLHandlerNameSelector,
 } from './handlers/GraphQLHandler'
+import { Path } from './utils/matching/matchRequestUrl'
 
 export interface TypedDocumentNode<
   Result = { [key: string]: any },

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -1,5 +1,4 @@
 import { DocumentNode, OperationTypeNode } from 'graphql'
-import { Path } from 'node-match-path'
 import { SerializedResponse } from '../setupWorker/glossary'
 import { set } from '../context/set'
 import { status } from '../context/status'
@@ -17,7 +16,7 @@ import { getTimestamp } from '../utils/logging/getTimestamp'
 import { getStatusCodeColor } from '../utils/logging/getStatusCodeColor'
 import { prepareRequest } from '../utils/logging/prepareRequest'
 import { prepareResponse } from '../utils/logging/prepareResponse'
-import { matchRequestUrl } from '../utils/matching/matchRequestUrl'
+import { matchRequestUrl, Path } from '../utils/matching/matchRequestUrl'
 import {
   ParsedGraphQLRequest,
   GraphQLMultipartRequestBody,

--- a/src/handlers/RestHandler.test.ts
+++ b/src/handlers/RestHandler.test.ts
@@ -73,7 +73,7 @@ describe('parse', () => {
 
     expect(handler.parse(request)).toEqual({
       matches: false,
-      params: null,
+      params: {},
     })
   })
 })

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -1,4 +1,3 @@
-import { Match, Path } from 'node-match-path'
 import {
   body,
   cookie,
@@ -18,7 +17,12 @@ import { getStatusCodeColor } from '../utils/logging/getStatusCodeColor'
 import { getTimestamp } from '../utils/logging/getTimestamp'
 import { prepareRequest } from '../utils/logging/prepareRequest'
 import { prepareResponse } from '../utils/logging/prepareResponse'
-import { matchRequestUrl } from '../utils/matching/matchRequestUrl'
+import {
+  Match,
+  matchRequestUrl,
+  Path,
+  PathParams,
+} from '../utils/matching/matchRequestUrl'
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
 import { cleanUrl, getSearchParams } from '../utils/url/cleanUrl'
 import {
@@ -79,7 +83,7 @@ export type RequestQuery = {
 
 export interface RestRequest<
   BodyType extends DefaultRequestBody = DefaultRequestBody,
-  ParamsType extends RequestParams = Record<string, any>,
+  ParamsType extends RequestParams = PathParams,
 > extends MockedRequest<BodyType> {
   params: ParamsType
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,12 @@ export {
 } from './handlers/GraphQLHandler'
 
 /* Utils */
-export { matchRequestUrl } from './utils/matching/matchRequestUrl'
+export {
+  Path,
+  PathParams,
+  Match,
+  matchRequestUrl,
+} from './utils/matching/matchRequestUrl'
 export { compose } from './utils/internal/compose'
 export { DelayMode } from './context/delay'
 export { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,4 +1,3 @@
-import { Path } from 'node-match-path'
 import { DefaultRequestBody, ResponseResolver } from './handlers/RequestHandler'
 import {
   RESTMethods,
@@ -7,6 +6,7 @@ import {
   RestRequest,
   RequestParams,
 } from './handlers/RestHandler'
+import { Path } from './utils/matching/matchRequestUrl'
 
 function createRestHandler(method: RESTMethods) {
   return <

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -1,4 +1,3 @@
-import { Path } from 'node-match-path'
 import { PartialDeep } from 'type-fest'
 import { FlatHeadersObject } from 'headers-utils'
 import { StrictEventEmitter } from 'strict-event-emitter'
@@ -10,6 +9,7 @@ import {
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
 import { RequestHandler } from '../handlers/RequestHandler'
 import { InterceptorApi } from '@mswjs/interceptors'
+import { Path } from '../utils/matching/matchRequestUrl'
 
 export type ResolvedPath = Path | URL
 
@@ -114,10 +114,10 @@ export interface SetupWorkerInternalContext {
      * Adds an event listener on the given target.
      * Returns a clean-up function that removes that listener.
      */
-    addListener<E extends Event>(
+    addListener<EventType extends Event = Event>(
       target: EventTarget,
       eventType: string,
-      listener: (event: E) => void,
+      listener: (event: EventType) => void,
     ): () => void
     /**
      * Removes all currently attached listeners.

--- a/src/utils/handleRequest.test.ts
+++ b/src/utils/handleRequest.test.ts
@@ -146,7 +146,7 @@ test('returns the mocked response for a request with a matching request handler'
     handler: handlers[0],
     response: mockedResponse,
     publicRequest: { ...request, params: {} },
-    parsedRequest: { matches: true, params: null },
+    parsedRequest: { matches: true, params: {} },
   }
 
   const result = await handleRequest(
@@ -194,7 +194,7 @@ test('returns a transformed response if the "transformResponse" option is provid
     handler: handlers[0],
     response: mockedResponse,
     publicRequest: { ...request, params: {} },
-    parsedRequest: { matches: true, params: null },
+    parsedRequest: { matches: true, params: {} },
   }
 
   const result = await handleRequest(request, handlers, options, emitter, {

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -1,15 +1,52 @@
-import { Path, match } from 'node-match-path'
+import { match } from 'path-to-regexp'
 import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
 import { normalizePath } from './normalizePath'
+
+export type Path = string | RegExp
+
+export type PathParams = Record<string, string | string[]>
+export interface Match {
+  matches: boolean
+  params?: PathParams
+}
+
+/**
+ * Coerce a path supported by MSW into a path
+ * supported by "path-to-regexp".
+ */
+export function coercePath(path: string): string {
+  return (
+    path
+      /**
+       * Escape the protocol so that "path-to-regexp" could match
+       * absolute URL.
+       * @see https://github.com/pillarjs/path-to-regexp/issues/259
+       */
+      .replace(/^([^\/]+)(:)(?=\/\/)/g, '$1\\$2')
+      /**
+       * Replace wildcards ("*") with unnamed capturing groups
+       * because "path-to-regexp" doesn't support wildcards.
+       * Ignore path parameter' modifiers (i.e. ":name*").
+       */
+      .replace(/(?<!(^|\/|\*+):[\w]+)(\*{1,2})/g, '(.*)')
+  )
+}
 
 /**
  * Returns the result of matching given request URL against a mask.
  */
-export function matchRequestUrl(
-  url: URL,
-  path: Path,
-  baseUrl?: string,
-): ReturnType<typeof match> {
+export function matchRequestUrl(url: URL, path: Path, baseUrl?: string): Match {
   const normalizedPath = normalizePath(path, baseUrl)
-  return match(normalizedPath, getCleanUrl(url))
+  const cleanPath =
+    typeof normalizedPath === 'string'
+      ? coercePath(normalizedPath)
+      : normalizedPath
+  const cleanUrl = getCleanUrl(url)
+  const result = match(cleanPath)(cleanUrl)
+  const params = (result && (result.params as PathParams)) || {}
+
+  return {
+    matches: result !== false,
+    params,
+  }
 }

--- a/src/utils/matching/normalizePath.ts
+++ b/src/utils/matching/normalizePath.ts
@@ -1,4 +1,4 @@
-import { Path } from 'node-match-path'
+import type { Path } from './matchRequestUrl'
 import { cleanUrl } from '../url/cleanUrl'
 import { getAbsoluteUrl } from '../url/getAbsoluteUrl'
 

--- a/test/msw-api/setup-server/scenarios/fall-through.node.test.ts
+++ b/test/msw-api/setup-server/scenarios/fall-through.node.test.ts
@@ -20,6 +20,7 @@ const server = setupServer(
 )
 
 beforeAll(() => {
+  // Supress the "Expeted mocking resolver function to return a mocked response" warnings.
   jest.spyOn(global.console, 'warn').mockImplementation()
   server.listen()
 })
@@ -36,20 +37,18 @@ test('falls through all relevant request handlers until response is returned', a
   expect(body).toEqual({
     firstName: 'John',
   })
-
   expect(log).toBeCalledWith('[get] first')
   expect(log).toBeCalledWith('[get] second')
   expect(log).not.toBeCalledWith('[get] third')
 })
 
-test('falls through all relevant handler even if none returns response', async () => {
+test('falls through all relevant handlers even if none return response', async () => {
   const res = await fetch('https://test.mswjs.io/blog/article', {
     method: 'POST',
   })
   const { status } = res
 
   expect(status).toBe(404)
-
   expect(log).toBeCalledWith('[post] first')
   expect(log).toBeCalledWith('[post] second')
 })

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
-import { match } from 'node-match-path'
 import { pageWith } from 'page-with'
+import { matchRequestUrl } from 'msw'
 
 function createRuntime() {
   return pageWith({
@@ -18,9 +18,7 @@ function createRuntime() {
       })
 
       app.post('/headers-proxy', (req, res) => {
-        const { authorization } = req.headers
-
-        if (!authorization) {
+        if (!req.headers.authorization) {
           return res.status(403).json({ message: 'error' }).end()
         }
 
@@ -73,7 +71,8 @@ test('bypasses the original request when it equals the mocked request', async ()
       return (
         // Await the response from MSW so that the original response
         // from the same URL would not interfere.
-        match(url, res.url()).matches && res.headers()['x-powered-by'] === 'msw'
+        matchRequestUrl(new URL(url), res.url()).matches &&
+        res.headers()['x-powered-by'] === 'msw'
       )
     },
   )
@@ -121,7 +120,7 @@ test('supports patching a HEAD request', async () => {
     },
     (res, url) => {
       return (
-        match(runtime.makeUrl(url), res.url()).matches &&
+        matchRequestUrl(new URL(runtime.makeUrl(url)), res.url()).matches &&
         res.headers()['x-powered-by'] === 'msw'
       )
     },
@@ -150,7 +149,7 @@ test('supports patching a GET request', async () => {
     },
     (res, url) => {
       return (
-        match(runtime.makeUrl(url), res.url()).matches &&
+        matchRequestUrl(new URL(runtime.makeUrl(url)), res.url()).matches &&
         res.headers()['x-powered-by'] === 'msw'
       )
     },
@@ -182,7 +181,7 @@ test('supports patching a POST request', async () => {
     },
     (res, url) => {
       return (
-        match(runtime.makeUrl(url), res.url()).matches &&
+        matchRequestUrl(new URL(runtime.makeUrl(url)), res.url()).matches &&
         res.headers()['x-powered-by'] === 'msw'
       )
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6116,11 +6116,6 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-match-path@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.6.3.tgz#55dd8443d547f066937a0752dce462ea7dc27551"
-  integrity sha512-fB1reOHKLRZCJMAka28hIxCwQLxGmd7WewOCBDYKpyA1KXi68A7vaGgdZAPhY2E6SXoYt3KqYCCvXLJ+O0Fu/Q==
-
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
@@ -6496,6 +6491,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
 
 path-type@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## GitHub

- Closes #691

## Breaking changes

- `req.params` now equals to `{}` (empty object) if there are no parameters.
- `req.params` values can now be `string[]` in the case of multiple path parameters:
```js
rest.get('/user/:segments+', (req) => {
  // Given "GET /user/foo/bar"
  req.params.segments // ["foo", "bar"]
})
```
- wildcard (`*`) segments now produce an unnamed parameter available as `req.params[i]`, where `i` is the index of the wildcard.