### PR TITLE
rest: Adds new ".all()" API

### DIFF
--- a/src/handlers/RestHandler.test.ts
+++ b/src/handlers/RestHandler.test.ts
@@ -89,6 +89,25 @@ describe('predicate', () => {
     expect(handler.predicate(request, handler.parse(request))).toBe(true)
   })
 
+  test('respects RegExp as the request method', () => {
+    const handler = new RestHandler(/.+/, '/login', resolver)
+    const requests = [
+      createMockedRequest({ url: new URL('/login', location.href) }),
+      createMockedRequest({
+        method: 'POST',
+        url: new URL('/login', location.href),
+      }),
+      createMockedRequest({
+        method: 'DELETE',
+        url: new URL('/login', location.href),
+      }),
+    ]
+
+    for (const request of requests) {
+      expect(handler.predicate(request, handler.parse(request))).toBe(true)
+    }
+  })
+
   test('returns false given a non-matching request', () => {
     const handler = new RestHandler('POST', '/login', resolver)
     const request = createMockedRequest({

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -32,8 +32,10 @@ import {
   ResponseResolver,
 } from './RequestHandler'
 
+type RestHandlerMethod = string | RegExp
+
 interface RestHandlerInfo {
-  method: string
+  method: RestHandlerMethod
   path: Path
 }
 
@@ -103,7 +105,7 @@ export class RestHandler<
   RestRequest<RequestParams>
 > {
   constructor(
-    method: string,
+    method: RestHandlerMethod,
     path: Path,
     resolver: ResponseResolver<any, any>,
   ) {
@@ -141,19 +143,9 @@ export class RestHandler<
       queryParams.push(paramName)
     })
 
-    devUtils.warn(`\
-Found a redundant usage of query parameters in the request handler URL for "${method} ${path}". Please match against a path instead, and access query parameters in the response resolver function:
-
-rest.${method.toLowerCase()}("${url}", (req, res, ctx) => {
-  const query = req.url.searchParams
-${queryParams
-  .map(
-    (paramName) => `\
-  const ${paramName} = query.get("${paramName}")`,
-  )
-  .join('\n')}
-})\
-      `)
+    devUtils.warn(
+      `Found a redundant usage of query parameters in the request handler URL for "${method} ${path}". Please match against a path instead and access query parameters in the response resolver function using "req.url.searchParams".`,
+    )
   }
 
   parse(request: RequestType, resolutionContext?: ResponseResolutionContext) {
@@ -175,9 +167,14 @@ ${queryParams
   }
 
   predicate(request: RequestType, parsedResult: ParsedRestRequest) {
-    return (
-      isStringEqual(this.info.method, request.method) && parsedResult.matches
-    )
+    const matchesMethod =
+      this.info.method instanceof RegExp
+        ? this.info.method.test(request.method)
+        : isStringEqual(this.info.method, request.method)
+
+    // console.log({ request, matchesMethod, parsedResult })
+
+    return matchesMethod && parsedResult.matches
   }
 
   log(request: RequestType, response: SerializedResponse) {

--- a/src/rest.spec.ts
+++ b/src/rest.spec.ts
@@ -3,6 +3,7 @@ import { rest } from './rest'
 test('exports all REST API methods', () => {
   expect(rest).toBeDefined()
   expect(Object.keys(rest)).toEqual([
+    'all',
     'head',
     'get',
     'post',

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -8,7 +8,7 @@ import {
 } from './handlers/RestHandler'
 import { Path } from './utils/matching/matchRequestUrl'
 
-function createRestHandler(method: RESTMethods) {
+function createRestHandler(method: RESTMethods | RegExp) {
   return <
     RequestBodyType extends DefaultRequestBody = DefaultRequestBody,
     ResponseBody extends DefaultRequestBody = any,
@@ -26,6 +26,7 @@ function createRestHandler(method: RESTMethods) {
 }
 
 export const rest = {
+  all: createRestHandler(/.+/),
   head: createRestHandler(RESTMethods.HEAD),
   get: createRestHandler(RESTMethods.GET),
   post: createRestHandler(RESTMethods.POST),

--- a/test/rest-api/query-params-warning.test.ts
+++ b/test/rest-api/query-params-warning.test.ts
@@ -7,23 +7,8 @@ test('warns when a request handler URL contains query parameters', async () => {
   })
 
   expect(consoleSpy.get('warning')).toEqual([
-    `\
-[MSW] Found a redundant usage of query parameters in the request handler URL for "GET /user?name=admin". Please match against a path instead, and access query parameters in the response resolver function:
-
-rest.get("/user", (req, res, ctx) => {
-  const query = req.url.searchParams
-  const name = query.get("name")
-})\
-`,
-    `\
-[MSW] Found a redundant usage of query parameters in the request handler URL for "POST /login?id=123&type=auth". Please match against a path instead, and access query parameters in the response resolver function:
-
-rest.post("/login", (req, res, ctx) => {
-  const query = req.url.searchParams
-  const id = query.get("id")
-  const type = query.get("type")
-})\
-`,
+    `[MSW] Found a redundant usage of query parameters in the request handler URL for "GET /user?name=admin". Please match against a path instead and access query parameters in the response resolver function using "req.url.searchParams".`,
+    `[MSW] Found a redundant usage of query parameters in the request handler URL for "POST /login?id=123&type=auth". Please match against a path instead and access query parameters in the response resolver function using "req.url.searchParams".`,
   ])
 
   await request('/user?name=admin').then(async (res) => {

--- a/test/rest-api/request/matching/all.mocks.ts
+++ b/test/rest-api/request/matching/all.mocks.ts
@@ -1,0 +1,12 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.all('*/api/*', (req, res, ctx) => {
+    return res(ctx.text('hello world'))
+  }),
+  rest.all('*', (req, res, ctx) => {
+    return res(ctx.text('welcome to the jungle'))
+  }),
+)
+
+worker.start()

--- a/test/rest-api/request/matching/all.node.test.ts
+++ b/test/rest-api/request/matching/all.node.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+import fetch, { Response } from 'node-fetch'
+import { createServer, ServerApi } from '@open-draft/test-server'
+import { RESTMethods, rest } from 'msw'
+import { setupServer } from 'msw/node'
+
+let httpServer: ServerApi
+
+const server = setupServer()
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    // Responding with "204 No Content" because the "OPTIONS"
+    // request returns 204 without an obvious way to override that.
+    app.all('*', (req, res) => res.status(204).end())
+  })
+  server.listen({
+    onUnhandledRequest: 'bypass',
+  })
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(async () => {
+  server.close()
+  await httpServer.close()
+})
+
+async function forEachMethod(callback: (method: RESTMethods) => unknown) {
+  for (const method of Object.values(RESTMethods)) {
+    await callback(method)
+  }
+}
+
+test('matches all requests given no custom path', async () => {
+  server.use(
+    rest.all('*', (req, res, ctx) => {
+      return res(ctx.text('welcome to the jungle'))
+    }),
+  )
+
+  const responses = await Promise.all(
+    Object.values(RESTMethods).reduce<Promise<Response>[]>((all, method) => {
+      return all.concat(
+        [
+          httpServer.http.makeUrl('/'),
+          httpServer.http.makeUrl('/foo'),
+          'https://example.com',
+        ].map((url) => fetch(url, { method })),
+      )
+    }, []),
+  )
+
+  for (const response of responses) {
+    expect(response.status).toEqual(200)
+    expect(await response.text()).toEqual('welcome to the jungle')
+  }
+})
+
+test('respects custom path when matching requests', async () => {
+  server.use(
+    rest.all(httpServer.http.makeUrl('/api/*'), (req, res, ctx) => {
+      return res(ctx.text('hello world'))
+    }),
+  )
+
+  // Root requests.
+  await forEachMethod(async (method) => {
+    const response = await fetch(httpServer.http.makeUrl('/api/'), { method })
+    expect(response.status).toEqual(200)
+    expect(await response.text()).toEqual('hello world')
+  })
+
+  // Nested requests.
+  await forEachMethod(async (method) => {
+    const response = await fetch(httpServer.http.makeUrl('/api/foo'), {
+      method,
+    })
+    expect(response.status).toEqual(200)
+    expect(await response.text()).toEqual('hello world')
+  })
+
+  // Mismatched requests.
+  await forEachMethod(async (method) => {
+    const response = await fetch(httpServer.http.makeUrl('/foo'), { method })
+    expect(response.status).toEqual(204)
+  })
+})

--- a/test/rest-api/request/matching/all.test.ts
+++ b/test/rest-api/request/matching/all.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment node
+ */
+import * as path from 'path'
+import { ScenarioApi, pageWith } from 'page-with'
+import { Response } from 'playwright'
+
+function createRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'all.mocks.ts'),
+  })
+}
+
+function requestAllMethods(
+  runtime: ScenarioApi,
+  url: string,
+): Promise<Response[]> {
+  return Promise.all(
+    ['HEAD', 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'].map((method) =>
+      runtime.request(url, { method }),
+    ),
+  )
+}
+
+test('respects custom path when matching requests', async () => {
+  const runtime = await createRuntime()
+
+  // Root request.
+  const rootResponses = await requestAllMethods(
+    runtime,
+    'http://localhost/api/',
+  )
+
+  for (const response of rootResponses) {
+    expect(response.status()).toEqual(200)
+    expect(await response.text()).toEqual('hello world')
+  }
+
+  // Nested request.
+  const nestedResponses = await requestAllMethods(
+    runtime,
+    'http://localhost/api/user',
+  )
+  for (const response of nestedResponses) {
+    expect(response.status()).toEqual(200)
+    expect(await response.text()).toEqual('hello world')
+  }
+
+  // Mismatched request.
+  // There's a fallback "rest.all()" in this test that acts
+  // as a fallback request handler for all otherwise mismatched requests.
+  const mismatchedResponses = await requestAllMethods(
+    runtime,
+    'http://localhost/foo',
+  )
+  for (const response of mismatchedResponses) {
+    expect(response.status()).toEqual(200)
+    expect(await response.text()).toEqual('welcome to the jungle')
+  }
+})


### PR DESCRIPTION
## GitHub

- Closes #893 

## Changes

- `RestHandler` now supports `RegExp` as the expected requests method.
- Adds a new `rest.all()` request handler that matches all requests to a given path regardless of their method. Useful when implementing mocking proxies. 