### PR TITLE
Handle properly unnamed graphql queries when a graphql operation handler exists

### DIFF
--- a/src/handlers/GraphQLHandler.test.ts
+++ b/src/handlers/GraphQLHandler.test.ts
@@ -67,14 +67,6 @@ const LOGIN = `
     }
   }
 `
-const UNNAMED_QUERY = `
-  query {
-    unnamedQuery {
-      query
-      variables
-    }
-  }
-`
 
 describe('info', () => {
   test('exposes request handler information for query', () => {
@@ -306,10 +298,17 @@ describe('predicate', () => {
     )
   })
 
-  test('respects graphql.operation endpoint', () => {
+  test('allows anonymous GraphQL opertaions when using "all" expected operation type', () => {
     const handler = new GraphQLHandler('all', new RegExp('.*'), '*', resolver)
     const request = createPostGraphQLRequest({
-      query: UNNAMED_QUERY,
+      query: `
+        query {
+          anonymousQuery {
+            query
+            variables
+          }
+        }
+      `,
     })
 
     expect(handler.predicate(request, handler.parse(request))).toBe(true)

--- a/src/handlers/GraphQLHandler.test.ts
+++ b/src/handlers/GraphQLHandler.test.ts
@@ -67,6 +67,14 @@ const LOGIN = `
     }
   }
 `
+const UNNAMED_QUERY = `
+  query {
+    unnamedQuery {
+      query
+      variables
+    }
+  }
+`
 
 describe('info', () => {
   test('exposes request handler information for query', () => {
@@ -296,6 +304,15 @@ describe('predicate', () => {
     expect(handler.predicate(alienRequest, handler.parse(alienRequest))).toBe(
       false,
     )
+  })
+
+  test('respects graphql.operation endpoint', () => {
+    const handler = new GraphQLHandler('all', new RegExp('.*'), '*', resolver)
+    const request = createPostGraphQLRequest({
+      query: UNNAMED_QUERY,
+    })
+
+    expect(handler.predicate(request, handler.parse(request))).toBe(true)
   })
 
   test('respects custom endpoint', () => {

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -165,7 +165,7 @@ export class GraphQLHandler<
     if (!parsedResult.operationName && this.info.operationType !== 'all') {
       const publicUrl = getPublicUrlFromRequest(request)
       devUtils.warn(`\
-Failed to intercept a GraphQL request at "${request.method} ${publicUrl}": unnamed GraphQL operations are not supported.
+Failed to intercept a GraphQL request at "${request.method} ${publicUrl}": anonymous GraphQL operations are not supported.
 
 Consider naming this operation or using "graphql.operation" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation\
       `)
@@ -200,7 +200,7 @@ Consider naming this operation or using "graphql.operation" request handler to i
     const statusColor = getStatusCodeColor(response.status)
     const requestInfo = parsedRequest?.operationName
       ? `${parsedRequest?.operationType} ${parsedRequest?.operationName}`
-      : `unnamed ${parsedRequest?.operationType}`
+      : `anonymous ${parsedRequest?.operationType}`
 
     console.groupCollapsed(
       devUtils.formatMessage('%s %s (%c%s%c)'),

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -162,7 +162,7 @@ export class GraphQLHandler<
       return false
     }
 
-    if (!parsedResult.operationName) {
+    if (!parsedResult.operationName && this.info.operationType !== 'all') {
       const publicUrl = getPublicUrlFromRequest(request)
       devUtils.warn(`\
 Failed to intercept a GraphQL request at "${request.method} ${publicUrl}": unnamed GraphQL operations are not supported.
@@ -176,9 +176,10 @@ Consider naming this operation or using "graphql.operation" request handler to i
     const hasMatchingOperationType =
       this.info.operationType === 'all' ||
       parsedResult.operationType === this.info.operationType
+
     const hasMatchingOperationName =
       this.info.operationName instanceof RegExp
-        ? this.info.operationName.test(parsedResult.operationName)
+        ? this.info.operationName.test(parsedResult.operationName || '')
         : parsedResult.operationName === this.info.operationName
 
     return (
@@ -197,11 +198,14 @@ Consider naming this operation or using "graphql.operation" request handler to i
     const loggedRequest = prepareRequest(request)
     const loggedResponse = prepareResponse(response)
     const statusColor = getStatusCodeColor(response.status)
+    const requestInfo = parsedRequest?.operationName
+      ? `${parsedRequest?.operationType} ${parsedRequest?.operationName}`
+      : `unnamed ${parsedRequest?.operationType}`
 
     console.groupCollapsed(
       devUtils.formatMessage('%s %s (%c%s%c)'),
       getTimestamp(),
-      `${parsedRequest?.operationType} ${parsedRequest?.operationName}`,
+      `${requestInfo}`,
       `color:${statusColor}`,
       `${response.status} ${response.statusText}`,
       'color:inherit',

--- a/test/graphql-api/mutation.test.ts
+++ b/test/graphql-api/mutation.test.ts
@@ -37,7 +37,7 @@ test('sends a mocked response to a GraphQL mutation', async () => {
   })
 })
 
-test('prints a warning when captured an unnamed GraphQL mutation', async () => {
+test('prints a warning when captured an anonymous GraphQL mutation', async () => {
   const runtime = await createRuntime()
 
   const res = await executeGraphQLQuery(runtime.page, {
@@ -54,7 +54,7 @@ test('prints a warning when captured an unnamed GraphQL mutation', async () => {
     expect.arrayContaining([
       expect.stringContaining(
         `\
-[MSW] Failed to intercept a GraphQL request at "POST ${GRAPHQL_TEST_URL}": unnamed GraphQL operations are not supported.
+[MSW] Failed to intercept a GraphQL request at "POST ${GRAPHQL_TEST_URL}": anonymous GraphQL operations are not supported.
 
 Consider naming this operation or using "graphql.operation" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation\
 `,

--- a/test/graphql-api/operation.test.ts
+++ b/test/graphql-api/operation.test.ts
@@ -51,11 +51,11 @@ test('intercepts and mocks a GraphQL query', async () => {
   )
 })
 
-test('intercepts and mocks an unnamed GraphQL query', async () => {
+test('intercepts and mocks an anonymous GraphQL query', async () => {
   const runtime = await createRuntime()
-  const UNNAMED_QUERY = gql`
+  const ANONYMOUS_QUERY = gql`
     query {
-      unnamedQuery {
+      anonymousQuery {
         query
         variables
       }
@@ -63,7 +63,7 @@ test('intercepts and mocks an unnamed GraphQL query', async () => {
   `
 
   const res = await executeGraphQLQuery(runtime.page, {
-    query: UNNAMED_QUERY,
+    query: ANONYMOUS_QUERY,
     variables: {
       id: 'abc-123',
     },
@@ -79,7 +79,7 @@ test('intercepts and mocks an unnamed GraphQL query', async () => {
   const body = await res.json()
   expect(body).toEqual({
     data: {
-      query: UNNAMED_QUERY,
+      query: ANONYMOUS_QUERY,
       variables: {
         id: 'abc-123',
       },
@@ -88,7 +88,7 @@ test('intercepts and mocks an unnamed GraphQL query', async () => {
 
   expect(runtime.consoleSpy.get('startGroupCollapsed')).toEqual(
     expect.arrayContaining([
-      expect.stringMatching(/\[MSW\] \d{2}:\d{2}:\d{2} unnamed query 200 OK/),
+      expect.stringMatching(/\[MSW\] \d{2}:\d{2}:\d{2} anonymous query 200 OK/),
     ]),
   )
 })

--- a/test/graphql-api/query.test.ts
+++ b/test/graphql-api/query.test.ts
@@ -74,7 +74,7 @@ test('mocks a GraphQL query issued with a POST request', async () => {
   })
 })
 
-test('prints a warning when captured an unnamed GraphQL query', async () => {
+test('prints a warning when captured an anonymous GraphQL query', async () => {
   const runtime = await createRuntime()
 
   const res = await executeGraphQLQuery(runtime.page, {
@@ -91,7 +91,7 @@ test('prints a warning when captured an unnamed GraphQL query', async () => {
     expect.arrayContaining([
       expect.stringContaining(
         `\
-[MSW] Failed to intercept a GraphQL request at "POST ${GRAPHQL_TEST_URL}": unnamed GraphQL operations are not supported.
+[MSW] Failed to intercept a GraphQL request at "POST ${GRAPHQL_TEST_URL}": anonymous GraphQL operations are not supported.
 
 Consider naming this operation or using "graphql.operation" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation\
 `,


### PR DESCRIPTION
- Fixes #918 

When registering a graphQL operation handler (https://mswjs.io/docs/api/graphql/operation), then send an unnamed graphQL query, we get this warning : 

```
Failed to intercept a GraphQL request at "${request.method} ${publicUrl}": unnamed GraphQL operations are not supported.
      
Consider naming this operation or using "graphql.operation" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation
```

This behavior looks wrong.

This MR allows to send unnamed graphql queries when an "operation" handler exists