### PR TITLE
fix(handleRequest): include handler header in the no-response warning

### DIFF
--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -120,7 +120,7 @@ export abstract class RequestHandler<
     this.ctx = options.ctx || defaultContext
     this.resolver = options.resolver
 
-    const callFrame = getCallFrame()
+    const callFrame = getCallFrame(new Error())
 
     this.info = {
       ...options.info,

--- a/src/utils/handleRequest.test.ts
+++ b/src/utils/handleRequest.test.ts
@@ -126,10 +126,14 @@ test('returns undefined and warns on a request handler that returns no response'
   expect(callbacks.onMockedResponse).not.toHaveBeenCalled()
   expect(callbacks.onMockedResponseSent).not.toHaveBeenCalled()
 
-  expect(console.warn).toHaveBeenNthCalledWith(
-    1,
-    '[MSW] Expected a mocking resolver function to return a mocked response Object, but got: undefined. Original response is going to be used instead.',
+  expect(console.warn).toHaveBeenCalledTimes(1)
+  const warning = (console.warn as unknown as jest.SpyInstance).mock.calls[0][0]
+
+  expect(warning).toContain(
+    '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
   )
+  expect(warning).toContain('GET /user')
+  expect(warning).toMatch(/\d+:\d+/)
 })
 
 test('returns the mocked response for a request with a matching request handler', async () => {

--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -86,8 +86,15 @@ export async function handleRequest<
   // as it may be an oversight on their part. Perform the request as-is.
   if (!response) {
     devUtils.warn(
-      'Expected a mocking resolver function to return a mocked response Object, but got: %s. Original response is going to be used instead.',
+      `\
+Expected response resolver to return a mocked response Object, but got %s. The original response is going to be used instead.\
+\n
+  \u2022 %s
+    %s\
+`,
       response,
+      handler.info.header,
+      handler.info.callFrame,
     )
 
     emitter.emit('request:end', request)

--- a/src/utils/internal/getCallFrame.test.ts
+++ b/src/utils/internal/getCallFrame.test.ts
@@ -3,179 +3,152 @@
  */
 import { getCallFrame } from './getCallFrame'
 
-const mockStack = jest.fn()
+class ErrorWithStack extends Error {
+  constructor(stack: string[] | undefined | null) {
+    super('')
+    this.stack = stack?.join('\n')
+  }
+}
 
-beforeAll(() => {
-  jest.spyOn(window, 'Error').mockImplementation(() => ({
-    name: 'mockError',
-    message: '',
-    stack: mockStack(),
-  }))
-})
-
-afterAll(() => {
-  jest.restoreAllMocks()
-})
-
-test('Node on Linux and macOS error stack', () => {
-  // version 1
-  mockStack.mockImplementationOnce(() =>
-    [
-      'Error: ',
-      '    at getCallFrame (/Users/mock/github/msw/lib/umd/index.js:3735:22)',
-      '    at Object.get (/Users/mock/github/msw/lib/umd/index.js:3776:29)',
-      '    at Object.<anonymous> (/Users/mock/github/msw/test/msw-api/setup-server/printHandlers.test.ts:13:8)', // <-- this one
-      '    at Runtime._execModule (/Users/mock/github/msw/node_modules/jest-runtime/build/index.js:1299:24)',
-      '    at Runtime._loadModule (/Users/mock/github/msw/node_modules/jest-runtime/build/index.js:898:12)',
-      '    at Runtime.requireModule (/Users/mock/github/msw/node_modules/jest-runtime/build/index.js:746:10)',
-      '    at jasmine2 (/Users/mock/github/msw/node_modules/jest-jasmine2/build/index.js:230:13)',
-      '    at runTestInternal (/Users/mock/github/msw/node_modules/jest-runner/build/runTest.js:380:22)',
-      '    at runTest (/Users/mock/github/msw/node_modules/jest-runner/build/runTest.js:472:34)',
-    ].join('\n'),
-  )
-
-  expect(getCallFrame()).toBe(
+test('supports Node.js (Linux, MacOS) error stack', () => {
+  const linuxError = new ErrorWithStack([
+    'Error: ',
+    '    at getCallFrame (/Users/mock/github/msw/lib/umd/index.js:3735:22)',
+    '    at Object.get (/Users/mock/github/msw/lib/umd/index.js:3776:29)',
+    '    at Object.<anonymous> (/Users/mock/github/msw/test/msw-api/setup-server/printHandlers.test.ts:13:8)', // <-- this one
+    '    at Runtime._execModule (/Users/mock/github/msw/node_modules/jest-runtime/build/index.js:1299:24)',
+    '    at Runtime._loadModule (/Users/mock/github/msw/node_modules/jest-runtime/build/index.js:898:12)',
+    '    at Runtime.requireModule (/Users/mock/github/msw/node_modules/jest-runtime/build/index.js:746:10)',
+    '    at jasmine2 (/Users/mock/github/msw/node_modules/jest-jasmine2/build/index.js:230:13)',
+    '    at runTestInternal (/Users/mock/github/msw/node_modules/jest-runner/build/runTest.js:380:22)',
+    '    at runTest (/Users/mock/github/msw/node_modules/jest-runner/build/runTest.js:472:34)',
+  ])
+  expect(getCallFrame(linuxError)).toEqual(
     '/Users/mock/github/msw/test/msw-api/setup-server/printHandlers.test.ts:13:8',
   )
 
-  // version 2
-  mockStack.mockImplementationOnce(() =>
-    [
-      'Error: ',
-      '    at getCallFrame (/Users/mock/git/msw/lib/umd/index.js:3735:22)',
-      '    at graphQLRequestHandler (/Users/mock/git/msw/lib/umd/index.js:7071:25)',
-      '    at Object.query (/Users/mock/git/msw/lib/umd/index.js:7182:18)',
-      '    at Object.<anonymous> (/Users/mock/git/msw/test/msw-api/setup-server/printHandlers.test.ts:14:11)', // <-- this one
-      '    at Runtime._execModule (/Users/mock/git/msw/node_modules/jest-runtime/build/index.js:1299:24)',
-      '    at Runtime._loadModule (/Users/mock/git/msw/node_modules/jest-runtime/build/index.js:898:12)',
-      '    at Runtime.requireModule (/Users/mock/git/msw/node_modules/jest-runtime/build/index.js:746:10)',
-      '    at jasmine2 (/Users/mock/git/msw/node_modules/jest-jasmine2/build/index.js:230:13)',
-      '    at runTestInternal (/Users/mock/git/msw/node_modules/jest-runner/build/runTest.js:380:22)',
-      '    at runTest (/Users/mock/git/msw/node_modules/jest-runner/build/runTest.js:472:34)',
-    ].join('\n'),
-  )
+  const macOsError = new ErrorWithStack([
+    'Error: ',
+    '    at getCallFrame (/Users/mock/git/msw/lib/umd/index.js:3735:22)',
+    '    at graphQLRequestHandler (/Users/mock/git/msw/lib/umd/index.js:7071:25)',
+    '    at Object.query (/Users/mock/git/msw/lib/umd/index.js:7182:18)',
+    '    at Object.<anonymous> (/Users/mock/git/msw/test/msw-api/setup-server/printHandlers.test.ts:14:11)', // <-- this one
+    '    at Runtime._execModule (/Users/mock/git/msw/node_modules/jest-runtime/build/index.js:1299:24)',
+    '    at Runtime._loadModule (/Users/mock/git/msw/node_modules/jest-runtime/build/index.js:898:12)',
+    '    at Runtime.requireModule (/Users/mock/git/msw/node_modules/jest-runtime/build/index.js:746:10)',
+    '    at jasmine2 (/Users/mock/git/msw/node_modules/jest-jasmine2/build/index.js:230:13)',
+    '    at runTestInternal (/Users/mock/git/msw/node_modules/jest-runner/build/runTest.js:380:22)',
+    '    at runTest (/Users/mock/git/msw/node_modules/jest-runner/build/runTest.js:472:34)',
+  ])
 
-  expect(getCallFrame()).toBe(
+  expect(getCallFrame(macOsError)).toEqual(
     '/Users/mock/git/msw/test/msw-api/setup-server/printHandlers.test.ts:14:11',
   )
 })
 
-test('Node on Windows error stack', () => {
-  mockStack.mockImplementationOnce(() =>
-    [
-      'Error: ',
-      '    at getCallFrame (C:\\Users\\mock\\git\\msw\\lib\\umd\\index.js:3735:22)',
-      '    at graphQLRequestHandler (C:\\Users\\mock\\git\\msw\\lib\\umd\\index.js:7071:25)',
-      '    at Object.query (C:\\Users\\mock\\git\\msw\\lib\\umd\\index.js:7182:18)',
-      '    at Object.<anonymous> (C:\\Users\\mock\\git\\msw\\test\\msw-api\\setup-server\\printHandlers.test.ts:75:13)', // <-- this one
-      '    at Object.asyncJestTest (C:\\Users\\mock\\git\\msw\\node_modules\\jest-jasmine2\\build\\jasmineAsyncInstall.js:106:37)',
-      '    at C:\\Users\\mock\\git\\msw\\node_modules\\jest-jasmine2\\build\\queueRunner.js:45:12',
-      '    at new Promise (<anonymous>)',
-      '    at mapper (C:\\Users\\mock\\git\\msw\\node_modules\\jest-jasmine2\\build\\queueRunner.js:28:19)',
-      '    at C:\\Users\\mock\\git\\msw\\node_modules\\jest-jasmine2\\build\\queueRunner.js:75:41',
-    ].join('\n'),
-  )
+test('supports Node.js (Windows) error stack', () => {
+  const error = new ErrorWithStack([
+    'Error: ',
+    '    at getCallFrame (C:\\Users\\mock\\git\\msw\\lib\\umd\\index.js:3735:22)',
+    '    at graphQLRequestHandler (C:\\Users\\mock\\git\\msw\\lib\\umd\\index.js:7071:25)',
+    '    at Object.query (C:\\Users\\mock\\git\\msw\\lib\\umd\\index.js:7182:18)',
+    '    at Object.<anonymous> (C:\\Users\\mock\\git\\msw\\test\\msw-api\\setup-server\\printHandlers.test.ts:75:13)', // <-- this one
+    '    at Object.asyncJestTest (C:\\Users\\mock\\git\\msw\\node_modules\\jest-jasmine2\\build\\jasmineAsyncInstall.js:106:37)',
+    '    at C:\\Users\\mock\\git\\msw\\node_modules\\jest-jasmine2\\build\\queueRunner.js:45:12',
+    '    at new Promise (<anonymous>)',
+    '    at mapper (C:\\Users\\mock\\git\\msw\\node_modules\\jest-jasmine2\\build\\queueRunner.js:28:19)',
+    '    at C:\\Users\\mock\\git\\msw\\node_modules\\jest-jasmine2\\build\\queueRunner.js:75:41',
+  ])
 
-  expect(getCallFrame()).toBe(
+  expect(getCallFrame(error)).toBe(
     'C:\\Users\\mock\\git\\msw\\test\\msw-api\\setup-server\\printHandlers.test.ts:75:13',
   )
 })
 
-test('Chrome and Edge error stack', () => {
-  mockStack.mockImplementationOnce(() =>
-    [
-      'Error',
-      '    at getCallFrame (webpack:///./lib/esm/getCallFrame-deps.js?:272:20)',
-      '    at Object.eval [as get] (webpack:///./lib/esm/rest-deps.js?:1402:90)',
-      '    at eval (webpack:///./test/msw-api/setup-worker/printHandlers.mocks.ts?:6:113)', // <-- this one
-      '    at Module../test/msw-api/setup-worker/printHandlers.mocks.ts (http://localhost:59464/main.js:1376:1)',
-      '    at __webpack_require__ (http://localhost:59464/main.js:790:30)',
-      '    at fn (http://localhost:59464/main.js:101:20)',
-      '    at eval (webpack:///multi_(webpack)-dev-server/client?:4:18)',
-      '    at Object.0 (http://localhost:59464/main.js:1399:1)',
-      '    at __webpack_require__ (http://localhost:59464/main.js:790:30)',
-      '    at http://localhost:59464/main.js:857:37',
-    ].join('\n'),
-  )
+test('supports Chrome and Edge error stack', () => {
+  const error = new ErrorWithStack([
+    'Error',
+    '    at getCallFrame (webpack:///./lib/esm/getCallFrame-deps.js?:272:20)',
+    '    at Object.eval [as get] (webpack:///./lib/esm/rest-deps.js?:1402:90)',
+    '    at eval (webpack:///./test/msw-api/setup-worker/printHandlers.mocks.ts?:6:113)', // <-- this one
+    '    at Module../test/msw-api/setup-worker/printHandlers.mocks.ts (http://localhost:59464/main.js:1376:1)',
+    '    at __webpack_require__ (http://localhost:59464/main.js:790:30)',
+    '    at fn (http://localhost:59464/main.js:101:20)',
+    '    at eval (webpack:///multi_(webpack)-dev-server/client?:4:18)',
+    '    at Object.0 (http://localhost:59464/main.js:1399:1)',
+    '    at __webpack_require__ (http://localhost:59464/main.js:790:30)',
+    '    at http://localhost:59464/main.js:857:37',
+  ])
 
-  expect(getCallFrame()).toBe(
+  expect(getCallFrame(error)).toBe(
     'webpack:///./test/msw-api/setup-worker/printHandlers.mocks.ts?:6:113',
   )
 })
 
-test('Firefox on macOS and Windows error stack', () => {
-  mockStack.mockImplementationOnce(() =>
-    [
-      'getCallFrame@webpack:///./lib/esm/getCallFrame-deps.js?:272:20',
-      'createRestHandler/<@webpack:///./lib/esm/rest-deps.js?:1402:90',
-      '@webpack:///./test/msw-api/setup-worker/printHandlers.mocks.ts?:6:113', // <-- this one
-      './test/msw-api/setup-worker/printHandlers.mocks.ts@http://localhost:59464/main.js:1376:1',
-      '__webpack_require__@http://localhost:59464/main.js:790:30',
-      'fn@http://localhost:59464/main.js:101:20',
-      '@webpack:///multi_(webpack)-dev-server/client?:4:18',
-      '0@http://localhost:59464/main.js:1399:1',
-      '__webpack_require__@http://localhost:59464/main.js:790:30',
-      '@http://localhost:59464/main.js:857:37',
-    ].join('\n'),
-  )
+test('supports Firefox (MacOS, Windows) error stack', () => {
+  const error = new ErrorWithStack([
+    'getCallFrame@webpack:///./lib/esm/getCallFrame-deps.js?:272:20',
+    'createRestHandler/<@webpack:///./lib/esm/rest-deps.js?:1402:90',
+    '@webpack:///./test/msw-api/setup-worker/printHandlers.mocks.ts?:6:113', // <-- this one
+    './test/msw-api/setup-worker/printHandlers.mocks.ts@http://localhost:59464/main.js:1376:1',
+    '__webpack_require__@http://localhost:59464/main.js:790:30',
+    'fn@http://localhost:59464/main.js:101:20',
+    '@webpack:///multi_(webpack)-dev-server/client?:4:18',
+    '0@http://localhost:59464/main.js:1399:1',
+    '__webpack_require__@http://localhost:59464/main.js:790:30',
+    '@http://localhost:59464/main.js:857:37',
+  ])
 
-  expect(getCallFrame()).toBe(
+  expect(getCallFrame(error)).toBe(
     'webpack:///./test/msw-api/setup-worker/printHandlers.mocks.ts?:6:113',
   )
 })
 
-test('Safari on macOS error stack', () => {
-  // version 1
-  mockStack.mockImplementationOnce(() =>
-    [
-      'getCallFrame',
-      '',
-      'eval code',
-      'eval@[native code]',
-      './test/msw-api/setup-worker/printHandlers.mocks.ts@http://localhost:59464/main.js:1376:5', // <-- this one
-      '__webpack_require__@http://localhost:59464/main.js:790:34',
-      'fn@http://localhost:59464/main.js:101:39',
-      'eval code',
-      'eval@[native code]',
-      'http://localhost:59464/main.js:1399:5',
-      '__webpack_require__@http://localhost:59464/main.js:790:34',
-      'http://localhost:59464/main.js:857:37',
-      'global code@http://localhost:59464/main.js:858:12',
-    ].join('\n'),
-  )
+test('supports Safari (MacOS) error stack', () => {
+  const errorOne = new ErrorWithStack([
+    'getCallFrame',
+    '',
+    'eval code',
+    'eval@[native code]',
+    './test/msw-api/setup-worker/printHandlers.mocks.ts@http://localhost:59464/main.js:1376:5', // <-- this one
+    '__webpack_require__@http://localhost:59464/main.js:790:34',
+    'fn@http://localhost:59464/main.js:101:39',
+    'eval code',
+    'eval@[native code]',
+    'http://localhost:59464/main.js:1399:5',
+    '__webpack_require__@http://localhost:59464/main.js:790:34',
+    'http://localhost:59464/main.js:857:37',
+    'global code@http://localhost:59464/main.js:858:12',
+  ])
 
-  expect(getCallFrame()).toBe(
+  expect(getCallFrame(errorOne)).toBe(
     './test/msw-api/setup-worker/printHandlers.mocks.ts@http://localhost:59464/main.js:1376:5',
   )
 
-  // version 2
-  mockStack.mockImplementationOnce(() =>
-    [
-      'getCallFrame',
-      'graphQLRequestHandler',
-      'eval code',
-      'eval@[native code]',
-      './test/msw-api/setup-worker/printHandlers.mocks.ts@http://localhost:56460/main.js:1376:5', // <-- this one
-      '__webpack_require__@http://localhost:56460/main.js:790:34',
-      'fn@http://localhost:56460/main.js:101:39',
-      'eval code',
-      'eval@[native code]',
-      'http://localhost:56460/main.js:1399:5',
-      '__webpack_require__@http://localhost:56460/main.js:790:34',
-      'http://localhost:56460/main.js:857:37',
-      'global code@http://localhost:56460/main.js:858:12',
-    ].join('\n'),
-  )
+  const errorTwo = new ErrorWithStack([
+    'getCallFrame',
+    'graphQLRequestHandler',
+    'eval code',
+    'eval@[native code]',
+    './test/msw-api/setup-worker/printHandlers.mocks.ts@http://localhost:56460/main.js:1376:5', // <-- this one
+    '__webpack_require__@http://localhost:56460/main.js:790:34',
+    'fn@http://localhost:56460/main.js:101:39',
+    'eval code',
+    'eval@[native code]',
+    'http://localhost:56460/main.js:1399:5',
+    '__webpack_require__@http://localhost:56460/main.js:790:34',
+    'http://localhost:56460/main.js:857:37',
+    'global code@http://localhost:56460/main.js:858:12',
+  ])
 
-  expect(getCallFrame()).toBe(
+  expect(getCallFrame(errorTwo)).toBe(
     './test/msw-api/setup-worker/printHandlers.mocks.ts@http://localhost:56460/main.js:1376:5',
   )
 })
 
-test('Handles the undefined stack trace', () => {
-  mockStack.mockImplementationOnce(() => undefined)
-  expect(() => getCallFrame()).not.toThrow(TypeError)
-
-  mockStack.mockImplementationOnce(() => null)
-  expect(() => getCallFrame()).not.toThrow(TypeError)
+test('handles the undefined stack trace', () => {
+  expect(() => getCallFrame(new ErrorWithStack(undefined))).not.toThrow(
+    TypeError,
+  )
+  expect(() => getCallFrame(new ErrorWithStack(null))).not.toThrow(TypeError)
 })

--- a/src/utils/internal/getCallFrame.ts
+++ b/src/utils/internal/getCallFrame.ts
@@ -1,17 +1,23 @@
+const BUILD_FRAME =
+  /(node_modules)?[\/\\]lib[\/\\](umd|esm|iief|cjs)[\/\\]|^[^\/\\]*$/
+
 /**
  * Return the stack trace frame of a function's invocation.
  */
-export function getCallFrame() {
+export function getCallFrame(error: Error) {
   // In <IE11, new Error may return an undefined stack
-  const stack = (new Error().stack || '') as string
-  const frames: string[] = stack.split('\n')
+  const stack = error.stack
+
+  if (!stack) {
+    return
+  }
+
+  const frames: string[] = stack.split('\n').slice(1)
 
   // Get the first frame that doesn't reference the library's internal trace.
   // Assume that frame is the invocation frame.
-  const ignoreFrameRegExp =
-    /(node_modules)?[\/\\]lib[\/\\](umd|esm|iief|cjs)[\/\\]|^[^\/\\]*$/
-  const declarationFrame = frames.slice(1).find((frame) => {
-    return !ignoreFrameRegExp.test(frame)
+  const declarationFrame = frames.find((frame) => {
+    return !BUILD_FRAME.test(frame)
   })
 
   if (!declarationFrame) {

--- a/test/msw-api/setup-worker/life-cycle-events/on.test.ts
+++ b/test/msw-api/setup-worker/life-cycle-events/on.test.ts
@@ -65,7 +65,7 @@ test('emits events for a handled request with no response', async () => {
   expect(runtime.consoleSpy.get('warning')).toEqual([
     `[request:start] POST ${url} ${requestId}`,
     expect.stringContaining(
-      '[MSW] Expected a mocking resolver function to return a mocked response',
+      '[MSW] Expected response resolver to return a mocked response Object',
     ),
     `[request:end] POST ${url} ${requestId}`,
     `[response:bypass] original-response ${requestId}`,


### PR DESCRIPTION
- Fixes #907 

## Changes

The no-response warning now contains the relevant request handler header and call frame:

```
[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.
    
  • GET /user
    /path/to/handler:6:18
```