### PR TITLE
Support a single number as a JSON request/response body

### DIFF
--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -26,8 +26,11 @@ const createFetchRequestParameters = (input: MockedRequest): RequestInit => {
     return requestParameters
   }
 
-  requestParameters.body =
-    typeof body === 'object' ? JSON.stringify(body) : body
+  if (typeof body === 'object' || typeof body === 'number') {
+    requestParameters.body = JSON.stringify(body)
+  } else {
+    requestParameters.body = body
+  }
 
   return requestParameters
 }

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -25,6 +25,7 @@ export type DefaultRequestBody =
   | Record<string, any>
   | DefaultRequestMultipartBody
   | string
+  | number
   | undefined
 
 export interface MockedRequest<Body = DefaultRequestBody> {

--- a/src/utils/internal/jsonParse.ts
+++ b/src/utils/internal/jsonParse.ts
@@ -3,10 +3,10 @@
  * Does not throw an exception on an invalid JSON string.
  */
 export function jsonParse<T extends Record<string, any>>(
-  str: string,
+  value: any,
 ): T | undefined {
   try {
-    return JSON.parse(str)
+    return JSON.parse(value)
   } catch (error) {
     return undefined
   }

--- a/src/utils/internal/jsonParse.ts
+++ b/src/utils/internal/jsonParse.ts
@@ -1,10 +1,10 @@
 /**
- * Parses a given string into a JSON.
+ * Parses a given value into a JSON.
  * Does not throw an exception on an invalid JSON string.
  */
-export function jsonParse<T extends Record<string, any>>(
+export function jsonParse<ValueType extends Record<string, any>>(
   value: any,
-): T | undefined {
+): ValueType | undefined {
   try {
     return JSON.parse(value)
   } catch (error) {

--- a/src/utils/request/parseBody.test.ts
+++ b/src/utils/request/parseBody.test.ts
@@ -84,14 +84,20 @@ test('returns an invalid Multipart body as-is even if the "Content-Type: multipa
     'content-type':
       'multipart/form-data; boundary=------WebKitFormBoundaryvZ1cVXWyK0ilQdab',
   })
-  expect(parseBody('text-body', headers)).toBe('text-body')
+  expect(parseBody('text-body', headers)).toEqual('text-body')
+})
+
+test('parses a single stringified number as a valid "application/json" body', () => {
+  const headers = new Headers({ 'Content-Type': 'application/json' })
+  expect(parseBody('1', headers)).toEqual(1)
+})
+
+test('preserves a single stringified number in a "multipart/form-data" body', () => {
+  const headers = new Headers({ 'Content-Type': 'multipart/form-data;' })
+  expect(parseBody('1', headers)).toEqual('1')
 })
 
 test('returns a falsy body as-is', () => {
-  expect(parseBody('')).toBe('')
+  expect(parseBody('')).toEqual('')
   expect(parseBody(undefined)).toBeUndefined()
-})
-
-test('parse a single number as valid JSON body', () => {
-  expect(parseBody('1')).toBe('1')
 })

--- a/src/utils/request/parseBody.test.ts
+++ b/src/utils/request/parseBody.test.ts
@@ -91,3 +91,7 @@ test('returns a falsy body as-is', () => {
   expect(parseBody('')).toBe('')
   expect(parseBody(undefined)).toBeUndefined()
 })
+
+test('parse a single number as valid JSON body', () => {
+  expect(parseBody('1')).toBe('1')
+})

--- a/src/utils/request/parseBody.ts
+++ b/src/utils/request/parseBody.ts
@@ -3,7 +3,7 @@ import { jsonParse } from '../internal/jsonParse'
 import { parseMultipartData } from '../internal/parseMultipartData'
 
 /**
- * Parses a given request/response body based on the `Content-Type` header.
+ * Parses a given request/response body based on the "Content-Type" header.
  */
 export function parseBody(body?: MockedRequest['body'], headers?: Headers) {
   // Return whatever falsey body value is given.
@@ -11,18 +11,18 @@ export function parseBody(body?: MockedRequest['body'], headers?: Headers) {
     return body
   }
 
-  const contentType = headers?.get('content-type')
+  const contentType = headers?.get('content-type') || ''
 
   // If the body has a Multipart Content-Type
   // parse it into an object.
-  const hasMultipartContent = contentType?.startsWith('multipart/form-data')
+  const hasMultipartContent = contentType.startsWith('multipart/form-data')
   if (hasMultipartContent && typeof body !== 'object') {
     return parseMultipartData(body.toString(), headers) || body
   }
 
   // If the intercepted request's body has a JSON Content-Type
   // parse it into an object.
-  const hasJsonContent = contentType?.includes('json')
+  const hasJsonContent = contentType.includes('json')
 
   if (hasJsonContent && typeof body !== 'object') {
     return jsonParse(body.toString()) || body

--- a/src/utils/request/parseBody.ts
+++ b/src/utils/request/parseBody.ts
@@ -17,7 +17,7 @@ export function parseBody(body?: MockedRequest['body'], headers?: Headers) {
   // parse it into an object.
   const hasMultipartContent = contentType?.startsWith('multipart/form-data')
   if (hasMultipartContent && typeof body !== 'object') {
-    return parseMultipartData(body, headers) || body
+    return parseMultipartData(body.toString(), headers) || body
   }
 
   // If the intercepted request's body has a JSON Content-Type
@@ -25,7 +25,7 @@ export function parseBody(body?: MockedRequest['body'], headers?: Headers) {
   const hasJsonContent = contentType?.includes('json')
 
   if (hasJsonContent && typeof body !== 'object') {
-    return jsonParse(body) || body
+    return jsonParse(body.toString()) || body
   }
 
   // Otherwise leave as-is.

--- a/src/utils/request/parseWorkerRequest.ts
+++ b/src/utils/request/parseWorkerRequest.ts
@@ -1,5 +1,5 @@
 import { Headers } from 'headers-utils'
-import { MockedRequest } from '../../handlers/RequestHandler'
+import { RestRequest } from '../../handlers/RestHandler'
 import { ServiceWorkerIncomingRequest } from '../../setupWorker/glossary'
 import { setRequestCookies } from './setRequestCookies'
 import { parseBody } from './parseBody'
@@ -11,8 +11,8 @@ import { pruneGetRequestBody } from './pruneGetRequestBody'
  */
 export function parseWorkerRequest(
   rawRequest: ServiceWorkerIncomingRequest,
-): MockedRequest {
-  const request = {
+): RestRequest {
+  const request: RestRequest = {
     id: rawRequest.id,
     cache: rawRequest.cache,
     credentials: rawRequest.credentials,
@@ -36,7 +36,7 @@ export function parseWorkerRequest(
   setRequestCookies(request)
 
   // Parse the request's body based on the "Content-Type" header.
-  request.body = parseBody(request.body, request.headers) as any
+  request.body = parseBody(request.body, request.headers)
 
   return request
 }

--- a/test/rest-api/request/body/body-form-data.page.html
+++ b/test/rest-api/request/body/body-form-data.page.html
@@ -13,7 +13,7 @@
         event.preventDefault()
         const formData = new FormData(form)
 
-        fetch('/sign-in', {
+        fetch('/', {
           method: 'POST',
           body: formData,
         })

--- a/test/rest-api/request/body/body-form-data.test.ts
+++ b/test/rest-api/request/body/body-form-data.test.ts
@@ -3,13 +3,13 @@ import { pageWith } from 'page-with'
 
 test('handles FormData as a request body', async () => {
   const { page, makeUrl } = await pageWith({
-    example: path.resolve(__dirname, 'body-form-data.mocks.ts'),
+    example: path.resolve(__dirname, 'body.mocks.ts'),
     markup: path.resolve(__dirname, 'body-form-data.page.html'),
   })
 
   await page.click('button')
 
-  const res = await page.waitForResponse(makeUrl('/sign-in'))
+  const res = await page.waitForResponse(makeUrl('/'))
   const status = res.status()
   const json = await res.json()
 

--- a/test/rest-api/request/body/body-json.test.ts
+++ b/test/rest-api/request/body/body-json.test.ts
@@ -1,0 +1,38 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+
+function prepareRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'body.mocks.ts'),
+  })
+}
+
+test('sends a JSON request body', async () => {
+  const runtime = await prepareRuntime()
+
+  const res = await runtime.request('/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ firstName: 'John' }),
+  })
+  const json = await res.json()
+
+  expect(json).toEqual({ firstName: 'John' })
+})
+
+test('sends a single number as a JSON request body', async () => {
+  const runtime = await prepareRuntime()
+
+  const res = await runtime.request('/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(123),
+  })
+  const json = await res.json()
+
+  expect(json).toEqual(123)
+})

--- a/test/rest-api/request/body/body.mocks.ts
+++ b/test/rest-api/request/body/body.mocks.ts
@@ -1,7 +1,7 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.post('/sign-in', (req, res, ctx) => {
+  rest.post('/', (req, res, ctx) => {
     return res(ctx.json(req.body))
   }),
 )

--- a/test/rest-api/response/body/body-json.mocks.ts
+++ b/test/rest-api/response/body/body-json.mocks.ts
@@ -4,6 +4,9 @@ const worker = setupWorker(
   rest.get('/json', (req, res, ctx) => {
     return res(ctx.json({ firstName: 'John' }))
   }),
+  rest.get('/number', (req, res, ctx) => {
+    return res(ctx.json(123))
+  }),
 )
 
 worker.start()

--- a/test/rest-api/response/body/body-json.node.test.ts
+++ b/test/rest-api/response/body/body-json.node.test.ts
@@ -9,6 +9,9 @@ const server = setupServer(
   rest.get('http://localhost/json', (req, res, ctx) => {
     return res(ctx.json({ firstName: 'John' }))
   }),
+  rest.get('http://localhost/number', (req, res, ctx) => {
+    return res(ctx.json(123))
+  }),
 )
 
 beforeAll(() => {
@@ -26,4 +29,13 @@ test('responds with a JSON response body', async () => {
 
   const json = await res.json()
   expect(json).toEqual({ firstName: 'John' })
+})
+
+test('responds with a single number JSON response body', async () => {
+  const res = await fetch('http://localhost/number')
+
+  expect(res.headers.get('content-type')).toBe('application/json')
+
+  const json = await res.json()
+  expect(json).toEqual(123)
 })

--- a/test/rest-api/response/body/body-json.test.ts
+++ b/test/rest-api/response/body/body-json.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import * as path from 'path'
 import { pageWith } from 'page-with'
 
@@ -13,4 +16,18 @@ test('responds with a JSON response body', async () => {
 
   const json = await res.json()
   expect(json).toEqual({ firstName: 'John' })
+})
+
+test('responds with a single number JSON response body', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'body-json.mocks.ts'),
+  })
+
+  const res = await runtime.request('/number')
+
+  const headers = await res.allHeaders()
+  expect(headers).toHaveProperty('content-type', 'application/json')
+
+  const json = await res.json()
+  expect(json).toEqual(123)
 })


### PR DESCRIPTION
Fix: #920 

## Motivation

Hi team! 👋 
As mentioned in #920, a single number value should be handled as a valid JSON value, but `msw` currently cannot handle number as JSON.

> A JSON text is a sequence of tokens. The set of tokens includes six
structural characters, strings, numbers, and three literal names.

https://www.ietf.org/rfc/rfc7159.txt

## Did

- [x] update `DefaultRequestBody` which seems to be used as JSON or JSON string type in request body and response body.
- [x] update some parse logic in order to enable parser  to parse number value as JSON