### PR TITLE
feat: support multipart binary request bodies

### DIFF
--- a/src/utils/internal/parseMultipartData.ts
+++ b/src/utils/internal/parseMultipartData.ts
@@ -55,8 +55,8 @@ export function parseMultipartData<T extends DefaultRequestMultipartBody>(
 
   const [, ...directives] = contentType.split(/; */)
   const boundary = directives
-    .filter((d) => d.startsWith('boundary='))
-    .map((s) => s.replace(/^boundary=/, ''))[0]
+    .filter((directive) => directive.startsWith('boundary='))
+    .map((directive) => directive.replace(/^boundary=/, ''))[0]
 
   if (!boundary) {
     return undefined

--- a/test/rest-api/response/body/body-binary.test.ts
+++ b/test/rest-api/response/body/body-binary.test.ts
@@ -1,22 +1,55 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { pageWith } from 'page-with'
+import { createServer, ServerApi } from '@open-draft/test-server'
 
-test('responds with a given binary body', async () => {
-  const runtime = await pageWith({
+const imageBuffer = fs.readFileSync(
+  path.resolve(__dirname, '../../../fixtures/image.jpg'),
+)
+
+let httpServer: ServerApi
+
+function createRuntime() {
+  return pageWith({
     example: path.resolve(__dirname, 'body-binary.mocks.ts'),
   })
+}
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.get('/image', (req, res) => {
+      res.type('jpg')
+      res.end(imageBuffer, 'binary')
+    })
+  })
+})
+
+afterAll(async () => {
+  await httpServer.close()
+})
+
+test('responds with a mocked binary response body', async () => {
+  const runtime = await createRuntime()
 
   const res = await runtime.request('/images/abc-123')
   const status = res.status()
   const headers = await res.allHeaders()
   const body = await res.body()
 
-  const expectedBuffer = fs.readFileSync(
-    path.resolve(__dirname, '../../../fixtures/image.jpg'),
-  )
-
   expect(status).toBe(200)
   expect(headers).toHaveProperty('x-powered-by', 'msw')
-  expect(new Uint8Array(body)).toEqual(new Uint8Array(expectedBuffer))
+  expect(new Uint8Array(body)).toEqual(new Uint8Array(imageBuffer))
+})
+
+test('responds with an original binary response body', async () => {
+  const runtime = await createRuntime()
+
+  const res = await runtime.request(httpServer.http.makeUrl('/image'))
+  const status = res.status()
+  const headers = res.headers()
+  const body = await res.body()
+
+  expect(status).toEqual(200)
+  expect(headers).not.toHaveProperty('x-powered-by', 'msw')
+  expect(new Uint8Array(body)).toEqual(new Uint8Array(imageBuffer))
 })


### PR DESCRIPTION
- Fixes #929

## Changes

- Adds a missing test case for the original (bypassed) binary response body.