### PR TITLE
getRequestCookies: check "document" and "location" explicitly

### DIFF
--- a/src/utils/request/getRequestCookies.node.test.ts
+++ b/src/utils/request/getRequestCookies.node.test.ts
@@ -4,23 +4,25 @@
 import { getRequestCookies } from './getRequestCookies'
 import { createMockedRequest } from '../../../test/support/utils'
 
+const prevLocation = global.location
+
 beforeAll(() => {
-  // Node applications performing Server-Side Rendering of front-end applications
-  // might have to polyfill some browser globals like document, location etc.
+  // Node.js applications may polyfill some browser globals (document, location)
+  // when performing Server-Side Rendering of front-end applications.
   global.location = {
-    href: 'https://google.nl',
-    origin: 'https://google.nl',
+    href: 'https://mswjs.io',
+    origin: 'https://mswjs.io',
   } as Location
 })
 
 afterAll(() => {
-  global.location = undefined as unknown as Location
+  global.location = prevLocation
 })
 
 test('returns empty object when in a node environment with polyfilled location object', () => {
   const cookies = getRequestCookies(
     createMockedRequest({
-      url: new URL(`${location.origin}/user`),
+      url: new URL('/user', location.origin),
       credentials: 'include',
     }),
   )

--- a/src/utils/request/getRequestCookies.node.test.ts
+++ b/src/utils/request/getRequestCookies.node.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+import { getRequestCookies } from './getRequestCookies'
+import { createMockedRequest } from '../../../test/support/utils'
+
+beforeAll(() => {
+  // Node applications performing Server-Side Rendering of front-end applications
+  // might have to polyfill some browser globals like document, location etc.
+  global.location = {
+    href: 'https://google.nl',
+    origin: 'https://google.nl',
+  } as Location
+})
+
+afterAll(() => {
+  global.location = undefined as unknown as Location
+})
+
+test('returns empty object when in a node environment with polyfilled location object', () => {
+  const cookies = getRequestCookies(
+    createMockedRequest({
+      url: new URL(`${location.origin}/user`),
+      credentials: 'include',
+    }),
+  )
+
+  expect(cookies).toEqual({})
+})

--- a/src/utils/request/getRequestCookies.ts
+++ b/src/utils/request/getRequestCookies.ts
@@ -1,13 +1,8 @@
 import * as cookieUtils from 'cookie'
-import { isNodeProcess } from 'is-node-process'
 import { MockedRequest } from '../../handlers/RequestHandler'
 
 function getAllCookies() {
   return cookieUtils.parse(document.cookie)
-}
-
-function isJSDOMEnvironment() {
-  return global.navigator?.userAgent?.includes('jsdom')
 }
 
 /**
@@ -17,7 +12,7 @@ export function getRequestCookies(request: MockedRequest) {
   /**
    * @note No cookies persist on the document in Node.js: no document.
    */
-  if (isNodeProcess() && !isJSDOMEnvironment()) {
+  if (typeof document === 'undefined' || typeof location === 'undefined') {
     return {}
   }
 

--- a/src/utils/request/getRequestCookies.ts
+++ b/src/utils/request/getRequestCookies.ts
@@ -1,8 +1,13 @@
 import * as cookieUtils from 'cookie'
+import { isNodeProcess } from 'is-node-process'
 import { MockedRequest } from '../../handlers/RequestHandler'
 
 function getAllCookies() {
   return cookieUtils.parse(document.cookie)
+}
+
+function isJSDOMEnvironment() {
+  return global.navigator?.userAgent?.includes('jsdom')
 }
 
 /**
@@ -12,7 +17,7 @@ export function getRequestCookies(request: MockedRequest) {
   /**
    * @note No cookies persist on the document in Node.js: no document.
    */
-  if (typeof location === 'undefined') {
+  if (isNodeProcess() && !isJSDOMEnvironment()) {
     return {}
   }
 


### PR DESCRIPTION
Following the conversation on discord this improves the environment detection to work when browser globals are polyfilled. This might happen as part of Server-Side Rendering front-end applications like react.

The tests use JSDOM to test msw in the context of the browser.`isNodeProcess` accurately detects that this is a node process. For the tests to work it would have to run like it's in a browser environment though. To accomplish that I considered mocking, but this would  only fix this for the tests of MSW, not for users using MSW in a JSDOM environment. Are there any other testing environments where this could break that we should account for?