### PR TITLE
chore: test failures macos

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "jest": "26",
     "json-bigint": "^1.0.0",
     "lint-staged": "^11.0.1",
-    "page-with": "^0.4.2",
+    "page-with": "^0.5.0",
     "prettier": "^2.3.2",
     "regenerator-runtime": "^0.13.7",
     "rimraf": "^3.0.2",

--- a/test/graphql-api/cookies.test.ts
+++ b/test/graphql-api/cookies.test.ts
@@ -19,7 +19,7 @@ test('sets cookie on the mocked GraphQL response', async () => {
     `,
   })
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/graphql-api/document-node.test.ts
+++ b/test/graphql-api/document-node.test.ts
@@ -23,7 +23,7 @@ test('intercepts a GraphQL query based on its DocumentNode', async () => {
   })
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
 
   const json = await res.json()
   expect(json).toEqual({
@@ -52,7 +52,7 @@ test('intercepts a GraphQL mutation based on its DocumentNode', async () => {
   })
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
 
   const json = await res.json()
   expect(json).toEqual({
@@ -87,7 +87,7 @@ test('intercepts a scoped GraphQL query based on its DocumentNode', async () => 
   )
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
 
   const json = await res.json()
   expect(json).toEqual({

--- a/test/graphql-api/link.test.ts
+++ b/test/graphql-api/link.test.ts
@@ -36,7 +36,7 @@ test('mocks a GraphQL query to the GitHub GraphQL API', async () => {
     },
   )
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toEqual(200)
@@ -73,7 +73,7 @@ test('mocks a GraphQL mutation to the Stripe GraphQL API', async () => {
     },
   )
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toEqual(200)
@@ -104,7 +104,7 @@ test('falls through to the matching GraphQL operation to an unknown endpoint', a
     },
   })
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-request-handler', 'fallback')

--- a/test/graphql-api/mutation.test.ts
+++ b/test/graphql-api/mutation.test.ts
@@ -23,7 +23,7 @@ test('sends a mocked response to a GraphQL mutation', async () => {
       }
     `,
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toEqual(200)

--- a/test/graphql-api/operation-reference.test.ts
+++ b/test/graphql-api/operation-reference.test.ts
@@ -23,7 +23,7 @@ test('allows referencing the request body in the request handler', async () => {
       id: 'abc-123',
     },
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')
@@ -53,7 +53,7 @@ test('allows referencing the request body in the request handler', async () => {
       password: 'super-secret',
     },
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/graphql-api/operation.test.ts
+++ b/test/graphql-api/operation.test.ts
@@ -30,7 +30,7 @@ test('intercepts and mocks a GraphQL query', async () => {
       id: 'abc-123',
     },
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toEqual(200)
@@ -73,7 +73,7 @@ test('intercepts and mocks an anonymous GraphQL query', async () => {
 
   expect(res.status()).toEqual(200)
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   expect(headers).toHaveProperty('x-powered-by', 'msw')
 
   const body = await res.json()
@@ -109,7 +109,7 @@ test('intercepts and mocks a GraphQL mutation', async () => {
       password: 'super-secret',
     },
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toEqual(200)
@@ -163,7 +163,7 @@ test('bypasses seemingly compatible REST requests', async () => {
     },
   )
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toBe(200)

--- a/test/graphql-api/query.test.ts
+++ b/test/graphql-api/query.test.ts
@@ -31,7 +31,7 @@ test('mocks a GraphQL query issued with a GET request', async () => {
     },
   )
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toEqual(200)
@@ -59,7 +59,7 @@ test('mocks a GraphQL query issued with a POST request', async () => {
       }
     `,
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toEqual(200)

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -78,6 +78,9 @@ Object.keys(console).forEach((methodName) => {
         },
       },
     },
+  }).catch((error) => {
+    console.error('Failed to create browser:', error)
+    return null
   })
 })
 

--- a/test/msw-api/context/async-response-transformer.test.ts
+++ b/test/msw-api/context/async-response-transformer.test.ts
@@ -13,7 +13,7 @@ test('supports asynchronous response transformer', async () => {
     path.resolve(__dirname, '../../fixtures/image.jpg'),
   )
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
 
   expect(status).toBe(201)
   expect(headers).toHaveProperty('content-type', 'image/jpeg')
@@ -34,7 +34,7 @@ test('supports asynchronous default response transformer', async () => {
   })
   const status = res.status()
   const statusText = res.statusText()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
 
   expect(status).toBe(301)
   expect(statusText).toBe('Custom Status Text')

--- a/test/msw-api/context/delay.test.ts
+++ b/test/msw-api/context/delay.test.ts
@@ -54,7 +54,7 @@ test('uses explicit server response delay', async () => {
   expect(responseTime).toRoughlyEqual(1200, 250)
 
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')
@@ -74,7 +74,7 @@ test('uses realistic server response delay when no delay value is provided', asy
   expect(responseTime).toRoughlyEqual(250, 200)
 
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')
@@ -96,7 +96,7 @@ test('uses realistic server response delay when "real" delay mode is provided', 
   expect(responseTime).toRoughlyEqual(250, 200)
 
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/msw-api/exception-handling.test.ts
+++ b/test/msw-api/exception-handling.test.ts
@@ -17,7 +17,7 @@ test('transforms uncaught exceptions into a 500 response', async () => {
 
   const res = await runtime.request('https://api.github.com/users/octocat')
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toEqual(500)

--- a/test/msw-api/hard-reload.test.ts
+++ b/test/msw-api/hard-reload.test.ts
@@ -18,7 +18,7 @@ test('keeps the mocking enabled after hard-reload of the page', async () => {
   })
 
   const res = await runtime.request('https://api.github.com')
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/msw-api/integrity-check.test.ts
+++ b/test/msw-api/integrity-check.test.ts
@@ -20,7 +20,7 @@ test('activates the worker without errors given the latest integrity', async () 
   expect(consoleSpy.get('error')).toBeUndefined()
 
   const res = await request('https://api.github.com/users/octocat')
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')
@@ -63,7 +63,7 @@ test('errors when activating the worker with an outdated integrity', async () =>
 
   // Should still keep the mocking enabled.
   const res = await request('https://api.github.com/users/octocat')
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/msw-api/res/network-error.test.ts
+++ b/test/msw-api/res/network-error.test.ts
@@ -15,7 +15,7 @@ test('throws a network error', async () => {
   await expect(requestPromise).rejects.toThrow(
     // The `fetch` call itself rejects with the "Failed to fetch" error,
     // the same error that happens on a regular network error.
-    'Evaluation failed: TypeError: Failed to fetch',
+    'TypeError: Failed to fetch',
   )
 
   // Assert a network error message printed into the console

--- a/test/msw-api/setup-worker/start/quiet.test.ts
+++ b/test/msw-api/setup-worker/start/quiet.test.ts
@@ -21,7 +21,7 @@ test('does not log the captured request when the "quiet" option is set to "true"
 
   const res = await request('/user')
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/msw-api/setup-worker/stop.test.ts
+++ b/test/msw-api/setup-worker/stop.test.ts
@@ -28,7 +28,7 @@ test('disables the mocking when the worker is stopped', async () => {
   await stopWorkerOn(runtime.page)
 
   const res = await runtime.request('https://api.github.com')
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).not.toHaveProperty('x-powered-by', 'msw')
@@ -56,7 +56,7 @@ test('keeps the mocking enabled in one tab when stopping the worker in another t
   // Create a request handler for the new page.
   const request = createRequestUtil(secondPage, server)
   const res = await request('https://api.github.com')
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/rest-api/basic.test.ts
+++ b/test/rest-api/basic.test.ts
@@ -7,10 +7,11 @@ test('mocks response to a basic GET request', async () => {
   })
 
   const res = await runtime.request('https://api.github.com/users/octocat')
+  const headers = await res.allHeaders()
   const body = await res.json()
 
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
   expect(res.status()).toBe(200)
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
   expect(body).toEqual({
     name: 'John Maverick',
     originalUsername: 'octocat',

--- a/test/rest-api/context.mocks.ts
+++ b/test/rest-api/context.mocks.ts
@@ -8,7 +8,7 @@ const worker = setupWorker(
         Accept: 'foo/bar',
         'Custom-Header': 'arbitrary-value',
       }),
-      ctx.status(305, 'Yahoo!'),
+      ctx.status(201, 'Yahoo!'),
       ctx.json({
         mocked: true,
       }),

--- a/test/rest-api/context.test.ts
+++ b/test/rest-api/context.test.ts
@@ -7,7 +7,7 @@ test('composes various context utilities into a valid mocked response', async ()
   })
 
   const res = await runtime.request('https://test.mswjs.io/')
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(res.status()).toEqual(201)

--- a/test/rest-api/context.test.ts
+++ b/test/rest-api/context.test.ts
@@ -10,7 +10,7 @@ test('composes various context utilities into a valid mocked response', async ()
   const headers = res.headers()
   const body = await res.json()
 
-  expect(res.status()).toEqual(305)
+  expect(res.status()).toEqual(201)
   expect(res.statusText()).toEqual('Yahoo!')
   expect(headers).toHaveProperty('x-powered-by', 'msw')
   expect(headers).toHaveProperty('content-type', 'application/json')

--- a/test/rest-api/cookies-request.test.ts
+++ b/test/rest-api/cookies-request.test.ts
@@ -18,7 +18,7 @@ test('returns all document cookies in "req.cookies" for "include" credentials', 
   const res = await runtime.request('/user', {
     credentials: 'include',
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')
@@ -36,7 +36,7 @@ test('returns all document cookies in "req.cookies" for "same-origin" credential
   const res = await runtime.request('/user', {
     credentials: 'same-origin',
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')
@@ -54,7 +54,7 @@ test('returns no cookies in "req.cookies" for "same-origin" credentials and requ
   const res = await runtime.request('https://test.mswjs.io/user', {
     credentials: 'same-origin',
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')
@@ -69,7 +69,7 @@ test('returns no cookies in "req.cookies" for "omit" credentials', async () => {
   const res = await runtime.request('/user', {
     credentials: 'omit',
   })
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/rest-api/cookies.test.ts
+++ b/test/rest-api/cookies.test.ts
@@ -11,7 +11,7 @@ test('allows setting cookies on the mocked response', async () => {
 
   const res = await runtime.request('/user')
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/rest-api/custom-request-handler.test.ts
+++ b/test/rest-api/custom-request-handler.test.ts
@@ -16,7 +16,7 @@ test('intercepts a request with a custom request handler with default context', 
     },
   })
   const body = await res.json()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
 
   expect(res.status()).toBe(401)
   expect(headers).toHaveProperty('x-powered-by', 'msw')
@@ -30,7 +30,7 @@ test('intercepts a request with a custom request handler with custom context', a
 
   const res = await runtime.request('https://test.url/')
   const body = await res.json()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
 
   expect(res.status()).toBe(200)
   expect(headers).toHaveProperty('x-powered-by', 'msw')

--- a/test/rest-api/generator.test.ts
+++ b/test/rest-api/generator.test.ts
@@ -18,7 +18,7 @@ test('supports a generator function as the response resolver', async () => {
   const assertRequest = async (expectedBody: ExpectedResponseBody) => {
     const res = await runtime.request('/polling/3')
     const body = await res.json()
-    expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+    expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
     expect(res.status()).toBe(200)
     expect(body).toEqual(expectedBody)
   }
@@ -39,7 +39,7 @@ test('supports one-time handlers with the generator as the response resolver', a
   const assertRequest = async (expectedBody: ExpectedResponseBody) => {
     const res = await runtime.request('/polling/once/3')
     const body = await res.json()
-    expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+    expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
     expect(res.status()).toBe(200)
     expect(body).toEqual(expectedBody)
   }

--- a/test/rest-api/headers-multiple.test.ts
+++ b/test/rest-api/headers-multiple.test.ts
@@ -34,7 +34,7 @@ test('supports setting a header with multiple values on the mocked response', as
 
   const res = await runtime.request('https://test.mswjs.io')
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toEqual(200)

--- a/test/rest-api/params.test.ts
+++ b/test/rest-api/params.test.ts
@@ -10,7 +10,7 @@ test('parses request URL parameters', async () => {
     'https://api.github.com/users/octocat/messages/abc-123',
   )
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)

--- a/test/rest-api/query.test.ts
+++ b/test/rest-api/query.test.ts
@@ -14,7 +14,7 @@ test('retrieves a single request URL query parameter', async () => {
     'https://test.mswjs.io/api/books?id=abc-123',
   )
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)
@@ -34,7 +34,7 @@ test('retrieves multiple request URL query parameters', async () => {
     },
   )
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)

--- a/test/rest-api/redirect.test.ts
+++ b/test/rest-api/redirect.test.ts
@@ -6,17 +6,18 @@ test('supports redirect in a mocked response', async () => {
     example: path.resolve(__dirname, 'redirect.mocks.ts'),
   })
   const res = await runtime.request('/login')
+  const headers = await res.allHeaders()
 
   // Assert the original response returns redirect.
-  expect(res.headers()).toHaveProperty('location', '/user')
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(headers).toHaveProperty('location', '/user')
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
   expect(res.status()).toBe(307)
 
   const redirectRes = await runtime.page.waitForResponse(
     runtime.makeUrl('/user'),
   )
   const redirectStatus = redirectRes.status()
-  const redirectHeaders = redirectRes.headers()
+  const redirectHeaders = await redirectRes.allHeaders()
   const redirectBody = await redirectRes.json()
 
   // Assert redirect gets requested and mocked.

--- a/test/rest-api/request/matching/method.test.ts
+++ b/test/rest-api/request/matching/method.test.ts
@@ -12,7 +12,7 @@ test('sends a mocked response to a POST request on the matching URL', async () =
     method: 'POST',
   })
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)
@@ -27,7 +27,7 @@ test('does not send a mocked response to a GET request on the matching URL', asy
 
   const res = await runtime.request('https://api.github.com/users/octocat')
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)

--- a/test/rest-api/request/matching/uri.test.ts
+++ b/test/rest-api/request/matching/uri.test.ts
@@ -13,7 +13,7 @@ test('matches an exact string with the same request URL with a trailing slash', 
   const res = await runtime.request('https://api.github.com/made-up/')
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
   expect(await res.json()).toEqual({
     mocked: true,
   })
@@ -35,7 +35,7 @@ test('matches an exact string with the same request URL without a trailing slash
   const res = await runtime.request('https://api.github.com/made-up')
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
   expect(await res.json()).toEqual({
     mocked: true,
   })
@@ -57,7 +57,7 @@ test('matches a mask against a matching request URL', async () => {
   const res = await runtime.request('https://test.mswjs.io/messages/abc-123')
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
   expect(await res.json()).toEqual({
     messageId: 'abc-123',
   })
@@ -71,7 +71,7 @@ test('ignores query parameters when matching a mask against a matching request U
   )
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
   expect(await res.json()).toEqual({
     messageId: 'abc-123',
   })
@@ -93,7 +93,7 @@ test('matches a RegExp against a matching request URL', async () => {
   const res = await runtime.request('https://mswjs.google.com/path')
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
   expect(await res.json()).toEqual({
     mocked: true,
   })
@@ -115,7 +115,7 @@ test('supports escaped parentheses in the request URL', async () => {
   const res = await runtime.request(`/resource('id')`)
 
   expect(res.status()).toEqual(200)
-  expect(res.headers()).toHaveProperty('x-powered-by', 'msw')
+  expect(await res.allHeaders()).toHaveProperty('x-powered-by', 'msw')
   expect(await res.json()).toEqual({
     mocked: true,
   })

--- a/test/rest-api/response-patching.test.ts
+++ b/test/rest-api/response-patching.test.ts
@@ -49,7 +49,7 @@ test('responds with a combination of the mocked and original responses', async (
 
   const res = await runtime.request('/user')
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)
@@ -77,7 +77,7 @@ test('bypasses the original request when it equals the mocked request', async ()
     },
   )
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)
@@ -127,7 +127,7 @@ test('supports patching a HEAD request', async () => {
   )
 
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)
@@ -155,7 +155,7 @@ test('supports patching a GET request', async () => {
     },
   )
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)
@@ -187,7 +187,7 @@ test('supports patching a POST request', async () => {
     },
   )
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.json()
 
   expect(status).toBe(200)

--- a/test/rest-api/response/body/body-binary.test.ts
+++ b/test/rest-api/response/body/body-binary.test.ts
@@ -9,7 +9,7 @@ test('responds with a given binary body', async () => {
 
   const res = await runtime.request('/images/abc-123')
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const body = await res.body()
 
   const expectedBuffer = fs.readFileSync(

--- a/test/rest-api/response/body/body-json.test.ts
+++ b/test/rest-api/response/body/body-json.test.ts
@@ -8,7 +8,7 @@ test('responds with a JSON response body', async () => {
 
   const res = await runtime.request('/json')
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   expect(headers).toHaveProperty('content-type', 'application/json')
 
   const json = await res.json()

--- a/test/rest-api/response/body/body-text.test.ts
+++ b/test/rest-api/response/body/body-text.test.ts
@@ -8,7 +8,7 @@ test('responds with a text response body', async () => {
 
   const res = await runtime.request('/text')
 
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   expect(headers).toHaveProperty('content-type', 'text/plain')
 
   const text = await res.text()

--- a/test/rest-api/response/body/body-xml.test.ts
+++ b/test/rest-api/response/body/body-xml.test.ts
@@ -8,7 +8,7 @@ test('responds with an XML response body', async () => {
 
   const res = await request('/user')
   const status = res.status()
-  const headers = res.headers()
+  const headers = await res.allHeaders()
   const text = await res.text()
 
   expect(status).toBe(200)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,10 +1635,12 @@
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.10.tgz#61cc8469849e5bcdd0c7044122265c39cec10cf4"
   integrity sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==
 
-"@types/debug@^4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
-  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
@@ -1666,11 +1668,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/estree@^0.0.47":
-  version "0.0.47"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
-  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
-
 "@types/estree@^0.0.50":
   version "0.0.50"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
@@ -1689,6 +1686,16 @@
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
   integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/express@^4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.18"
@@ -1772,6 +1779,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
   integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
+"@types/json-schema@^7.0.8":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -1782,10 +1794,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/mustache@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.1.1.tgz#fcfa2db0cee6261e66f2437dc2fe71e26c7856b4"
-  integrity sha512-Sm0NWeLhS2QL7NNGsXvO+Fgp7e3JLHCO6RS3RCnfjAnkw6Y1bsji/AGfISdQZDIR/AeOyzkrxRk9jBkl55zdJw==
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
+
+"@types/mustache@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.1.2.tgz#d0e158013c81674a5b6d8780bc3fe234e1804eaf"
+  integrity sha512-c4OVMMcyodKQ9dpwBwh3ofK9P6U9ZktKU9S+p33UqwMNN1vlv2P0zJZUScTshnx7OEoIIRcCFNQ904sYxZz8kg==
 
 "@types/node-fetch@^2.5.11":
   version "2.5.11"
@@ -1871,10 +1888,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/uuid@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
-  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+"@types/uuid@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
+  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -1964,14 +1981,6 @@
     "@typescript-eslint/types" "4.28.3"
     eslint-visitor-keys "^2.0.0"
 
-"@webassemblyjs/ast@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.0.tgz#a5aa679efdc9e51707a4207139da57920555961f"
-  integrity sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==
-  dependencies:
-    "@webassemblyjs/helper-numbers" "1.11.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
-
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -1980,44 +1989,20 @@
     "@webassemblyjs/helper-numbers" "1.11.1"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
 
-"@webassemblyjs/floating-point-hex-parser@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz#34d62052f453cd43101d72eab4966a022587947c"
-  integrity sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==
-
 "@webassemblyjs/floating-point-hex-parser@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
   integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
-
-"@webassemblyjs/helper-api-error@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz#aaea8fb3b923f4aaa9b512ff541b013ffb68d2d4"
-  integrity sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==
 
 "@webassemblyjs/helper-api-error@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
   integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
 
-"@webassemblyjs/helper-buffer@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz#d026c25d175e388a7dbda9694e91e743cbe9b642"
-  integrity sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==
-
 "@webassemblyjs/helper-buffer@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
   integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
-
-"@webassemblyjs/helper-numbers@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz#7ab04172d54e312cc6ea4286d7d9fa27c88cd4f9"
-  integrity sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==
-  dependencies:
-    "@webassemblyjs/floating-point-hex-parser" "1.11.0"
-    "@webassemblyjs/helper-api-error" "1.11.0"
-    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/helper-numbers@1.11.1":
   version "1.11.1"
@@ -2028,25 +2013,10 @@
     "@webassemblyjs/helper-api-error" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/helper-wasm-bytecode@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz#85fdcda4129902fe86f81abf7e7236953ec5a4e1"
-  integrity sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==
-
 "@webassemblyjs/helper-wasm-bytecode@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
   integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
-
-"@webassemblyjs/helper-wasm-section@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz#9ce2cc89300262509c801b4af113d1ca25c1a75b"
-  integrity sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.0"
-    "@webassemblyjs/helper-buffer" "1.11.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
-    "@webassemblyjs/wasm-gen" "1.11.0"
 
 "@webassemblyjs/helper-wasm-section@1.11.1":
   version "1.11.1"
@@ -2058,26 +2028,12 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
     "@webassemblyjs/wasm-gen" "1.11.1"
 
-"@webassemblyjs/ieee754@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz#46975d583f9828f5d094ac210e219441c4e6f5cf"
-  integrity sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==
-  dependencies:
-    "@xtuc/ieee754" "^1.2.0"
-
 "@webassemblyjs/ieee754@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
   integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
-
-"@webassemblyjs/leb128@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.0.tgz#f7353de1df38aa201cba9fb88b43f41f75ff403b"
-  integrity sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==
-  dependencies:
-    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/leb128@1.11.1":
   version "1.11.1"
@@ -2086,29 +2042,10 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/utf8@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.0.tgz#86e48f959cf49e0e5091f069a709b862f5a2cadf"
-  integrity sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==
-
 "@webassemblyjs/utf8@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
   integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
-
-"@webassemblyjs/wasm-edit@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz#ee4a5c9f677046a210542ae63897094c2027cb78"
-  integrity sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.0"
-    "@webassemblyjs/helper-buffer" "1.11.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
-    "@webassemblyjs/helper-wasm-section" "1.11.0"
-    "@webassemblyjs/wasm-gen" "1.11.0"
-    "@webassemblyjs/wasm-opt" "1.11.0"
-    "@webassemblyjs/wasm-parser" "1.11.0"
-    "@webassemblyjs/wast-printer" "1.11.0"
 
 "@webassemblyjs/wasm-edit@1.11.1":
   version "1.11.1"
@@ -2124,17 +2061,6 @@
     "@webassemblyjs/wasm-parser" "1.11.1"
     "@webassemblyjs/wast-printer" "1.11.1"
 
-"@webassemblyjs/wasm-gen@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz#3cdb35e70082d42a35166988dda64f24ceb97abe"
-  integrity sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
-    "@webassemblyjs/ieee754" "1.11.0"
-    "@webassemblyjs/leb128" "1.11.0"
-    "@webassemblyjs/utf8" "1.11.0"
-
 "@webassemblyjs/wasm-gen@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
@@ -2146,16 +2072,6 @@
     "@webassemblyjs/leb128" "1.11.1"
     "@webassemblyjs/utf8" "1.11.1"
 
-"@webassemblyjs/wasm-opt@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz#1638ae188137f4bb031f568a413cd24d32f92978"
-  integrity sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.0"
-    "@webassemblyjs/helper-buffer" "1.11.0"
-    "@webassemblyjs/wasm-gen" "1.11.0"
-    "@webassemblyjs/wasm-parser" "1.11.0"
-
 "@webassemblyjs/wasm-opt@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
@@ -2165,18 +2081,6 @@
     "@webassemblyjs/helper-buffer" "1.11.1"
     "@webassemblyjs/wasm-gen" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
-
-"@webassemblyjs/wasm-parser@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz#3e680b8830d5b13d1ec86cc42f38f3d4a7700754"
-  integrity sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.0"
-    "@webassemblyjs/helper-api-error" "1.11.0"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
-    "@webassemblyjs/ieee754" "1.11.0"
-    "@webassemblyjs/leb128" "1.11.0"
-    "@webassemblyjs/utf8" "1.11.0"
 
 "@webassemblyjs/wasm-parser@1.11.1":
   version "1.11.1"
@@ -2189,14 +2093,6 @@
     "@webassemblyjs/ieee754" "1.11.1"
     "@webassemblyjs/leb128" "1.11.1"
     "@webassemblyjs/utf8" "1.11.1"
-
-"@webassemblyjs/wast-printer@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz#680d1f6a5365d6d401974a8e949e05474e1fab7e"
-  integrity sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==
-  dependencies:
-    "@webassemblyjs/ast" "1.11.0"
-    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/wast-printer@1.11.1":
   version "1.11.1"
@@ -2242,6 +2138,11 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
+acorn-import-assertions@^1.7.6:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
+  integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
+
 acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
@@ -2257,17 +2158,12 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.2.1:
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.4.tgz#caba24b08185c3b56e3168e97d15ed17f4d31fd0"
-  integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
-
 acorn@^8.2.4, acorn@^8.4.1:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
   integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
 
-agent-base@6:
+agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
@@ -3240,15 +3136,15 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
-  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
-
 commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+commander@^8.2.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -3679,6 +3575,14 @@ enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
+enhanced-resolve@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
+  integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -3720,15 +3624,15 @@ es-abstract@^1.18.0-next.1:
     string.prototype.trimend "^1.0.3"
     string.prototype.trimstart "^1.0.3"
 
-es-module-lexer@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.4.0.tgz#21f4181cc8b7eee06855f1c59e6087c7bc4f77b0"
-  integrity sha512-iuEGihqqhKWFgh72Q/Jtch7V2t/ft8w8IPP2aEN8ArYKO+IWyo6hsi96hCdgyeEDQIV3InhYQ9BlwUFPGXrbEQ==
-
 es-module-lexer@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.7.1.tgz#c2c8e0f46f2df06274cdaf0dd3f3b33e0a0b267d"
   integrity sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==
+
+es-module-lexer@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
+  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -5882,10 +5786,10 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-memfs@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.2.2.tgz#5de461389d596e3f23d48bb7c2afb6161f4df40e"
-  integrity sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==
+memfs@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.3.0.tgz#4da2d1fc40a04b170a56622c7164c6be2c4cbef2"
+  integrity sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==
   dependencies:
     fs-monkey "1.0.3"
 
@@ -6054,10 +5958,10 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
-mustache@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.1.0.tgz#8c1b042238a982d2eb2d30efc6c14296ae3f699d"
-  integrity sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ==
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -6400,25 +6304,25 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-page-with@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/page-with/-/page-with-0.4.2.tgz#ee78dc05e7fd12881809b828c55f219acded9de5"
-  integrity sha512-fRzeel8bJfXFXdawmwZkbg8pK/IROnbcfp7GDoSerpcCbLQr9hW+zZURAgccG4JwCO5q+K3wdv44VBxRYTb9Dg==
+page-with@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/page-with/-/page-with-0.5.0.tgz#4c7f710699ba2ded834a0b407b0cbe93577d1d70"
+  integrity sha512-bO+Anha8YHSh+BJMHl5UbGI4Ur0R0dsJGKGWJCF1Wkb9bnOXkaDNKU63M5GaV+5bVaUh3cdDhCS7cg8gqiKB6g==
   dependencies:
     "@open-draft/until" "^1.0.3"
-    "@types/debug" "^4.1.5"
-    "@types/express" "^4.17.11"
-    "@types/mustache" "^4.1.1"
-    "@types/uuid" "^8.3.0"
-    debug "^4.3.1"
+    "@types/debug" "^4.1.7"
+    "@types/express" "^4.17.13"
+    "@types/mustache" "^4.1.2"
+    "@types/uuid" "^8.3.1"
+    debug "^4.3.2"
     express "^4.17.1"
     headers-utils "^3.0.2"
-    memfs "^3.2.2"
-    mustache "^4.1.0"
-    playwright "^1.12.1"
+    memfs "^3.3.0"
+    mustache "^4.2.0"
+    playwright "^1.16.2"
     uuid "^8.3.2"
-    webpack "^5.38.1"
-    webpack-merge "^5.7.3"
+    webpack "^5.61.0"
+    webpack-merge "^5.8.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -6560,12 +6464,12 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright@^1.12.1:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.12.2.tgz#a484447177b061dd76247734fe65d77e3fb139fa"
-  integrity sha512-tSZGeILY70T4imhCMCsvzhoaDm9baosIG5fQncSWprpjVc/X4yYdBQCLBMvOi98H50hvu9fhgy2hpsgFKCsUaw==
+playwright-core@=1.16.2:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.16.2.tgz#13c4c352a41e431ba167dbadb80e8c628e1e1b79"
+  integrity sha512-8WkoP5OfZAYrRxtW/PCVACn9bNgqrTxVVPlc+MoxvJ48knNsZ+skrPjfno/XF3SgTUY9DyYX0g5fVOB7lkPtGg==
   dependencies:
-    commander "^6.1.0"
+    commander "^8.2.0"
     debug "^4.1.1"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
@@ -6576,9 +6480,18 @@ playwright@^1.12.1:
     proper-lockfile "^4.1.1"
     proxy-from-env "^1.1.0"
     rimraf "^3.0.2"
+    socks-proxy-agent "^6.1.0"
     stack-utils "^2.0.3"
     ws "^7.4.6"
+    yauzl "^2.10.0"
     yazl "^2.5.1"
+
+playwright@^1.16.2:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.16.2.tgz#92e1c48a74cab778970facca4094ce79fb57cae4"
+  integrity sha512-lqndwy5rDIp3tOLex5lnLSrltomqxgVkRkRi547rXoTl2qy7PY2rtHbUouQl7KY2XoVSeSeECYVq/bLJ+bbJNg==
+  dependencies:
+    playwright-core "=1.16.2"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -7128,6 +7041,15 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+schema-utils@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -7197,13 +7119,6 @@ serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
-  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
@@ -7336,6 +7251,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+smart-buffer@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -7386,6 +7306,23 @@ sockjs@^0.3.21:
     faye-websocket "^0.11.3"
     uuid "^3.4.0"
     websocket-driver "^0.7.4"
+
+socks-proxy-agent@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz#869cf2d7bd10fea96c7ad3111e81726855e285c3"
+  integrity sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "^4.3.1"
+    socks "^2.6.1"
+
+socks@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
+  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
 
 source-list-map@^2.0.1:
   version "2.0.1"
@@ -7706,18 +7643,6 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz#7effadee06f7ecfa093dbbd3e9ab23f5f3ed8673"
-  integrity sha512-5XNNXZiR8YO6X6KhSGXfY0QrGrCRlSwAEjIIrlRQR4W8nP69TaJUlh3bkuac6zzgspiGPfKEHcY295MMVExl5Q==
-  dependencies:
-    jest-worker "^26.6.2"
-    p-limit "^3.1.0"
-    schema-utils "^3.0.0"
-    serialize-javascript "^5.0.1"
-    source-map "^0.6.1"
-    terser "^5.5.1"
-
 terser-webpack-plugin@^5.1.3:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz#c369cf8a47aa9922bd0d8a94fe3d3da11a7678a1"
@@ -7730,7 +7655,7 @@ terser-webpack-plugin@^5.1.3:
     source-map "^0.6.1"
     terser "^5.7.0"
 
-terser@^5.0.0, terser@^5.5.1:
+terser@^5.0.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.0.tgz#138cdf21c5e3100b1b3ddfddf720962f88badcd2"
   integrity sha512-vyqLMoqadC1uR0vywqOZzriDYzgEkNJFK4q9GeyOBHIbiECHiWLKcWfbQWAUaPfxkjDhapSlZB9f7fkMrvkVjA==
@@ -8244,10 +8169,10 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-merge@^5.7.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
-  integrity sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==
+webpack-merge@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.8.0.tgz#2b39dbf22af87776ad744c390223731d30a68f61"
+  integrity sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==
   dependencies:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
@@ -8260,34 +8185,10 @@ webpack-sources@^2.3.0:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack@^5.38.1:
-  version "5.39.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.39.1.tgz#d1e014b6d71e1aef385316ad528f21cd5b1f9784"
-  integrity sha512-ulOvoNCh2PvTUa+zbpRuEb1VPeQnhxpnHleMPVVCq3QqnaFogjsLyps+o42OviQFoaGtTQYrUqDXu1QNkvUPzw==
-  dependencies:
-    "@types/eslint-scope" "^3.7.0"
-    "@types/estree" "^0.0.47"
-    "@webassemblyjs/ast" "1.11.0"
-    "@webassemblyjs/wasm-edit" "1.11.0"
-    "@webassemblyjs/wasm-parser" "1.11.0"
-    acorn "^8.2.1"
-    browserslist "^4.14.5"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.0"
-    es-module-lexer "^0.4.0"
-    eslint-scope "5.1.1"
-    events "^3.2.0"
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.4"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^4.2.0"
-    mime-types "^2.1.27"
-    neo-async "^2.6.2"
-    schema-utils "^3.0.0"
-    tapable "^2.1.1"
-    terser-webpack-plugin "^5.1.1"
-    watchpack "^2.2.0"
-    webpack-sources "^2.3.0"
+webpack-sources@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.1.tgz#251a7d9720d75ada1469ca07dbb62f3641a05b6d"
+  integrity sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==
 
 webpack@^5.44.0:
   version "5.44.0"
@@ -8317,6 +8218,36 @@ webpack@^5.44.0:
     terser-webpack-plugin "^5.1.3"
     watchpack "^2.2.0"
     webpack-sources "^2.3.0"
+
+webpack@^5.61.0:
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.61.0.tgz#fa827f0ee9bdfd141dd73c3e891e955ebd52fe7f"
+  integrity sha512-fPdTuaYZ/GMGFm4WrPi2KRCqS1vDp773kj9S0iI5Uc//5cszsFEDgHNaX4Rj1vobUiU1dFIV3mA9k1eHeluFpw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.50"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.3"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.2.0"
+    webpack-sources "^3.2.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"


### PR DESCRIPTION
- Resolves recent test failures on the latest MacOS. 
- Migrates from `res.headers()` to `res.allHeaders()` in `playwright` (deprecated). 