### PR TITLE
fix: add missing debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "chalk": "^4.1.1",
     "chokidar": "^3.4.2",
     "cookie": "^0.4.1",
+    "debug": "^4.3.2",
     "graphql": "^15.5.1",
     "headers-utils": "^3.0.2",
     "inquirer": "^8.1.5",


### PR DESCRIPTION
`debug` is required in `msw` via the rollup config, but it not declared as a dependency. Strict node linkers like pnp and pnpm throw errors when building a project with `msw` as it cannot access the `debug` package.