### PR TITLE
fix(rest): support ReadableStream as response body

### DIFF
--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -78,6 +78,9 @@ export type ServiceWorkerOutgoingEventTypes =
  */
 export type ServiceWorkerFetchEventTypes =
   | 'MOCK_SUCCESS'
+  | 'MOCK_STREAM_START'
+  | 'MOCK_STREAM_CHUNK'
+  | 'MOCK_STREAM_END'
   | 'MOCK_NOT_FOUND'
   | 'NETWORK_ERROR'
   | 'INTERNAL_ERROR'

--- a/test/rest-api/response/body/body-stream.mocks.ts
+++ b/test/rest-api/response/body/body-stream.mocks.ts
@@ -1,0 +1,24 @@
+import { setupWorker, rest } from 'msw'
+
+const stream = new ReadableStream({
+  start(controller) {
+    controller.enqueue('line1\n')
+
+    setTimeout(() => {
+      controller.enqueue('line2\n')
+      controller.close()
+    }, 0)
+  },
+})
+
+const worker = setupWorker(
+  rest.get('/sse', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.set('Content-Type', 'text/plain'),
+      ctx.body(stream),
+    )
+  }),
+)
+
+worker.start()

--- a/test/rest-api/response/body/body-stream.node.test.ts
+++ b/test/rest-api/response/body/body-stream.node.test.ts
@@ -1,0 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
+test('Node does not support ReadableStream yet', () => {
+  expect(typeof ReadableStream).toBe('undefined')
+})

--- a/test/rest-api/response/body/body-stream.test.ts
+++ b/test/rest-api/response/body/body-stream.test.ts
@@ -1,0 +1,17 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+
+test('responds with a ReadableStream response body', async () => {
+  const { request } = await pageWith({
+    example: path.resolve(__dirname, 'body-stream.mocks.ts'),
+  })
+
+  const res = await request('/sse')
+  const status = res.status()
+  const headers = await res.allHeaders()
+  const text = await res.text()
+
+  expect(status).toBe(200)
+  expect(headers['content-type']).toBe('text/plain')
+  expect(text).toBe('line1\nline2\n')
+})


### PR DESCRIPTION
Fixes #581 .. but in a totally hacky* way and only tested with a stream of string chunks.

If improvements are needed before merge, please feel free to edit the PR or close it and just take inspiration for some better solution 😅  But I'm afraid I won't have more time until next weekend.

*hacky => original code counts that there will be only 1 message from client, and that will resolve a Promise... but when multiple messages come back, only one of them can resolve a promise - but even after the Promise is resolved, the onmessage handler lives inside the closure of a new Promise function, so it's a bit unexpected that we can handle multiple messages there even AFTER the Promise is resolved