### PR TITLE
fix: no-unused-vars lint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,11 @@ module.exports = {
     ],
     '@typescript-eslint/no-namespace': 0,
     '@typescript-eslint/no-var-requires': 0,
+    '@typescript-eslint/no-unused-vars': [
+      1,
+      {
+        argsIgnorePattern: '^_',
+      },
+    ],
   },
 }

--- a/test/msw-api/setup-server/scenarios/custom-transformers.test.ts
+++ b/test/msw-api/setup-server/scenarios/custom-transformers.test.ts
@@ -11,7 +11,7 @@ const jsonBig = (body: Record<string, any>): ResponseTransformer => {
 }
 
 const server = setupServer(
-  rest.get('http://test.mswjs.io/me', (req, res, ctx) => {
+  rest.get('http://test.mswjs.io/me', (req, res) => {
     return res(
       jsonBig({
         username: 'john.maverick',

--- a/test/msw-api/setup-worker/scenarios/custom-transformers.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/custom-transformers.mocks.ts
@@ -9,7 +9,7 @@ const jsonBig = (body: Record<string, any>): ResponseTransformer => {
 }
 
 const worker = setupWorker(
-  rest.get('/user', (req, res, ctx) => {
+  rest.get('/user', (req, res) => {
     return res(
       jsonBig({
         username: 'john.maverick',

--- a/test/msw-api/setup-worker/scenarios/errors/network-error.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/errors/network-error.mocks.ts
@@ -1,7 +1,7 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.get('/user', (req, res, ctx) => {
+  rest.get('/user', (req, res) => {
     return res.networkError('Custom network error message')
   }),
 )

--- a/test/msw-api/setup-worker/scenarios/text-event-stream.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/text-event-stream.mocks.ts
@@ -1,7 +1,7 @@
 import { setupWorker, rest } from 'msw'
 
 const worker = setupWorker(
-  rest.get('/user', (req, res, ctx) => {
+  rest.get('/user', (req, res) => {
     return res()
   }),
 )

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -22,7 +22,7 @@ rest.get<{ userId: string }, { postCount: number }>(
   },
 )
 
-rest.get<any, any, { userId: string }>('/user/:userId', (req, res, ctx) => {
+rest.get<any, any, { userId: string }>('/user/:userId', (req) => {
   req.params.userId
 
   // @ts-expect-error `unknown` is not defined in the request params type.


### PR DESCRIPTION
Ignore all variables start with `_`.

Before:

<img width="725" alt="截圖 2021-11-11 下午12 31 19" src="https://user-images.githubusercontent.com/3382565/141238210-09b04ac6-371d-42b0-a13a-55270820470f.png">

After:

<img width="311" alt="截圖 2021-11-11 下午12 36 32" src="https://user-images.githubusercontent.com/3382565/141238192-6499da37-3c36-4ab7-92df-def233580b5d.png">
