### PR TITLE
fix(getAbsoluteUrl): fix full url check

### DIFF
--- a/src/utils/matching/normalizePath.test.ts
+++ b/src/utils/matching/normalizePath.test.ts
@@ -39,10 +39,12 @@ test('removes query parameters and hashes from a relative URL', () => {
 })
 
 test('returns a path pattern string as-is', () => {
-  expect(normalizePath(':api/user')).toEqual(':api/user')
+  expect(normalizePath(':api/user')).toEqual('http://localhost/:api/user')
   expect(normalizePath('*/resource/*')).toEqual('*/resource/*')
 })
 
 test('removeß query parameters and hashes from a path pattern string', () => {
-  expect(normalizePath(':api/user?query=123#some')).toEqual(':api/user')
+  expect(normalizePath(':api/user?query=123#some')).toEqual(
+    'http://localhost/:api/user',
+  )
 })

--- a/src/utils/url/getAbsoluteUrl.test.ts
+++ b/src/utils/url/getAbsoluteUrl.test.ts
@@ -24,6 +24,6 @@ test('returns an absolute URL given a relative path without a leading slash', ()
 })
 
 test('returns a path with a pattern as-is', () => {
-  expect(getAbsoluteUrl(':api/user')).toEqual(':api/user')
+  expect(getAbsoluteUrl(':api/user')).toEqual('http://localhost/:api/user')
   expect(getAbsoluteUrl('*/resource/*')).toEqual('*/resource/*')
 })

--- a/src/utils/url/getAbsoluteUrl.test.ts
+++ b/src/utils/url/getAbsoluteUrl.test.ts
@@ -18,3 +18,12 @@ test('returns a given absolute URL as-is', () => {
     'https://api.mswjs.io/users',
   )
 })
+
+test('returns an absolute URL given a relative path without a leading slash', () => {
+  expect(getAbsoluteUrl('users')).toEqual('http://localhost/users')
+})
+
+test('returns a path with a pattern as-is', () => {
+  expect(getAbsoluteUrl(':api/user')).toEqual(':api/user')
+  expect(getAbsoluteUrl('*/resource/*')).toEqual('*/resource/*')
+})

--- a/src/utils/url/getAbsoluteUrl.ts
+++ b/src/utils/url/getAbsoluteUrl.ts
@@ -9,8 +9,8 @@ export function getAbsoluteUrl(path: string, baseUrl?: string): string {
     return path
   }
 
-  // Ignore path with pattern start with :*
-  if (/^[:*]/.test(path)) {
+  // Ignore path with pattern start with *
+  if (path.startsWith('*')) {
     return path
   }
 

--- a/src/utils/url/getAbsoluteUrl.ts
+++ b/src/utils/url/getAbsoluteUrl.ts
@@ -1,9 +1,16 @@
+import { isAbsoluteUrl } from './isAbsoluteUrl'
+
 /**
  * Returns an absolute URL based on the given path.
  */
 export function getAbsoluteUrl(path: string, baseUrl?: string): string {
-  // Ignore absolute URLs.
-  if (!path.startsWith('/')) {
+  // already absolute URL
+  if (isAbsoluteUrl(path)) {
+    return path
+  }
+
+  // Ignore path with pattern start with :*
+  if (/^[:*]/.test(path)) {
     return path
   }
 

--- a/src/utils/url/isAbsoluteUrl.test.ts
+++ b/src/utils/url/isAbsoluteUrl.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment node
+ */
+import { isAbsoluteUrl } from './isAbsoluteUrl'
+
+test('returns true for the "http" scheme', () => {
+  expect(isAbsoluteUrl('http://www.domain.com')).toEqual(true)
+})
+
+test('returns true for the "https" scheme', () => {
+  expect(isAbsoluteUrl('https://www.domain.com')).toEqual(true)
+})
+
+test('returns true for the "ws" scheme', () => {
+  expect(isAbsoluteUrl('ws://www.domain.com')).toEqual(true)
+})
+
+test('returns true for the "ftp" scheme', () => {
+  expect(isAbsoluteUrl('ftp://www.domain.com')).toEqual(true)
+})
+
+test('returns true for the custom scheme', () => {
+  expect(isAbsoluteUrl('web+my://www.example.com')).toEqual(true)
+})
+
+test('returns false for the relative URL', () => {
+  expect(isAbsoluteUrl('/test')).toEqual(false)
+})
+
+test('returns false for the relative URL without a leading slash', () => {
+  expect(isAbsoluteUrl('test')).toEqual(false)
+})

--- a/src/utils/url/isAbsoluteUrl.ts
+++ b/src/utils/url/isAbsoluteUrl.ts
@@ -1,0 +1,6 @@
+/**
+ * Determines if the given URL string is an absolute URL.
+ */
+export function isAbsoluteUrl(url: string): boolean {
+  return /^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(url)
+}


### PR DESCRIPTION
Fix absolute url check.

## Changes

- Adds a new `isAbsoluteUrl` function that determines if the given URL is absolute. 
- Replaces a simple `.startsWith('/')` logic in `getAbsoluteUrl` to use `isAbsoluteUrl`.
- Supports `api/xyz` paths to convert to `http://domain/api/xyz`
