### PR TITLE
feat: export Worker and Server api options type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ import * as context from './context'
 export { context }
 
 export { setupWorker } from './setupWorker/setupWorker'
-export { SetupWorkerApi } from './setupWorker/glossary'
+export type {
+  SetupWorkerApi,
+  PartialStartOptions,
+} from './setupWorker/glossary'
+export type { SharedOptions } from './sharedOptions'
 export {
   response,
   defaultResponse,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,42 @@ import * as context from './context'
 export { context }
 
 export { setupWorker } from './setupWorker/setupWorker'
-export type { SetupWorkerApi, StartOptions } from './setupWorker/glossary'
-export type { SharedOptions } from './sharedOptions'
 export {
   response,
   defaultResponse,
   createResponseComposition,
+} from './response'
+
+/* Request handlers */
+export { RequestHandler, defaultContext } from './handlers/RequestHandler'
+export { rest } from './rest'
+export { RestHandler, RESTMethods, restContext } from './handlers/RestHandler'
+export { graphql } from './graphql'
+export { GraphQLHandler, graphqlContext } from './handlers/GraphQLHandler'
+
+/* Utils */
+export { matchRequestUrl } from './utils/matching/matchRequestUrl'
+export { compose } from './utils/internal/compose'
+export * from './utils/handleRequest'
+export * from './utils/request/parseIsomorphicRequest'
+export { cleanUrl } from './utils/url/cleanUrl'
+
+/**
+ * Type definitions.
+ */
+export type { SetupWorkerApi, StartOptions } from './setupWorker/glossary'
+export type { SharedOptions } from './sharedOptions'
+
+export type {
+  MockedRequest,
+  ResponseResolver,
+  ResponseResolverReturnType,
+  AsyncResponseResolverReturnType,
+  DefaultRequestBody,
+  DefaultRequestMultipartBody,
+} from './handlers/RequestHandler'
+
+export type {
   MockedResponse,
   ResponseTransformer,
   ResponseComposition,
@@ -15,48 +45,21 @@ export {
   ResponseFunction,
 } from './response'
 
-/* Request handlers */
-export {
-  RequestHandler,
-  MockedRequest,
-  ResponseResolver,
-  ResponseResolverReturnType,
-  AsyncResponseResolverReturnType,
-  DefaultRequestBody,
-  DefaultRequestMultipartBody,
-  defaultContext,
-} from './handlers/RequestHandler'
-export { rest } from './rest'
-export {
-  RestHandler,
-  RESTMethods,
+export type {
   RestContext,
   RequestQuery,
   RestRequest,
   ParsedRestRequest,
-  restContext,
 } from './handlers/RestHandler'
-export { graphql } from './graphql'
-export {
-  GraphQLHandler,
+
+export type {
   GraphQLContext,
   GraphQLVariables,
   GraphQLRequest,
   GraphQLRequestBody,
   GraphQLJsonRequestBody,
-  graphqlContext,
 } from './handlers/GraphQLHandler'
 
-/* Utils */
-export {
-  Path,
-  PathParams,
-  Match,
-  matchRequestUrl,
-} from './utils/matching/matchRequestUrl'
-export { compose } from './utils/internal/compose'
-export { DelayMode } from './context/delay'
+export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
+export type { DelayMode } from './context/delay'
 export { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'
-export * from './utils/handleRequest'
-export * from './utils/request/parseIsomorphicRequest'
-export { cleanUrl } from './utils/url/cleanUrl'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,7 @@ import * as context from './context'
 export { context }
 
 export { setupWorker } from './setupWorker/setupWorker'
-export type {
-  SetupWorkerApi,
-  PartialStartOptions,
-} from './setupWorker/glossary'
+export type { SetupWorkerApi, StartOptions } from './setupWorker/glossary'
 export type { SharedOptions } from './sharedOptions'
 export {
   response,

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -15,8 +15,9 @@ import { handleRequest } from '../utils/handleRequest'
 import { mergeRight } from '../utils/internal/mergeRight'
 import { devUtils } from '../utils/internal/devUtils'
 import { pipeEvents } from '../utils/internal/pipeEvents'
+import { RequiredDeep } from '../typeUtils'
 
-const DEFAULT_LISTEN_OPTIONS: SharedOptions = {
+const DEFAULT_LISTEN_OPTIONS: RequiredDeep<SharedOptions> = {
   onUnhandledRequest: 'warn',
 }
 
@@ -54,7 +55,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
       )
     }
 
-    let resolvedOptions = {} as SharedOptions
+    let resolvedOptions = {} as RequiredDeep<SharedOptions>
 
     const interceptor = createInterceptor({
       modules: interceptors,
@@ -98,7 +99,7 @@ export function createSetupServer(...interceptors: Interceptor[]) {
         resolvedOptions = mergeRight(
           DEFAULT_LISTEN_OPTIONS,
           options || {},
-        ) as SharedOptions
+        ) as RequiredDeep<SharedOptions>
         interceptor.apply()
       },
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,2 +1,2 @@
 export { setupServer } from './setupServer'
-export { SetupServerApi } from './glossary'
+export type { SetupServerApi } from './glossary'

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -1,4 +1,3 @@
-import { PartialDeep } from 'type-fest'
 import { FlatHeadersObject } from 'headers-utils'
 import { StrictEventEmitter } from 'strict-event-emitter'
 import {
@@ -10,6 +9,7 @@ import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
 import { RequestHandler } from '../handlers/RequestHandler'
 import { InterceptorApi } from '@mswjs/interceptors'
 import { Path } from '../utils/matching/matchRequestUrl'
+import { RequiredDeep } from '../typeUtils'
 
 export type ResolvedPath = Path | URL
 
@@ -85,7 +85,7 @@ export type ServiceWorkerFetchEventTypes =
 export type WorkerLifecycleEventsMap = LifeCycleEventsMap<Response>
 
 export interface SetupWorkerInternalContext {
-  startOptions?: StartOptions
+  startOptions?: RequiredDeep<StartOptions>
   worker: ServiceWorker | null
   registration: ServiceWorkerRegistration | null
   requestHandlers: RequestHandler[]
@@ -150,28 +150,28 @@ export interface StartOptions extends SharedOptions {
   /**
    * Service Worker instance options.
    */
-  serviceWorker: {
-    url: string
-    options: RegistrationOptions
+  serviceWorker?: {
+    url?: string
+    options?: RegistrationOptions
   }
 
   /**
    * Disables the logging of captured requests
    * into browser's console.
    */
-  quiet: boolean
+  quiet?: boolean
 
   /**
    * Defers any network requests until the Service Worker
    * instance is ready. Defaults to `true`.
    */
-  waitUntilReady: boolean
+  waitUntilReady?: boolean
 
   /**
    * A custom lookup function to find a Mock Service Worker in the list
    * of all registered Service Workers on the page.
    */
-  findWorker: FindWorker
+  findWorker?: FindWorker
 }
 
 export interface SerializedResponse<BodyType = any> {
@@ -181,11 +181,10 @@ export interface SerializedResponse<BodyType = any> {
   body: BodyType
 }
 
-export type PartialStartOptions = PartialDeep<StartOptions>
 export type StartReturnType = Promise<ServiceWorkerRegistration | undefined>
 export type StartHandler = (
-  options: StartOptions,
-  initialOptions: PartialStartOptions,
+  options: RequiredDeep<StartOptions>,
+  initialOptions: StartOptions,
 ) => StartReturnType
 export type StopHandler = () => void
 
@@ -194,7 +193,7 @@ export interface SetupWorkerApi {
    * Registers and activates the mock Service Worker.
    * @see {@link https://mswjs.io/docs/api/setup-worker/start `worker.start()`}
    */
-  start: (options?: PartialStartOptions) => StartReturnType
+  start: (options?: StartOptions) => StartReturnType
 
   /**
    * Stops requests interception for the current client.

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -181,10 +181,11 @@ export interface SerializedResponse<BodyType = any> {
   body: BodyType
 }
 
+export type PartialStartOptions = PartialDeep<StartOptions>
 export type StartReturnType = Promise<ServiceWorkerRegistration | undefined>
 export type StartHandler = (
   options: StartOptions,
-  initialOptions: PartialDeep<StartOptions>,
+  initialOptions: PartialStartOptions,
 ) => StartReturnType
 export type StopHandler = () => void
 
@@ -193,7 +194,7 @@ export interface SetupWorkerApi {
    * Registers and activates the mock Service Worker.
    * @see {@link https://mswjs.io/docs/api/setup-worker/start `worker.start()`}
    */
-  start: (options?: PartialDeep<StartOptions>) => StartReturnType
+  start: (options?: PartialStartOptions) => StartReturnType
 
   /**
    * Stops requests interception for the current client.

--- a/src/setupWorker/start/utils/prepareStartHandler.test.ts
+++ b/src/setupWorker/start/utils/prepareStartHandler.test.ts
@@ -1,5 +1,4 @@
-import { PartialDeep } from 'type-fest'
-import { SetupWorkerInternalContext, StartOptions } from '../../glossary'
+import { SetupWorkerInternalContext, PartialStartOptions } from '../../glossary'
 import {
   DEFAULT_START_OPTIONS,
   resolveStartOptions,
@@ -39,7 +38,7 @@ describe('prepareStartHandler', () => {
     const startHandler = prepareStartHandler(createStartHandler, context)
     expect(startHandler).toBeInstanceOf(Function)
 
-    const initialOptions: PartialDeep<StartOptions> = {
+    const initialOptions: PartialStartOptions = {
       quiet: true,
       serviceWorker: {
         url: './custom.js',

--- a/src/setupWorker/start/utils/prepareStartHandler.test.ts
+++ b/src/setupWorker/start/utils/prepareStartHandler.test.ts
@@ -1,4 +1,4 @@
-import { SetupWorkerInternalContext, PartialStartOptions } from '../../glossary'
+import { SetupWorkerInternalContext, StartOptions } from '../../glossary'
 import {
   DEFAULT_START_OPTIONS,
   resolveStartOptions,
@@ -38,7 +38,7 @@ describe('prepareStartHandler', () => {
     const startHandler = prepareStartHandler(createStartHandler, context)
     expect(startHandler).toBeInstanceOf(Function)
 
-    const initialOptions: PartialStartOptions = {
+    const initialOptions: StartOptions = {
       quiet: true,
       serviceWorker: {
         url: './custom.js',

--- a/src/setupWorker/start/utils/prepareStartHandler.ts
+++ b/src/setupWorker/start/utils/prepareStartHandler.ts
@@ -1,13 +1,13 @@
+import { RequiredDeep } from '../../../typeUtils'
 import { mergeRight } from '../../../utils/internal/mergeRight'
 import {
   SetupWorkerApi,
   SetupWorkerInternalContext,
   StartHandler,
   StartOptions,
-  PartialStartOptions,
 } from '../../glossary'
 
-export const DEFAULT_START_OPTIONS: StartOptions = {
+export const DEFAULT_START_OPTIONS: RequiredDeep<StartOptions> = {
   serviceWorker: {
     url: '/mockServiceWorker.js',
     options: null as any,
@@ -25,9 +25,12 @@ export const DEFAULT_START_OPTIONS: StartOptions = {
  * with the given custom options.
  */
 export function resolveStartOptions(
-  initialOptions?: PartialStartOptions,
-): StartOptions {
-  return mergeRight(DEFAULT_START_OPTIONS, initialOptions || {}) as StartOptions
+  initialOptions?: StartOptions,
+): RequiredDeep<StartOptions> {
+  return mergeRight(
+    DEFAULT_START_OPTIONS,
+    initialOptions || {},
+  ) as RequiredDeep<StartOptions>
 }
 
 export function prepareStartHandler(

--- a/src/setupWorker/start/utils/prepareStartHandler.ts
+++ b/src/setupWorker/start/utils/prepareStartHandler.ts
@@ -1,10 +1,10 @@
-import { PartialDeep } from 'type-fest'
 import { mergeRight } from '../../../utils/internal/mergeRight'
 import {
   SetupWorkerApi,
   SetupWorkerInternalContext,
   StartHandler,
   StartOptions,
+  PartialStartOptions,
 } from '../../glossary'
 
 export const DEFAULT_START_OPTIONS: StartOptions = {
@@ -25,7 +25,7 @@ export const DEFAULT_START_OPTIONS: StartOptions = {
  * with the given custom options.
  */
 export function resolveStartOptions(
-  initialOptions?: PartialDeep<StartOptions>,
+  initialOptions?: PartialStartOptions,
 ): StartOptions {
   return mergeRight(DEFAULT_START_OPTIONS, initialOptions || {}) as StartOptions
 }

--- a/src/sharedOptions.ts
+++ b/src/sharedOptions.ts
@@ -11,7 +11,7 @@ export interface SharedOptions {
    * @example worker.start({ onUnhandledRequest: 'warn' })
    * @example server.listen({ onUnhandledRequest: 'error' })
    */
-  onUnhandledRequest: UnhandledRequestStrategy
+  onUnhandledRequest?: UnhandledRequestStrategy
 }
 
 export interface LifeCycleEventsMap<ResponseType> {

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -2,16 +2,22 @@ import { ResponseTransformer } from './response'
 
 type Fn = (...arg: any[]) => any
 
-export type DeepRequired<
-  T,
-  U extends Record<string, any> | Fn | undefined = undefined,
-> = T extends Record<string, any>
+export type RequiredDeep<
+  Type,
+  U extends Record<string, unknown> | Fn | undefined = undefined,
+> = Type extends Fn
+  ? Type
+  : /**
+   * @note The "Fn" type satisfies the predicate below.
+   * It must always come first, before the Record check.
+   */
+  Type extends Record<string, any>
   ? {
-      [P in keyof T]-?: NonNullable<T[P]> extends NonNullable<U | Fn>
-        ? NonNullable<T[P]>
-        : DeepRequired<NonNullable<T[P]>, U>
+      [Key in keyof Type]-?: NonNullable<Type[Key]> extends NonNullable<U>
+        ? NonNullable<Type[Key]>
+        : RequiredDeep<NonNullable<Type[Key]>, U>
     }
-  : T
+  : Type
 
 export type GraphQLPayloadContext<QueryType extends Record<string, unknown>> = (
   payload: QueryType,

--- a/src/utils/handleRequest.test.ts
+++ b/src/utils/handleRequest.test.ts
@@ -8,6 +8,7 @@ import { rest } from '../rest'
 import { handleRequest } from './handleRequest'
 import { response } from '../response'
 import { context } from '..'
+import { RequiredDeep } from '../typeUtils'
 
 const emitter = new StrictEventEmitter<ServerLifecycleEventsMap>()
 const listener = jest.fn()
@@ -20,7 +21,7 @@ function getEmittedEvents() {
   return listener.mock.calls
 }
 
-const options: SharedOptions = {
+const options: RequiredDeep<SharedOptions> = {
   onUnhandledRequest: jest.fn(),
 }
 const callbacks = {

--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -3,7 +3,7 @@ import { MockedRequest, RequestHandler } from '../handlers/RequestHandler'
 import { ServerLifecycleEventsMap } from '../node/glossary'
 import { MockedResponse } from '../response'
 import { SharedOptions } from '../sharedOptions'
-import { DeepRequired } from '../typeUtils'
+import { RequiredDeep } from '../typeUtils'
 import { ResponseLookupResult, getResponse } from './getResponse'
 import { devUtils } from './internal/devUtils'
 import { onUnhandledRequest } from './request/onUnhandledRequest'
@@ -33,7 +33,7 @@ export interface HandleRequestOptions<ResponseType> {
    */
   onMockedResponse?(
     response: ResponseType,
-    handler: DeepRequired<ResponseLookupResult>,
+    handler: RequiredDeep<ResponseLookupResult>,
   ): void
 
   /**
@@ -42,7 +42,7 @@ export interface HandleRequestOptions<ResponseType> {
    */
   onMockedResponseSent?(
     response: ResponseType,
-    handler: DeepRequired<ResponseLookupResult>,
+    handler: RequiredDeep<ResponseLookupResult>,
   ): void
 }
 
@@ -51,7 +51,7 @@ export async function handleRequest<
 >(
   request: MockedRequest,
   handlers: RequestHandler[],
-  options: SharedOptions,
+  options: RequiredDeep<SharedOptions>,
   emitter: StrictEventEmitter<ServerLifecycleEventsMap>,
   handleRequestOptions?: HandleRequestOptions<ResponseType>,
 ): Promise<ResponseType | undefined> {
@@ -109,7 +109,7 @@ Expected response resolver to return a mocked response Object, but got %s. The o
 
   return new Promise((resolve) => {
     const requiredLookupResult =
-      lookupResult as DeepRequired<ResponseLookupResult>
+      lookupResult as RequiredDeep<ResponseLookupResult>
     const transformedResponse =
       handleRequestOptions?.transformResponse?.(response) ||
       (response as any as ResponseType)

--- a/src/utils/worker/createFallbackRequestListener.ts
+++ b/src/utils/worker/createFallbackRequestListener.ts
@@ -7,12 +7,13 @@ import {
   SetupWorkerInternalContext,
   StartOptions,
 } from '../../setupWorker/glossary'
+import { RequiredDeep } from '../../typeUtils'
 import { handleRequest } from '../handleRequest'
 import { parseIsomorphicRequest } from '../request/parseIsomorphicRequest'
 
 export function createFallbackRequestListener(
   context: SetupWorkerInternalContext,
-  options: StartOptions,
+  options: RequiredDeep<StartOptions>,
 ): InterceptorApi {
   const interceptor = createInterceptor({
     modules: [interceptFetch, interceptXMLHttpRequest],

--- a/src/utils/worker/createRequestListener.ts
+++ b/src/utils/worker/createRequestListener.ts
@@ -12,10 +12,11 @@ import { NetworkError } from '../NetworkError'
 import { parseWorkerRequest } from '../request/parseWorkerRequest'
 import { handleRequest } from '../handleRequest'
 import { RequestHandler } from '../../handlers/RequestHandler'
+import { RequiredDeep } from '../../typeUtils'
 
 export const createRequestListener = (
   context: SetupWorkerInternalContext,
-  options: StartOptions,
+  options: RequiredDeep<StartOptions>,
 ) => {
   return async (
     event: MessageEvent,


### PR DESCRIPTION
As part of the work done in the [Storybook addon for MSW](https://github.com/mswjs/msw-storybook-addon/pull/61), we need certain types which are not exported directly from MSW.

This PR exports the options used both in `worker.start` and `server.listen`.

## Roadmap

- [x] Export `SetupServerApi` interface