### PR TITLE
fix(RestHandler): set default "req.params" to ambiguous type

### DIFF
--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -75,17 +75,17 @@ export const restContext: RestContext = {
   fetch,
 }
 
-export type RequestParams = {
-  [paramName: string]: any
-}
+// Preserving for backwards-compatibility.
+// "RequestParams" must not be used in the source.
+export type RequestParams = PathParams
 
 export type RequestQuery = {
-  [queryName: string]: any
+  [queryName: string]: string
 }
 
 export interface RestRequest<
   BodyType extends DefaultRequestBody = DefaultRequestBody,
-  ParamsType extends RequestParams = PathParams,
+  ParamsType extends PathParams = PathParams,
 > extends MockedRequest<BodyType> {
   params: ParamsType
 }
@@ -102,7 +102,12 @@ export class RestHandler<
   RestHandlerInfo,
   RequestType,
   ParsedRestRequest,
-  RestRequest<RequestParams>
+  RestRequest<
+    RequestType extends MockedRequest<infer RequestBodyType>
+      ? RequestBodyType
+      : any,
+    PathParams
+  >
 > {
   constructor(
     method: RestHandlerMethod,
@@ -159,7 +164,7 @@ export class RestHandler<
   protected getPublicRequest(
     request: RequestType,
     parsedResult: ParsedRestRequest,
-  ): RestRequest<any, RequestParams> {
+  ): RestRequest<any, PathParams> {
     return {
       ...request,
       params: parsedResult.params || {},

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -75,10 +75,6 @@ export const restContext: RestContext = {
   fetch,
 }
 
-// Preserving for backwards-compatibility.
-// "RequestParams" must not be used in the source.
-export type RequestParams = PathParams
-
 export type RequestQuery = {
   [queryName: string]: string
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ export {
   RestHandler,
   RESTMethods,
   RestContext,
-  RequestParams,
   RequestQuery,
   RestRequest,
   ParsedRestRequest,

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -4,15 +4,14 @@ import {
   RestContext,
   RestHandler,
   RestRequest,
-  RequestParams,
 } from './handlers/RestHandler'
-import { Path } from './utils/matching/matchRequestUrl'
+import { Path, PathParams } from './utils/matching/matchRequestUrl'
 
 function createRestHandler(method: RESTMethods | RegExp) {
   return <
     RequestBodyType extends DefaultRequestBody = DefaultRequestBody,
-    ResponseBody extends DefaultRequestBody = any,
-    Params extends RequestParams = RequestParams,
+    Params extends PathParams = PathParams,
+    ResponseBody extends DefaultRequestBody = DefaultRequestBody,
   >(
     path: Path,
     resolver: ResponseResolver<

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -3,8 +3,8 @@ import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
 import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp
-
 export type PathParams = Record<string, string | string[]>
+
 export interface Match {
   matches: boolean
   params?: PathParams

--- a/test/rest-api/params.mocks.ts
+++ b/test/rest-api/params.mocks.ts
@@ -5,13 +5,13 @@ interface ResponseType {
   messageId: string
 }
 
-interface RequestParams {
+type RequestParams = {
   username: string
   messageId: string
 }
 
 const worker = setupWorker(
-  rest.get<any, ResponseType, RequestParams>(
+  rest.get<never, RequestParams, ResponseType>(
     'https://api.github.com/users/:username/messages/:messageId',
     (req, res, ctx) => {
       const { username, messageId } = req.params

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -1,6 +1,6 @@
 import { rest } from 'msw'
 
-rest.get<{ userId: string }, { postCount: number }>(
+rest.get<{ userId: string }, never, { postCount: number }>(
   '/user',
   (req, res, ctx) => {
     req.body.userId
@@ -22,7 +22,7 @@ rest.get<{ userId: string }, { postCount: number }>(
   },
 )
 
-rest.get<any, any, { userId: string }>('/user/:userId', (req) => {
+rest.get<never, { userId: string }>('/user/:userId', (req) => {
   req.params.userId
 
   // @ts-expect-error `unknown` is not defined in the request params type.
@@ -38,12 +38,31 @@ rest.get<
   null
 >('/user', () => null)
 
-rest.get<any, { label: boolean }>('/user', (req, res, ctx) =>
+rest.get<never, never, { label: boolean }>('/user', (req, res, ctx) =>
   // allow ResponseTransformer to contain a more specific type
   res(ctx.json({ label: true })),
 )
 
-rest.get<any, string | string[]>('/user', (req, res, ctx) =>
+rest.get<never, never, string | string[]>('/user', (req, res, ctx) =>
   // allow ResponseTransformer to return a narrower type than a given union
   res(ctx.json('hello')),
 )
+
+rest.get<never>('/user/:id', (req, res, ctx) => {
+  const { userId } = req.params
+
+  return res(
+    ctx.body(
+      // @ts-expect-error "userId" parameter is not annotated
+      // and is ambiguous (string | string[]).
+      userId,
+    ),
+  )
+})
+
+rest.get<
+  never,
+  // @ts-expect-error Path parameters are always strings.
+  // Parse them to numbers in the resolver if necessary.
+  { id: number }
+>('/posts/:id', () => null)


### PR DESCRIPTION
## Breaking changes

- Move the `Params` generic of `rest` handlers to be the _second_ one:
```diff
- rest.get<RequestBodyType, ResponseBodyType, RequestParameters>
+ rest.get<RequestBodyType, RequestParameters, ResponseBodyType>
```
- Removes the `RequestParams` type. Use `PathParams` type instead. 
- Sets the `ResponseBody` generic of `rest` handlers to `DefaultRequestBody` by default. 

## Motivation

Request path parameters that do not have an explicit generic type must have a default ambiguous type of `string | string[]`. Previously `any`.

```ts
rest.get('/user/:id', (req, res, ctx) => {
  const id = req.params.id // string | string[]
})
```

Request path parameter may also be an array of strings in the case of the path including multiple parameters with the same name:

```ts
rest.get('/user/:id/message/:id', (req, res, ctx) => {
  const id = req.params.id // ["a", "b"] given /user/a/message/b
})
```

Until the consumer provides the explicit parameters type generic to `rest.get` (or any other `rest` handler), the library should treat path parameters as ambiguous. 
