### PR TITLE
fix(rest): annotate "req.body" as never for HEAD/GET requests

### DIFF
--- a/src/rest.ts
+++ b/src/rest.ts
@@ -7,7 +7,9 @@ import {
 } from './handlers/RestHandler'
 import { Path, PathParams } from './utils/matching/matchRequestUrl'
 
-function createRestHandler(method: RESTMethods | RegExp) {
+function createRestHandler<Method extends RESTMethods | RegExp>(
+  method: Method,
+) {
   return <
     RequestBodyType extends DefaultRequestBody = DefaultRequestBody,
     Params extends PathParams = PathParams,
@@ -15,7 +17,12 @@ function createRestHandler(method: RESTMethods | RegExp) {
   >(
     path: Path,
     resolver: ResponseResolver<
-      RestRequest<RequestBodyType, Params>,
+      RestRequest<
+        Method extends RESTMethods.HEAD | RESTMethods.GET
+          ? never
+          : RequestBodyType,
+        Params
+      >,
       RestContext,
       ResponseBody
     >,

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -1,26 +1,21 @@
 import { rest } from 'msw'
 
-rest.get<{ userId: string }, never, { postCount: number }>(
-  '/user',
-  (req, res, ctx) => {
-    req.body.userId
+rest.get<never, never, { postCount: number }>('/user', (req, res, ctx) => {
+  // @ts-expect-error `session` property is not defined on the request body type.
+  req.body.session
 
-    // @ts-expect-error `session` property is not defined on the request body type.
-    req.body.session
+  res(
+    // @ts-expect-error JSON doesn't match given response body generic type.
+    ctx.json({ unknown: true }),
+  )
 
-    res(
-      // @ts-expect-error JSON doesn't match given response body generic type.
-      ctx.json({ unknown: true }),
-    )
+  res(
+    // @ts-expect-error value types do not match
+    ctx.json({ postCount: 'this is not a number' }),
+  )
 
-    res(
-      // @ts-expect-error value types do not match
-      ctx.json({ postCount: 'this is not a number' }),
-    )
-
-    return res(ctx.json({ postCount: 2 }))
-  },
-)
+  return res(ctx.json({ postCount: 2 }))
+})
 
 rest.get<never, { userId: string }>('/user/:userId', (req) => {
   req.params.userId
@@ -66,3 +61,27 @@ rest.get<
   // Parse them to numbers in the resolver if necessary.
   { id: number }
 >('/posts/:id', () => null)
+
+rest.head('/user', (req) => {
+  // @ts-expect-error GET requests cannot have body.
+  req.body.toString()
+})
+
+rest.head<string>('/user', (req) => {
+  // @ts-expect-error GET requests cannot have body.
+  req.body.toString()
+})
+
+rest.get('/user', (req) => {
+  // @ts-expect-error GET requests cannot have body.
+  req.body.toString()
+})
+
+rest.get<string>('/user', (req) => {
+  // @ts-expect-error GET requests cannot have body.
+  req.body.toString()
+})
+
+rest.post<{ userId: string }>('/user', (req) => {
+  req.body.userId.toUpperCase()
+})


### PR DESCRIPTION
HEAD/GET requests cannot have a body. This must be enforced on the type definitions' side as well. 