### PR TITLE
feat: use document.baseURI as the relative request's base URL

### DIFF
--- a/src/utils/url/getAbsoluteUrl.test.ts
+++ b/src/utils/url/getAbsoluteUrl.test.ts
@@ -3,7 +3,7 @@
  */
 import { getAbsoluteUrl } from './getAbsoluteUrl'
 
-test('rebases a relative URL against the current location (default)', () => {
+test('rebases a relative URL against the current "baseURI" (default)', () => {
   expect(getAbsoluteUrl('/reviews')).toEqual('http://localhost/reviews')
 })
 

--- a/src/utils/url/getAbsoluteUrl.ts
+++ b/src/utils/url/getAbsoluteUrl.ts
@@ -8,8 +8,9 @@ export function getAbsoluteUrl(path: string, baseUrl?: string): string {
   }
 
   // Resolve a relative request URL against a given custom "baseUrl"
-  // or the current location (in the case of browser/browser-like environments).
-  const origin = baseUrl || (typeof location !== 'undefined' && location.origin)
+  // or the document baseURI (in the case of browser/browser-like environments).
+  const origin =
+    baseUrl || (typeof document !== 'undefined' && document.baseURI)
 
   return origin
     ? // Encode and decode the path to preserve escaped characters.


### PR DESCRIPTION
- Closes #1007 

use document.baseURI as the relative request's base URL