### PR TITLE
fix: TypedDocumentNode compatibility for @graphql-typed-document-node/core v3.1.1

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -14,6 +14,7 @@ export interface TypedDocumentNode<
   Result = { [key: string]: any },
   Variables = { [key: string]: any },
 > extends DocumentNode {
+  __apiType?: (variables: Variables) => Result
   __resultType?: Result
   __variablesType?: Variables
 }


### PR DESCRIPTION
`TypedDocumentNode` interface has breaking change at `@graphql-typed-document-node/core v3.1.1`, so this PR appends a new method interface for compatibility.

v3.1.0
https://github.com/dotansimha/graphql-typed-document-node/blob/defbca2a7e46feed938e314cb755da0edb625e92/packages/core/src/index.ts#L1-L7

v3.1.1
https://github.com/dotansimha/graphql-typed-document-node/blob/6443194dcaa60602e6418141a91cae0ae1996fe8/packages/core/src/index.ts#L1-L11