### PR TITLE
fix(matchRequestUrl): replace negative lookbehind regexp

### DIFF
--- a/src/utils/matching/matchRequestUrl.test.ts
+++ b/src/utils/matching/matchRequestUrl.test.ts
@@ -3,66 +3,91 @@
  */
 import { coercePath, matchRequestUrl } from './matchRequestUrl'
 
-test('returns true when matched against a wildcard', () => {
-  const match = matchRequestUrl(new URL('https://test.mswjs.io'), '*')
-  expect(match).toHaveProperty('matches', true)
-  expect(match).toHaveProperty('params', {
-    '0': 'https://test.mswjs.io/',
+describe('matchRequestUrl', () => {
+  test('returns true when matches against an exact URL', () => {
+    const match = matchRequestUrl(
+      new URL('https://test.mswjs.io'),
+      'https://test.mswjs.io',
+    )
+    expect(match).toHaveProperty('matches', true)
+    expect(match).toHaveProperty('params', {})
   })
-})
 
-test('returns true when matches against an exact URL', () => {
-  const match = matchRequestUrl(
-    new URL('https://test.mswjs.io'),
-    'https://test.mswjs.io',
-  )
-  expect(match).toHaveProperty('matches', true)
-  expect(match).toHaveProperty('params', {})
-})
-
-test('returns true when matched against a RegExp', () => {
-  const match = matchRequestUrl(
-    new URL('https://test.mswjs.io'),
-    /test\.mswjs\.io/,
-  )
-  expect(match).toHaveProperty('matches', true)
-  expect(match).toHaveProperty('params', {})
-})
-
-test('returns request parameters when matched', () => {
-  const match = matchRequestUrl(
-    new URL('https://test.mswjs.io/user/abc-123'),
-    'https://test.mswjs.io/user/:userId',
-  )
-  expect(match).toHaveProperty('matches', true)
-  expect(match).toHaveProperty('params', {
-    userId: 'abc-123',
+  test('returns true when matched against a wildcard', () => {
+    const match = matchRequestUrl(new URL('https://test.mswjs.io'), '*')
+    expect(match).toHaveProperty('matches', true)
+    expect(match).toHaveProperty('params', {
+      '0': 'https://test.mswjs.io/',
+    })
   })
-})
 
-test('decodes request parameters', () => {
-  const url = 'http://example.com:5001/example'
-  const match = matchRequestUrl(
-    new URL(`https://test.mswjs.io/reflect-url/${encodeURIComponent(url)}`),
-    'https://test.mswjs.io/reflect-url/:url',
-  )
-  expect(match).toHaveProperty('matches', true)
-  expect(match).toHaveProperty('params', {
-    url,
+  test('returns true when matched against a RegExp', () => {
+    const match = matchRequestUrl(
+      new URL('https://test.mswjs.io'),
+      /test\.mswjs\.io/,
+    )
+    expect(match).toHaveProperty('matches', true)
+    expect(match).toHaveProperty('params', {})
   })
-})
 
-test('returns false when does not match against the request URL', () => {
-  const match = matchRequestUrl(
-    new URL('https://test.mswjs.io'),
-    'https://google.com',
-  )
-  expect(match).toHaveProperty('matches', false)
-  expect(match).toHaveProperty('params', {})
+  test('returns path parameters when matched', () => {
+    const match = matchRequestUrl(
+      new URL('https://test.mswjs.io/user/abc-123'),
+      'https://test.mswjs.io/user/:userId',
+    )
+    expect(match).toHaveProperty('matches', true)
+    expect(match).toHaveProperty('params', {
+      userId: 'abc-123',
+    })
+  })
+
+  test('decodes path parameters', () => {
+    const url = 'http://example.com:5001/example'
+    const match = matchRequestUrl(
+      new URL(`https://test.mswjs.io/reflect-url/${encodeURIComponent(url)}`),
+      'https://test.mswjs.io/reflect-url/:url',
+    )
+    expect(match).toHaveProperty('matches', true)
+    expect(match).toHaveProperty('params', {
+      url,
+    })
+  })
+
+  test('returns false when does not match against the request URL', () => {
+    const match = matchRequestUrl(
+      new URL('https://test.mswjs.io'),
+      'https://google.com',
+    )
+    expect(match).toHaveProperty('matches', false)
+    expect(match).toHaveProperty('params', {})
+  })
 })
 
 describe('coercePath', () => {
-  test('escapes semicolor in a protocol', () => {
+  test('replaces wildcard with an unnnamed capturing group', () => {
+    expect(coercePath('*')).toEqual('(.*)')
+    expect(coercePath('**')).toEqual('(.*)')
+    expect(coercePath('/us*')).toEqual('/us(.*)')
+    expect(coercePath('/user/*')).toEqual('/user/(.*)')
+    expect(coercePath('https://example.com/user/*')).toEqual(
+      'https\\://example.com/user/(.*)',
+    )
+    expect(coercePath('https://example.com/us*')).toEqual(
+      'https\\://example.com/us(.*)',
+    )
+  })
+
+  test('preserves path parameter modifiers', () => {
+    expect(coercePath(':name*')).toEqual(':name*')
+    expect(coercePath('/foo/:name*')).toEqual('/foo/:name*')
+    expect(coercePath('/foo/**:name*')).toEqual('/foo/(.*):name*')
+    expect(coercePath('**/foo/*/:name*')).toEqual('(.*)/foo/(.*)/:name*')
+    expect(coercePath('/foo/:first/bar/:second*/*')).toEqual(
+      '/foo/:first/bar/:second*/(.*)',
+    )
+  })
+
+  test('escapes the semicolon in protocol', () => {
     expect(coercePath('https://example.com')).toEqual('https\\://example.com')
     expect(coercePath('https://example.com/:userId')).toEqual(
       'https\\://example.com/:userId',
@@ -70,21 +95,5 @@ describe('coercePath', () => {
     expect(coercePath('http://localhost:3000')).toEqual(
       'http\\://localhost:3000',
     )
-  })
-
-  test('replaces wildcard with an unnnamed capturing group', () => {
-    expect(coercePath('*')).toEqual('(.*)')
-    expect(coercePath('**')).toEqual('(.*)')
-    expect(coercePath('/user/*')).toEqual('/user/(.*)')
-    expect(coercePath('https://example.com/user/*')).toEqual(
-      'https\\://example.com/user/(.*)',
-    )
-  })
-
-  test('preserves "*" parameter modifier', () => {
-    expect(coercePath(':name*')).toEqual(':name*')
-    expect(coercePath('/foo/:name*')).toEqual('/foo/:name*')
-    expect(coercePath('/foo/**:name*')).toEqual('/foo/(.*):name*')
-    expect(coercePath('**/foo/*/:name*')).toEqual('(.*)/foo/(.*)/:name*')
   })
 })


### PR DESCRIPTION
- Fixes #1018 

## Changes

- Removes the negative lookbehind regular expression (`?<!`) that's not supported in Safari.
- Replaces the said expression with a positive lookup (optional path parameters are now a capturing group).
- Moves the wildcard coercion _before_ the protocol escaping so it could handle simpler paths.
- Restructures tests around `matchRequestUrl` slightly. 