### PR TITLE
fix(onUnhandledRequest): ignore regexp method/operationName

### DIFF
--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -12,6 +12,7 @@ import { cookie } from '../context/cookie'
 import {
   MockedRequest,
   RequestHandler,
+  RequestHandlerDefaultInfo,
   ResponseResolver,
 } from './RequestHandler'
 import { getTimestamp } from '../utils/logging/getTimestamp'
@@ -59,7 +60,7 @@ export const graphqlContext: GraphQLContext<any> = {
 
 export type GraphQLVariables = Record<string, any>
 
-export interface GraphQLHandlerInfo {
+export interface GraphQLHandlerInfo extends RequestHandlerDefaultInfo {
   operationType: ExpectedOperationTypeNode
   operationName: GraphQLHandlerNameSelector
 }

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -47,13 +47,13 @@ export interface MockedRequest<Body = DefaultRequestBody> {
   bodyUsed: Request['bodyUsed']
 }
 
-interface RequestHandlerDefaultInfo {
-  callFrame?: string
+export interface RequestHandlerDefaultInfo {
+  header: string
 }
 
-type RequestHandlerInfo<ExtraInfo extends Record<string, any>> = {
-  header: string
-} & ExtraInfo
+export interface RequestHandlerInternalInfo {
+  callFrame?: string
+}
 
 type ContextMap = Record<string, (...args: any[]) => any>
 
@@ -85,7 +85,7 @@ export type ResponseResolver<
 ) => AsyncResponseResolverReturnType<MockedResponse<BodyType>>
 
 export interface RequestHandlerOptions<HandlerInfo> {
-  info: RequestHandlerInfo<HandlerInfo>
+  info: HandlerInfo
   resolver: ResponseResolver<any, any>
   ctx?: ContextMap
 }
@@ -98,12 +98,12 @@ export interface RequestHandlerExecutionResult<PublicRequestType> {
 }
 
 export abstract class RequestHandler<
-  HandlerInfo extends Record<string, any> = Record<string, any>,
+  HandlerInfo extends RequestHandlerDefaultInfo = RequestHandlerDefaultInfo,
   Request extends MockedRequest = MockedRequest,
   ParsedResult = any,
   PublicRequest extends MockedRequest = Request,
 > {
-  public info: RequestHandlerDefaultInfo & RequestHandlerInfo<HandlerInfo>
+  public info: HandlerInfo & RequestHandlerInternalInfo
   public shouldSkip: boolean
 
   private ctx: ContextMap

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -29,12 +29,13 @@ import {
   DefaultRequestBody,
   MockedRequest,
   RequestHandler,
+  RequestHandlerDefaultInfo,
   ResponseResolver,
 } from './RequestHandler'
 
 type RestHandlerMethod = string | RegExp
 
-interface RestHandlerInfo {
+export interface RestHandlerInfo extends RequestHandlerDefaultInfo {
   method: RestHandlerMethod
   path: Path
 }
@@ -172,8 +173,6 @@ export class RestHandler<
       this.info.method instanceof RegExp
         ? this.info.method.test(request.method)
         : isStringEqual(this.info.method, request.method)
-
-    // console.log({ request, matchesMethod, parsedResult })
 
     return matchesMethod && parsedResult.matches
   }

--- a/src/utils/request/onUnhandledRequest.test.ts
+++ b/src/utils/request/onUnhandledRequest.test.ts
@@ -1,0 +1,181 @@
+import { onUnhandledRequest } from './onUnhandledRequest'
+import { createMockedRequest } from '../../../test/support/utils'
+import { RestHandler, RESTMethods } from '../../handlers/RestHandler'
+import { ResponseResolver } from '../../handlers/RequestHandler'
+
+const resolver: ResponseResolver = () => void 0
+
+const fixtures = {
+  warningWithoutSuggestions: `\
+[MSW] Warning: captured a request without a matching request handler:
+
+  • GET http://localhost/api
+
+If you still wish to intercept this unhandled request, please create a request handler for it.
+Read more: https://mswjs.io/docs/getting-started/mocks`,
+
+  errorWithoutSuggestions: `\
+[MSW] Error: captured a request without a matching request handler:
+
+  • GET http://localhost/api
+
+If you still wish to intercept this unhandled request, please create a request handler for it.
+Read more: https://mswjs.io/docs/getting-started/mocks`,
+
+  warningWithSuggestions: (suggestions: string) => `\
+[MSW] Warning: captured a request without a matching request handler:
+
+  • GET http://localhost/api
+
+Did you mean to request one of the following resources instead?
+
+${suggestions}
+
+If you still wish to intercept this unhandled request, please create a request handler for it.
+Read more: https://mswjs.io/docs/getting-started/mocks`,
+}
+
+beforeAll(() => {
+  jest.spyOn(console, 'warn').mockImplementation()
+  jest.spyOn(console, 'error').mockImplementation()
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+test('supports the "bypass" request strategy', () => {
+  onUnhandledRequest(createMockedRequest(), [], 'bypass')
+
+  expect(console.warn).not.toHaveBeenCalled()
+  expect(console.error).not.toHaveBeenCalled()
+})
+
+test('supports the "warn" request strategy', () => {
+  onUnhandledRequest(
+    createMockedRequest({
+      url: new URL('http://localhost/api'),
+    }),
+    [],
+    'warn',
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(fixtures.warningWithoutSuggestions)
+})
+
+test('supports the "error" request strategy', () => {
+  expect(() =>
+    onUnhandledRequest(
+      createMockedRequest({
+        url: new URL('http://localhost/api'),
+      }),
+      [],
+      'error',
+    ),
+  ).toThrow(
+    '[MSW] Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.',
+  )
+
+  expect(console.error).toHaveBeenCalledWith(fixtures.errorWithoutSuggestions)
+})
+
+test('supports custom callback function', () => {
+  const handleRequest = jest.fn()
+  const request = createMockedRequest()
+  onUnhandledRequest(request, [], handleRequest)
+
+  expect(handleRequest).toHaveBeenCalledWith(request)
+})
+
+test('does not print any suggestions given no handlers to suggest', () => {
+  onUnhandledRequest(
+    createMockedRequest({ url: new URL('http://localhost/api') }),
+    [],
+    'warn',
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(fixtures.warningWithoutSuggestions)
+})
+
+test('does not print any suggestions given no handlers are similar', () => {
+  onUnhandledRequest(
+    createMockedRequest({ url: new URL('http://localhost/api') }),
+    [
+      // None of the defined request handlers match the actual request URL
+      // to be used as suggestions.
+      new RestHandler(RESTMethods.GET, 'https://api.github.com', resolver),
+      new RestHandler(RESTMethods.GET, 'https://api.stripe.com', resolver),
+    ],
+    'warn',
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(fixtures.warningWithoutSuggestions)
+})
+
+test('respects RegExp as a request handler method', () => {
+  onUnhandledRequest(
+    createMockedRequest({ url: new URL('http://localhost/api') }),
+    [new RestHandler(/^GE/, 'http://localhost/api', resolver)],
+    'warn',
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(fixtures.warningWithoutSuggestions)
+})
+
+test('sorts the suggestions by relevance', () => {
+  onUnhandledRequest(
+    createMockedRequest({ url: new URL('http://localhost/api') }),
+    [
+      new RestHandler(RESTMethods.GET, 'http://localhost/', resolver),
+      new RestHandler(RESTMethods.GET, 'http://localhost:9090/api', resolver),
+      new RestHandler(RESTMethods.POST, 'http://localhost/api', resolver),
+    ],
+    'warn',
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(
+    fixtures.warningWithSuggestions(`\
+  • POST http://localhost/api
+  • GET http://localhost/`),
+  )
+})
+
+test('does not print more than 4 suggestions', () => {
+  onUnhandledRequest(
+    createMockedRequest({ url: new URL('http://localhost/api') }),
+    [
+      new RestHandler(RESTMethods.GET, 'http://localhost/ap', resolver),
+      new RestHandler(RESTMethods.GET, 'http://localhost/api', resolver),
+      new RestHandler(RESTMethods.GET, 'http://localhost/api-1', resolver),
+      new RestHandler(RESTMethods.GET, 'http://localhost/api-2', resolver),
+      new RestHandler(RESTMethods.GET, 'http://localhost/api-3', resolver),
+      new RestHandler(RESTMethods.GET, 'http://localhost/api-4', resolver),
+    ],
+    'warn',
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(
+    fixtures.warningWithSuggestions(`\
+  • GET http://localhost/api
+  • GET http://localhost/ap
+  • GET http://localhost/api-1
+  • GET http://localhost/api-2`),
+  )
+})
+
+test('throws an exception given unknown request strategy', () => {
+  expect(() =>
+    onUnhandledRequest(
+      createMockedRequest(),
+      [],
+      // @ts-expect-error Intentional unknown strategy.
+      'arbitrary-strategy',
+    ),
+  ).toThrow(
+    '[MSW] Failed to react to an unhandled request: unknown strategy "arbitrary-strategy". Please provide one of the supported strategies ("bypass", "warn", "error") or a custom callback function as the value of the "onUnhandledRequest" option.',
+  )
+})

--- a/src/utils/request/onUnhandledRequest.ts
+++ b/src/utils/request/onUnhandledRequest.ts
@@ -183,7 +183,9 @@ Read more: https://mswjs.io/docs/getting-started/mocks\
 
       // Throw an exception to halt request processing and not perform the original request.
       throw new Error(
-        'Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.',
+        devUtils.formatMessage(
+          'Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.',
+        ),
       )
     }
 

--- a/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
+++ b/test/msw-api/setup-server/scenarios/on-unhandled-request/error.test.ts
@@ -59,7 +59,7 @@ test('errors on unhandled request when using the "error" value', async () => {
   const makeRequest = () => fetch(endpointUrl)
 
   await expect(() => makeRequest()).rejects.toThrow(
-    `request to ${endpointUrl} failed, reason: Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.`,
+    `request to ${endpointUrl} failed, reason: [MSW] Cannot bypass a request when using the "error" strategy for the "onUnhandledRequest" option.`,
   )
   expect(console.error)
     .toHaveBeenCalledWith(`[MSW] Error: captured a request without a matching request handler:


### PR DESCRIPTION
- Fixes #1020 

## Changes

- Does not print any suggestions if the `method` or `operationName` of the handler is a `RegExp`. In that case, it's impossible to suggest anything because the regular expression is a dynamic sort of thing. 
- Adds missing unit tests for the `onUnhandledRequest` function. 