### PR TITLE
fix: replace "x-msw-request-id" header

### DIFF
--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -81,16 +81,14 @@ export function createSetupServer(...interceptors: Interceptor[]) {
     })
 
     interceptor.on('response', (request, response) => {
-      const requestId = request.headers.get('x-msw-request-id')
-
-      if (!requestId) {
+      if (!request.id) {
         return
       }
 
       if (response.headers.get('x-powered-by') === 'msw') {
-        emitter.emit('response:mocked', response, requestId)
+        emitter.emit('response:mocked', response, request.id)
       } else {
-        emitter.emit('response:bypass', response, requestId)
+        emitter.emit('response:bypass', response, request.id)
       }
     })
 

--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -19,7 +19,7 @@ export interface HandleRequestOptions<ResponseType> {
 
   /**
    * Transforms a `MockedResponse` instance returned from a handler
-   * to a response instance
+   * to a response instance supported by the lower tooling (i.e. interceptors).
    */
   transformResponse?(response: MockedResponse<string>): ResponseType
 

--- a/src/utils/request/parseIsomorphicRequest.ts
+++ b/src/utils/request/parseIsomorphicRequest.ts
@@ -1,7 +1,6 @@
 import * as cookieUtils from 'cookie'
 import { IsomorphicRequest } from '@mswjs/interceptors'
 import { MockedRequest } from '../../handlers/RequestHandler'
-import { uuidv4 } from '../internal/uuidv4'
 import { parseBody } from './parseBody'
 import { setRequestCookies } from './setRequestCookies'
 
@@ -11,12 +10,8 @@ import { setRequestCookies } from './setRequestCookies'
 export function parseIsomorphicRequest(
   request: IsomorphicRequest,
 ): MockedRequest {
-  const requestId = uuidv4()
-
-  request.headers.set('x-msw-request-id', requestId)
-
   const mockedRequest: MockedRequest = {
-    id: requestId,
+    id: request.id,
     url: request.url,
     method: request.method,
     body: parseBody(request.body, request.headers),


### PR DESCRIPTION
- Fixes #1022
- Resolves discussion #713

## Changes

- The library no longer sets the `x-msw-request-id` header on the request (previously happened during the request parsing). Instead, the response/request mapping logic is achieved in the following way:
  - Node.js: relies on the `request.id` set by the interceptors library;
  - Browser: relies on the generated `requestId` 

https://github.com/mswjs/msw/blob/97fba97b7d01674965cc6147ba7fed631e584906/src/mockServiceWorker.js#L268

https://github.com/mswjs/msw/blob/97fba97b7d01674965cc6147ba7fed631e584906/src/mockServiceWorker.js#L121-L134

https://github.com/mswjs/msw/blob/97fba97b7d01674965cc6147ba7fed631e584906/src/utils/worker/createResponseListener.ts#L31-L35