### PR TITLE
fix: list "typescript" as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,14 @@
     "webpack": "^5.64.4",
     "webpack-dev-server": "^3.11.2"
   },
+  "peerDependencies": {
+    "typescript": "4.2.x"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "resolutions": {
     "chokidar": "3.4.1"
   }


### PR DESCRIPTION
- A mirror of #985

This pull request tries to reproduce the failing `test:smoke` job on CI.