### PR TITLE
fix: make PathParams type readonly

### DIFF
--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -3,7 +3,7 @@ import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
 import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp
-export type PathParams = Record<string, string | string[]>
+export type PathParams = Record<string, string | ReadonlyArray<string>>
 
 export interface Match {
   matches: boolean


### PR DESCRIPTION
following up on #1017 tihs pr makes the `PathParams` type readonly.