### PR TITLE
feat: support a single boolean or null as a JSON request/response body

### DIFF
--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -26,7 +26,11 @@ const createFetchRequestParameters = (input: MockedRequest): RequestInit => {
     return requestParameters
   }
 
-  if (typeof body === 'object' || typeof body === 'number') {
+  if (
+    typeof body === 'object' ||
+    typeof body === 'number' ||
+    typeof body === 'boolean'
+  ) {
     requestParameters.body = JSON.stringify(body)
   } else {
     requestParameters.body = body

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -26,6 +26,8 @@ export type DefaultRequestBody =
   | DefaultRequestMultipartBody
   | string
   | number
+  | boolean
+  | null
   | undefined
 
 export interface MockedRequest<Body = DefaultRequestBody> {


### PR DESCRIPTION
v0.36 broke the `ctx.json`, which is the unadded part of #925.

- Closes #1042 

The test of this project is flaky, I can't run the test at all, so I don’t know if it breaks anything.