### PR TITLE
chore: remove unused test script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:integration": "jest --config=test/jest.config.js --maxWorkers=3",
     "test:smoke": "config/scripts/smoke.sh",
     "test:ts": "tsc -p test/typings/tsconfig.json",
-    "test:focused": "node node_modules/ts-node/dist/bin.js --project=test/tsconfig.json test/focusedTest.ts",
     "prepublishOnly": "yarn lint && yarn test:unit && yarn build && yarn test:integration",
     "prepare": "husky install",
     "postinstall": "node -e \"try{require('./config/scripts/postinstall')}catch(e){}\""


### PR DESCRIPTION
**test/focusedTest.ts** file  was removed within commit **2fb37a**

`2fb37a :   Uses "page-with" for example-based testing`

This cleans up package.json to remove the unused script


