### PR TITLE
chore: add semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+on:
+  workflow_run:
+    workflows: ['ci']
+    branches: [main]
+    types:
+      - completed
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish
+        if: contains(github.ref, 'refs/heads/main')
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  branches: ['main'],
+}


### PR DESCRIPTION
Uses `semantic-release` during the CI to automatically publish the package. 