### PR TITLE
fix: parse request body with letter case header

### DIFF
--- a/src/utils/request/parseBody.test.ts
+++ b/src/utils/request/parseBody.test.ts
@@ -14,6 +14,17 @@ test('parses a body if the "Content-Type:application/json" header is set', () =>
   })
 })
 
+test('parses a body for headers with letter cases', () => {
+  expect(
+    parseBody(
+      `{"property":2}`,
+      new Headers({ 'Content-Type': 'Application/JSON' }),
+    ),
+  ).toEqual({
+    property: 2,
+  })
+})
+
 test('parses a body if the "Content-Type*/json" header is set', () => {
   expect(
     parseBody(

--- a/src/utils/request/parseBody.ts
+++ b/src/utils/request/parseBody.ts
@@ -11,7 +11,7 @@ export function parseBody(body?: MockedRequest['body'], headers?: Headers) {
     return body
   }
 
-  const contentType = (headers?.get('content-type') || '').toLowerCase()
+  const contentType = headers?.get('content-type')?.toLowerCase() || ''
 
   // If the body has a Multipart Content-Type
   // parse it into an object.

--- a/src/utils/request/parseBody.ts
+++ b/src/utils/request/parseBody.ts
@@ -11,7 +11,7 @@ export function parseBody(body?: MockedRequest['body'], headers?: Headers) {
     return body
   }
 
-  const contentType = headers?.get('content-type') || ''
+  const contentType = (headers?.get('content-type') || '').toLowerCase()
 
   // If the body has a Multipart Content-Type
   // parse it into an object.


### PR DESCRIPTION
Fixes the problem mentioned in this [comment](https://github.com/mswjs/msw/pull/172#discussion_r786449936)

The request body is not parsed if the `Content-type` header has the value with letter cases like `Application/JSON`.

# GitHub
Fixes #171 (Might need to reopen or create a new one)