### PR TITLE
feat(rest): infer path parameters from the path string

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:unit": "cross-env BABEL_ENV=test jest --maxWorkers=3",
     "test:integration": "jest --config=test/jest.config.js --maxWorkers=1",
     "test:smoke": "config/scripts/smoke.sh",
-    "test:ts": "tsc -p test/typings/tsconfig.json",
+    "test:ts": "tsc -p test-d.tsconfig.json",
     "prepare": "yarn simple-git-hooks init",
     "prepack": "yarn build",
     "release": "semantic-release",

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -21,7 +21,7 @@ export type DefaultRequestMultipartBody = Record<
   string | File | (string | File)[]
 >
 
-export type DefaultRequestBody =
+export type DefaultBodyType =
   | Record<string, any>
   | DefaultRequestMultipartBody
   | string
@@ -30,7 +30,7 @@ export type DefaultRequestBody =
   | null
   | undefined
 
-export interface MockedRequest<Body = DefaultRequestBody> {
+export interface MockedRequest<Body extends DefaultBodyType = DefaultBodyType> {
   id: string
   url: URL
   method: Request['method']
@@ -77,9 +77,9 @@ export type AsyncResponseResolverReturnType<ReturnType> =
     >
 
 export type ResponseResolver<
-  RequestType = MockedRequest,
+  RequestType extends MockedRequest = MockedRequest,
   ContextType = typeof defaultContext,
-  BodyType = any,
+  BodyType extends DefaultBodyType = any,
 > = (
   req: RequestType,
   res: ResponseComposition<BodyType>,

--- a/src/handlers/RestHandler.test-d.ts
+++ b/src/handlers/RestHandler.test-d.ts
@@ -1,0 +1,18 @@
+import { RestHandler, RESTMethods } from './RestHandler'
+
+/**
+ * Path parameter inference.
+ */
+new RestHandler(RESTMethods.GET, '/user/:id', (req) => {
+  req.params.id.trim()
+})
+
+new RestHandler(RESTMethods.POST, '/user/:id', (req) => {
+  // @ts-expect-error Property "foo" doesn't exist in path params.
+  req.params.foo
+})
+
+new RestHandler(RESTMethods.PUT, '/:service/user/:id/message/:id', (req) => {
+  req.params.service.trim()
+  req.params.id.map
+})

--- a/src/handlers/RestHandler.test.ts
+++ b/src/handlers/RestHandler.test.ts
@@ -1,17 +1,27 @@
 /**
  * @jest-environment jsdom
  */
-import { RestHandler, RestRequest, RestContext } from './RestHandler'
+import {
+  RestHandler,
+  RestRequest,
+  RestContext,
+  RESTMethods,
+} from './RestHandler'
 import { createMockedRequest } from '../../test/support/utils'
 import { response } from '../response'
 import { context } from '..'
 import { ResponseResolver } from './RequestHandler'
 
-const resolver: ResponseResolver<
-  RestRequest<{ userId: string }>,
-  RestContext
-> = (req, res, ctx) => {
-  return res(ctx.json({ userId: req.params.userId }))
+const resolver: ResponseResolver<RestRequest, RestContext> = (
+  req,
+  res,
+  ctx,
+) => {
+  return res(
+    ctx.json({
+      userId: req.params.userId,
+    }),
+  )
 }
 
 const generatorResolver: ResponseResolver<
@@ -28,7 +38,7 @@ const generatorResolver: ResponseResolver<
 
 describe('info', () => {
   test('exposes request handler information', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     expect(handler.info.header).toEqual('GET /user/:userId')
     expect(handler.info.method).toEqual('GET')
     expect(handler.info.path).toEqual('/user/:userId')
@@ -37,7 +47,7 @@ describe('info', () => {
 
 describe('parse', () => {
   test('parses a URL given a matching request', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const request = createMockedRequest({
       url: new URL('/user/abc-123', location.href),
     })
@@ -51,7 +61,7 @@ describe('parse', () => {
   })
 
   test('parses a URL and ignores the request method', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const request = createMockedRequest({
       method: 'POST',
       url: new URL('/user/def-456', location.href),
@@ -66,7 +76,7 @@ describe('parse', () => {
   })
 
   test('returns negative match result given a non-matching request', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const request = createMockedRequest({
       url: new URL('/login', location.href),
     })
@@ -80,7 +90,7 @@ describe('parse', () => {
 
 describe('predicate', () => {
   test('returns true given a matching request', () => {
-    const handler = new RestHandler('POST', '/login', resolver)
+    const handler = new RestHandler(RESTMethods.POST, '/login', resolver)
     const request = createMockedRequest({
       method: 'POST',
       url: new URL('/login', location.href),
@@ -109,7 +119,7 @@ describe('predicate', () => {
   })
 
   test('returns false given a non-matching request', () => {
-    const handler = new RestHandler('POST', '/login', resolver)
+    const handler = new RestHandler(RESTMethods.POST, '/login', resolver)
     const request = createMockedRequest({
       url: new URL('/user/abc-123', location.href),
     })
@@ -120,7 +130,7 @@ describe('predicate', () => {
 
 describe('test', () => {
   test('returns true given a matching request', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const firstTest = handler.test(
       createMockedRequest({
         url: new URL('/user/abc-123', location.href),
@@ -137,7 +147,7 @@ describe('test', () => {
   })
 
   test('returns false given a non-matching request', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const firstTest = handler.test(
       createMockedRequest({
         url: new URL('/login', location.href),
@@ -162,7 +172,7 @@ describe('test', () => {
 
 describe('run', () => {
   test('returns a mocked response given a matching request', async () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const request = createMockedRequest({
       url: new URL('/user/abc-123', location.href),
     })
@@ -187,7 +197,7 @@ describe('run', () => {
   })
 
   test('returns null given a non-matching request', async () => {
-    const handler = new RestHandler('POST', '/login', resolver)
+    const handler = new RestHandler(RESTMethods.POST, '/login', resolver)
     const result = await handler.run(
       createMockedRequest({
         method: 'GET',
@@ -199,7 +209,7 @@ describe('run', () => {
   })
 
   test('returns an empty object as "req.params" given request with no URL parameters', async () => {
-    const handler = new RestHandler('GET', '/users', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/users', resolver)
     const result = await handler.run(
       createMockedRequest({
         url: new URL('/users', location.href),
@@ -212,7 +222,11 @@ describe('run', () => {
 
 describe('run with generator', () => {
   test('Resolver runs until generator completes', async () => {
-    const handler = new RestHandler('GET', '/users', generatorResolver)
+    const handler = new RestHandler(
+      RESTMethods.GET,
+      '/users',
+      generatorResolver,
+    )
     const run = async () => {
       const result = await handler.run(
         createMockedRequest({

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -21,23 +21,25 @@ import {
   Match,
   matchRequestUrl,
   Path,
-  PathParams,
+  ExtractPathParams,
+  DefaultParamsType,
 } from '../utils/matching/matchRequestUrl'
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
 import { cleanUrl, getSearchParams } from '../utils/url/cleanUrl'
 import {
-  DefaultRequestBody,
+  DefaultBodyType,
   MockedRequest,
   RequestHandler,
   RequestHandlerDefaultInfo,
   ResponseResolver,
 } from './RequestHandler'
 
-type RestHandlerMethod = string | RegExp
+export type RestMethodType = RESTMethods | RegExp
 
-export interface RestHandlerInfo extends RequestHandlerDefaultInfo {
-  method: RestHandlerMethod
-  path: Path
+export interface RestHandlerInfo<ExactPath extends Path>
+  extends RequestHandlerDefaultInfo {
+  method: RestMethodType
+  path: ExactPath
 }
 
 export enum RESTMethods {
@@ -81,35 +83,54 @@ export type RequestQuery = {
 }
 
 export interface RestRequest<
-  BodyType extends DefaultRequestBody = DefaultRequestBody,
-  ParamsType extends PathParams<Path> = PathParams<RegExp>,
+  BodyType extends DefaultBodyType = DefaultBodyType,
+  ParamsType extends ExtractPathParams<Path> = ExtractPathParams<RegExp>,
 > extends MockedRequest<BodyType> {
   params: ParamsType
 }
 
 export type ParsedRestRequest<P extends Path> = Match<P>
 
+export type RestResponseResolver<
+  MethodType extends RestMethodType,
+  RequestBodyType extends DefaultBodyType,
+  ParamsType extends DefaultParamsType,
+  ResponseBodyType extends DefaultBodyType,
+> = ResponseResolver<
+  RestRequest<
+    MethodType extends RESTMethods.HEAD | RESTMethods.GET
+      ? never
+      : RequestBodyType,
+    ParamsType
+  >,
+  RestContext,
+  ResponseBodyType
+>
+
 /**
  * Request handler for REST API requests.
  * Provides request matching based on method and URL.
  */
 export class RestHandler<
-  RequestType extends MockedRequest<DefaultRequestBody> = MockedRequest<DefaultRequestBody>,
+  MethodType extends RESTMethods | RegExp = RESTMethods | RegExp,
+  PathType extends Path = Path,
+  RequestBodyType extends DefaultBodyType = DefaultBodyType,
+  ResponseBodyType extends DefaultBodyType = DefaultBodyType,
 > extends RequestHandler<
-  RestHandlerInfo,
-  RequestType,
-  ParsedRestRequest<RestHandlerInfo['path']>,
-  RestRequest<
-    RequestType extends MockedRequest<infer RequestBodyType>
-      ? RequestBodyType
-      : any,
-    PathParams<RestHandlerInfo['path']>
-  >
+  RestHandlerInfo<PathType>,
+  MockedRequest<RequestBodyType>,
+  ParsedRestRequest<PathType>,
+  RestRequest<RequestBodyType, ExtractPathParams<PathType>>
 > {
   constructor(
-    method: RestHandlerMethod,
-    path: Path,
-    resolver: ResponseResolver<any, any>,
+    method: MethodType,
+    path: PathType,
+    resolver: RestResponseResolver<
+      MethodType,
+      RequestBodyType,
+      ExtractPathParams<PathType>,
+      ResponseBodyType
+    >,
   ) {
     super({
       info: {
@@ -150,7 +171,10 @@ export class RestHandler<
     )
   }
 
-  parse(request: RequestType, resolutionContext?: ResponseResolutionContext) {
+  parse(
+    request: MockedRequest<RequestBodyType>,
+    resolutionContext?: ResponseResolutionContext,
+  ) {
     return matchRequestUrl(
       request.url,
       this.info.path,
@@ -159,18 +183,18 @@ export class RestHandler<
   }
 
   protected getPublicRequest(
-    request: RequestType,
-    parsedResult: ParsedRestRequest<RestHandlerInfo['path']>,
-  ): RestRequest<any, PathParams<RestHandlerInfo['path']>> {
+    request: MockedRequest<RequestBodyType>,
+    parsedResult: ParsedRestRequest<PathType>,
+  ): RestRequest<any, ExtractPathParams<PathType>> {
     return {
       ...request,
-      params: parsedResult.params || {},
+      params: parsedResult.params,
     }
   }
 
   predicate(
-    request: RequestType,
-    parsedResult: ParsedRestRequest<RestHandlerInfo['path']>,
+    request: MockedRequest<RequestBodyType>,
+    parsedResult: ParsedRestRequest<PathType>,
   ) {
     const matchesMethod =
       this.info.method instanceof RegExp
@@ -180,7 +204,7 @@ export class RestHandler<
     return matchesMethod && parsedResult.matches
   }
 
-  log(request: RequestType, response: SerializedResponse) {
+  log(request: MockedRequest<RequestBodyType>, response: SerializedResponse) {
     const publicUrl = getPublicUrlFromRequest(request)
     const loggedRequest = prepareRequest(request)
     const loggedResponse = prepareResponse(response)

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -82,12 +82,12 @@ export type RequestQuery = {
 
 export interface RestRequest<
   BodyType extends DefaultRequestBody = DefaultRequestBody,
-  ParamsType extends PathParams = PathParams,
+  ParamsType extends PathParams<Path> = PathParams<RegExp>,
 > extends MockedRequest<BodyType> {
   params: ParamsType
 }
 
-export type ParsedRestRequest = Match
+export type ParsedRestRequest<P extends Path> = Match<P>
 
 /**
  * Request handler for REST API requests.
@@ -98,12 +98,12 @@ export class RestHandler<
 > extends RequestHandler<
   RestHandlerInfo,
   RequestType,
-  ParsedRestRequest,
+  ParsedRestRequest<RestHandlerInfo['path']>,
   RestRequest<
     RequestType extends MockedRequest<infer RequestBodyType>
       ? RequestBodyType
       : any,
-    PathParams
+    PathParams<RestHandlerInfo['path']>
   >
 > {
   constructor(
@@ -160,15 +160,18 @@ export class RestHandler<
 
   protected getPublicRequest(
     request: RequestType,
-    parsedResult: ParsedRestRequest,
-  ): RestRequest<any, PathParams> {
+    parsedResult: ParsedRestRequest<RestHandlerInfo['path']>,
+  ): RestRequest<any, PathParams<RestHandlerInfo['path']>> {
     return {
       ...request,
       params: parsedResult.params || {},
     }
   }
 
-  predicate(request: RequestType, parsedResult: ParsedRestRequest) {
+  predicate(
+    request: RequestType,
+    parsedResult: ParsedRestRequest<RestHandlerInfo['path']>,
+  ) {
     const matchesMethod =
       this.info.method instanceof RegExp
         ? this.info.method.test(request.method)

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export type {
   ResponseResolver,
   ResponseResolverReturnType,
   AsyncResponseResolverReturnType,
-  DefaultRequestBody,
+  DefaultBodyType,
   DefaultRequestMultipartBody,
 } from './handlers/RequestHandler'
 
@@ -46,10 +46,12 @@ export type {
 } from './response'
 
 export type {
+  RestMethodType,
   RestContext,
   RequestQuery,
   RestRequest,
   ParsedRestRequest,
+  RestResponseResolver,
 } from './handlers/RestHandler'
 
 export type {
@@ -60,6 +62,11 @@ export type {
   GraphQLJsonRequestBody,
 } from './handlers/GraphQLHandler'
 
-export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
+export type {
+  Path,
+  Match,
+  ExtractPathParams,
+  DefaultParamsType,
+} from './utils/matching/matchRequestUrl'
 export type { DelayMode } from './context/delay'
 export { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -4,18 +4,13 @@ import {
   RestHandler,
   RestResponseResolver,
 } from './handlers/RestHandler'
-import {
-  Path,
-  ExtractPathParams,
-  DefaultParamsType,
-} from './utils/matching/matchRequestUrl'
+import { Path, ExtractPathParams } from './utils/matching/matchRequestUrl'
 
 function createRestHandler<MethodType extends RESTMethods | RegExp>(
   method: MethodType,
 ) {
   return <
     RequestBodyType extends DefaultBodyType = DefaultBodyType,
-    ParamsType extends DefaultParamsType = never,
     ResponseBodyType extends DefaultBodyType = DefaultBodyType,
     PathType extends Path = Path,
   >(

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,33 +1,38 @@
-import { DefaultRequestBody, ResponseResolver } from './handlers/RequestHandler'
+import { DefaultBodyType } from './handlers/RequestHandler'
 import {
   RESTMethods,
-  RestContext,
   RestHandler,
-  RestRequest,
+  RestResponseResolver,
 } from './handlers/RestHandler'
-import { Path, PathParams } from './utils/matching/matchRequestUrl'
+import {
+  Path,
+  ExtractPathParams,
+  DefaultParamsType,
+} from './utils/matching/matchRequestUrl'
 
-function createRestHandler<Method extends RESTMethods | RegExp>(
-  method: Method,
+function createRestHandler<MethodType extends RESTMethods | RegExp>(
+  method: MethodType,
 ) {
   return <
-    RequestBodyType extends DefaultRequestBody = DefaultRequestBody,
-    Params extends PathParams<Path> = PathParams<Path>,
-    ResponseBody extends DefaultRequestBody = DefaultRequestBody,
+    RequestBodyType extends DefaultBodyType = DefaultBodyType,
+    ParamsType extends DefaultParamsType = never,
+    ResponseBodyType extends DefaultBodyType = DefaultBodyType,
+    PathType extends Path = Path,
   >(
-    path: Path,
-    resolver: ResponseResolver<
-      RestRequest<
-        Method extends RESTMethods.HEAD | RESTMethods.GET
-          ? never
-          : RequestBodyType,
-        Params
-      >,
-      RestContext,
-      ResponseBody
+    path: PathType,
+    resolver: RestResponseResolver<
+      MethodType,
+      RequestBodyType,
+      ExtractPathParams<PathType>,
+      ResponseBodyType
     >,
   ) => {
-    return new RestHandler(method, path, resolver)
+    return new RestHandler<
+      MethodType,
+      PathType,
+      RequestBodyType,
+      ResponseBodyType
+    >(method, path, resolver as any)
   }
 }
 

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -12,7 +12,7 @@ function createRestHandler<Method extends RESTMethods | RegExp>(
 ) {
   return <
     RequestBodyType extends DefaultRequestBody = DefaultRequestBody,
-    Params extends PathParams = PathParams,
+    Params extends PathParams<Path> = PathParams<Path>,
     ResponseBody extends DefaultRequestBody = DefaultRequestBody,
   >(
     path: Path,

--- a/src/utils/matching/matchRequestUrl.test-d.ts
+++ b/src/utils/matching/matchRequestUrl.test-d.ts
@@ -11,3 +11,6 @@ matchRequestUrl(url, '/user/:id').params.foo
 // Multiple occurrences of the same path parameter
 // are inferred as a readonly array of strings.
 matchRequestUrl(url, '/:a/chunk/:a').params.a.map
+
+// Path parameter modifiers are stripped from the path names.
+matchRequestUrl(url, '/path/:chunks+').params.chunks.trim()

--- a/src/utils/matching/matchRequestUrl.test-d.ts
+++ b/src/utils/matching/matchRequestUrl.test-d.ts
@@ -1,0 +1,13 @@
+import { matchRequestUrl } from './matchRequestUrl'
+
+const url = new URL('')
+
+// Path parameter type is inferred from the path string.
+matchRequestUrl(url, '/user/:id').params.id.trim()
+
+// @ts-expect-error Property "foo" doesn't exist in path params.
+matchRequestUrl(url, '/user/:id').params.foo
+
+// Multiple occurrences of the same path parameter
+// are inferred as a readonly array of strings.
+matchRequestUrl(url, '/:a/chunk/:a').params.a.map

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -4,6 +4,12 @@ import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp
 
+type NormalizeParamName<P extends string> = P extends
+  | `${infer N}+`
+  | `${infer N}*`
+  ? N
+  : P
+
 type IsUnique<
   P extends string,
   R extends string,
@@ -30,11 +36,12 @@ export type PathParamsString<
   R extends string,
   O extends string = R,
 > = R extends `${infer _Before}:${infer P}/${infer After}`
-  ? Record<P, StringOrArray<P, O>> & PathParamsString<After, O>
+  ? Record<NormalizeParamName<P>, StringOrArray<P, O>> &
+      PathParamsString<After, O>
   : R extends `${infer _Before}:${infer P}`
-  ? Record<P, StringOrArray<P, O>>
+  ? Record<NormalizeParamName<P>, StringOrArray<P, O>>
   : R extends `:${infer P}`
-  ? Record<P, StringOrArray<P, O>>
+  ? Record<NormalizeParamName<P>, StringOrArray<P, O>>
   : DefaultParamsType
 
 export type DefaultParamsType = Record<string, string | string[]>

--- a/test-d.tsconfig.json
+++ b/test-d.tsconfig.json
@@ -9,9 +9,9 @@
     "baseUrl": ".",
     "typeRoots": ["node_modules/@types"],
     "paths": {
-      "msw": ["../../"]
+      "msw": ["."]
     }
   },
-  "include": ["../../global.d.ts", "**/*.test-d.ts"],
+  "include": ["global.d.ts", "**/*.test-d.ts"],
   "exclude": ["node_modules"]
 }

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -17,8 +17,18 @@ rest.get<never, never, { postCount: number }>('/user', (req, res, ctx) => {
   return res(ctx.json({ postCount: 2 }))
 })
 
-rest.get<never, { userId: string }>('/user/:userId', (req) => {
-  req.params.userId
+rest.get('/user/:userId', (req) => {
+  // Path parameter type is inferred from the path string.
+  req.params.userId.trim()
+
+  // @ts-expect-error `unknown` is not defined in the request params type.
+  req.params.unknown
+})
+
+rest.get('/user/:id/message/:id', (req) => {
+  // Multiple same path parameters are inferred
+  // as a read-only array of strings.
+  req.params.id.map
 
   // @ts-expect-error `unknown` is not defined in the request params type.
   req.params.unknown
@@ -43,14 +53,14 @@ rest.get<never, never, string | string[]>('/user', (req, res, ctx) =>
   res(ctx.json('hello')),
 )
 
-rest.get<never>('/user/:id', (req, res, ctx) => {
-  const { userId } = req.params
+rest.get('/user/:id', (req, res, ctx) => {
+  const { id } = req.params
 
   return res(
     ctx.body(
-      // @ts-expect-error "userId" parameter is not annotated
-      // and is ambiguous (string | string[]).
-      userId,
+      // The type of the "id" path parameter
+      // is inferred from the path string.
+      id,
     ),
   )
 })

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -1,6 +1,6 @@
 import { rest } from 'msw'
 
-rest.get<never, never, { postCount: number }>('/user', (req, res, ctx) => {
+rest.get<never, { postCount: number }>('/user', (req, res, ctx) => {
   // @ts-expect-error `session` property is not defined on the request body type.
   req.body.session
 
@@ -34,43 +34,38 @@ rest.get('/user/:id/message/:id', (req) => {
   req.params.unknown
 })
 
-rest.post<// @ts-expect-error `null` is not a valid request body type.
-null>('/submit', () => null)
+rest.post<null, { a: number }>('/submit', (req, res, ctx) => {
+  // @ts-expect-error Request body is annotated as null.
+  req.body.toString()
 
-rest.get<
-  any,
-  // @ts-expect-error `null` is not a valid response body type.
-  null
->('/user', () => null)
+  return res(
+    // @ts-expect-error Response body is annotated as non-nullable.
+    // Ignore the "unused directive" TS error: again some "tsc" versions mismatch.
+    ctx.json(null),
+  )
+})
 
-rest.get<never, never, { label: boolean }>('/user', (req, res, ctx) =>
+rest.get<any, null>('/user', (req, res, ctx) => {
+  return res(
+    // @ts-expect-error Response body must be null.
+    ctx.json({ value: 'no-op' }),
+  )
+})
+
+rest.get<never, { label: boolean }>('/user', (req, res, ctx) =>
   // allow ResponseTransformer to contain a more specific type
   res(ctx.json({ label: true })),
 )
 
-rest.get<never, never, string | string[]>('/user', (req, res, ctx) =>
+rest.get<never, string | string[]>('/user', (req, res, ctx) =>
   // allow ResponseTransformer to return a narrower type than a given union
   res(ctx.json('hello')),
 )
 
-rest.get('/user/:id', (req, res, ctx) => {
-  const { id } = req.params
-
-  return res(
-    ctx.body(
-      // The type of the "id" path parameter
-      // is inferred from the path string.
-      id,
-    ),
-  )
+rest.get('/user/:id', (req) => {
+  // The "id" path parameter type is inferred as string.
+  req.params.id.toUpperCase()
 })
-
-rest.get<
-  never,
-  // @ts-expect-error Path parameters are always strings.
-  // Parse them to numbers in the resolver if necessary.
-  { id: number }
->('/posts/:id', () => null)
 
 rest.head('/user', (req) => {
   // @ts-expect-error GET requests cannot have body.


### PR DESCRIPTION
- Implements #429 

**This is a work in progress**

I am trying to redefine `PathParams` type to only include properties based on the `route`.

This is the main change I aim to introduce:

``` typescript
type PathParams<R extends string, O extends string = R> = /* where R = "route", and the O = "original route" */
  R extends `${infer _Before}:${infer P}/${infer After}` ? (Record<P,StringOrArray<P,O>> & PathParams<After,O>) :
  R extends `${infer _Before}:${infer P}` ? Record<P,StringOrArray<P,O>> :
  R extends `:${infer P}` ? Record<P,StringOrArray<P,O>> : unknown;
```

`StringOrArray` inspects the route and decides if the param `P` appears once or multiple times,
and returns a `string` or `string[]`.

I know I am supposed to write unit tests first; it is just this is my first time writing _unit tests for types_ so I am a bit lost here. I kind of wrote a few "unit tests" while I wrote the type, [you can see them in this playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAkgzgVQHYEsCOBXCAeAClCAD2AiQBM4o5gAnFJAcwBooAlA40iq2+hgPigBeKAFgAUFDYcS5SgAMAJAG96AMwg0oAfQBCENQHsaEAL4AuFblMr1mqAEE1JGqflQA-FAAU8ZOiw8FicXQSJZblosTyg1AEMAGzhocygoiABKKHMJKXZwrgVLZWsAencvdOzYxOSJZVyoAGNDJGo0miwARlS-VEwcAHIMfqxBlkHzEYCIQcERdMaWtuAOrAAmXsRRoemB8ahJvaxSueE1iCXW9vSAZi3-AexhnYPB0qnX+YurlYuAFgeO2ex1mEw+ZAwYFKoIhUI+oLOC06l0kzWuq3SAFYgTMQa9weZIdDYUT4Z8ZqdvotxL92vEkhAerBtnjBhBGW9zABbCCGADuVPODLqaOW9NqEE2LMegXZnImPL5gqRNUZdNWIog9xlwPlyTeH15AtVWo1auSgN1bOJhrJJJ2cOhFP23zN4lMEgkoEgUAAyrxGAB5GgOGg0OIgbAAdRkhR4dEYLD9cbkCb480afTx0aYfrCnDTVS81ETDGqpb4AG0ALoAbnq5rgqQDZZDYYjUZeMztxJhjvtCMdqu7+3NcRbgYY7fDkeetsJfdJfZdJ1VVcGtprEk94lKpTS4GgrEMGBIADVEoF8AU05Wk9Jb9x7wJzqwIC0aGQgv6pzPOz+rD8PwEhEGAxiYkeUC4HEwAABYwRG3JwOs2D5IWz5TiwQapphZZvpmaLoRECi2EgGhaHoBjGGYxR2FoZRkRRjjOJobgxN476ft+uB5n+oazlGvFBsBUAAGTQbBCFxEhKHYCEmhMCJWQ5ERuGkao5H2FRRgmBYTH2NYFRsB+xg8XxbYCQBwmiapeTqVA8h0VpDHsV4XFmUErZ8P+c42YIqQjAA1kgApIA24gNGKGJQGAUnMjB8GIXEyGoe8g7LuSiLfFFUhSMSqQbl0gw1kwjRSKCqSDOs4yNKYEVSOKqxxfB0qJdJslpU6-aUoOq4QEKIi5XlBVQEVJVlWiFU7FVNWTVI9Xmi1cE6u1yWpc8-WqsN00zLNtVoot0V-MtVprTJKVyUcw45eVUCVYcc11Q16InVJOKSUlF0bel2XnDt90zY9B0LRFphAA) but I am still not sure how to write them in the code; maybe under `test/typings/rest.test-d.ts`?

In any case, I need help building the project since this change broke the existing tests. Eventually I will understand what's wrong, but it will probably take me a while since I am not familiar with all the interfaces yet.

This is the tail of the output from `yarn build `, when running `tsc`:

``` shell
$ tsc -p test/typings/tsconfig.json
test/typings/rest.test-d.ts:32:3 - error TS2578: Unused '@ts-expect-error' directive.

32   // @ts-expect-error `null` is not a valid response body type.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

test/typings/rest.test-d.ts:34:18 - error TS2322: Type 'null' is not assignable to type 'AsyncResponseResolverReturnType<MockedResponse<DefaultRequestBody>>'.

34 >('/user', () => null)
                    ~~~~

  lib/types/handlers/RequestHandler.d.ts:42:122
    42 export declare type ResponseResolver<RequestType = MockedRequest, ContextType = typeof defaultContext, BodyType = any> = (req: RequestType, res: ResponseComposition<BodyType>, context: ContextType) => AsyncResponseResolverReturnType<MockedResponse<BodyType>>;
                                                                                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    The expected type comes from the return type of this signature.

test/typings/rest.test-d.ts:47:11 - error TS2339: Property 'userId' does not exist on type 'unknown'.

47   const { userId } = req.params
             ~~~~~~

test/typings/rest.test-d.ts:51:7 - error TS2578: Unused '@ts-expect-error' directive.

51       // @ts-expect-error "userId" parameter is not annotated
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

test/typings/rest.test-d.ts:60:3 - error TS2578: Unused '@ts-expect-error' directive.

60   // @ts-expect-error Path parameters are always strings.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

test/typings/rest.test-d.ts:63:23 - error TS2322: Type 'null' is not assignable to type 'AsyncResponseResolverReturnType<MockedResponse<DefaultRequestBody>>'.

63 >('/posts/:id', () => null)
                         ~~~~

  lib/types/handlers/RequestHandler.d.ts:42:122
    42 export declare type ResponseResolver<RequestType = MockedRequest, ContextType = typeof defaultContext, BodyType = any> = (req: RequestType, res: ResponseComposition<BodyType>, context: ContextType) => AsyncResponseResolverReturnType<MockedResponse<BodyType>>;
                                                                                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    The expected type comes from the return type of this signature.


Found 6 errors.
```