### PR TITLE
chore: schedule daily releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: release
 
 on:
+  schedule:
+    - cron: '0 23 * * *'
   workflow_run:
     workflows: ['ci']
     branches: [main]


### PR DESCRIPTION
Runs the `release` workflow once per day at 23:00 only if the `ci` workflow has successded.