### PR TITLE
fix: allow variables inference in GraphQLRequest

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -36,7 +36,12 @@ function createScopedGraphQLHandler(
       GraphQLContext<Query>
     >,
   ) => {
-    return new GraphQLHandler(operationType, operationName, url, resolver)
+    return new GraphQLHandler<GraphQLRequest<Variables>>(
+      operationType,
+      operationName,
+      url,
+      resolver,
+    )
   }
 }
 
@@ -50,7 +55,12 @@ function createGraphQLOperationHandler(url: Path) {
       GraphQLContext<Query>
     >,
   ) => {
-    return new GraphQLHandler('all', new RegExp('.*'), url, resolver)
+    return new GraphQLHandler<GraphQLRequest<Variables>>(
+      'all',
+      new RegExp('.*'),
+      url,
+      resolver,
+    )
   }
 }
 

--- a/test/typings/graphql.test-d.ts
+++ b/test/typings/graphql.test-d.ts
@@ -1,5 +1,11 @@
 import { parse } from 'graphql'
-import { graphql } from 'msw'
+import {
+  MockedRequest,
+  GraphQLRequest,
+  graphql,
+  GraphQLHandler,
+  GraphQLVariables,
+} from 'msw'
 
 graphql.query<{ key: string }>('', (req, res, ctx) => {
   return res(
@@ -109,3 +115,21 @@ graphql.mutation(createUser, (req, res, ctx) =>
     }),
   ),
 )
+
+// GraphQL request variables must be inferrable
+// via the variables generic.
+function extractVariables<Variables extends GraphQLVariables>(
+  _handler: GraphQLHandler<GraphQLRequest<Variables>>,
+): MockedRequest<GraphQLRequest<Variables>> {
+  return null as any
+}
+const handlerWithVariables = graphql.query<{ data: unknown }, { id: string }>(
+  'GetUser',
+  () => void 0,
+)
+const handler = extractVariables(handlerWithVariables)
+
+handler.body.variables.id
+
+// @ts-expect-error Property "foo" is not defined on the variables generic.
+handler.body.variables.foo


### PR DESCRIPTION
I noticed that the return type of a `graphql.query<T, N>...` call is
`GraphQLHandler<GraphQLRequest<any>>` - it's not propagating the
variables generic parameter into the return type.  I assume this wasn't
intentional.

This change annotates the constructor of the `GraphQLHandler` class with
the correct generic parameters, so the return type should now be
`GraphQLHandler<GraphqlRequest<N>>`.