### PR TITLE
chore: run smoke tests on main only

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,13 +1,14 @@
 name: ci
 
 on:
-  push:
+  workflow_run:
+    workflows: ['ci']
     branches: [main]
-  pull_request:
-    branches: [main]
+    types: [completed]
 
 jobs:
-  build:
+  test-smoke:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,11 +16,8 @@ jobs:
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 
-      - name: Unit tests
-        run: yarn test:unit
-
       - name: Build
         run: yarn build
 
-      - name: Integration tests
-        run: yarn test:integration test/rest-api/basic.test.ts
+      - name: Smoke tests
+        run: yarn test:smoke


### PR DESCRIPTION
Running smoke tests takes up to 9 minutes. That reduces the iteration speed on pull requests. While I like the idea of testing all examples upon each change, it's often irrelevant and runs all the time, regardless if the changes affect examples or not (although that is not possible to assess reliably).

I suggest removing smoke tests from pull request builds and running them on merges to the default branch only. 