### PR TITLE
feat(ci): enable caching through `setup-node`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.14.0
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn install
 
       - name: Unit tests
         run: yarn test:unit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.14.0
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn install
 
       - name: Unit tests
         run: yarn test:unit

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,15 +11,17 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 16.14.0
+          cache: yarn
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: yarn install
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
Since newer versions of the `setup-node` handles caching, we can remove one extra action.