### PR TITLE
chore: use node 14 in codesandbox

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
-  "node": "12",
+  "node": "14",
   "sandboxes": ["msw-react-xx1c8"]
 }


### PR DESCRIPTION
It seems like engine requirements for dependencies are requiring the node 14 runtime. Since `devDependencies` has types for node 14 I thought it might make sense to just bump it.