### PR TITLE
fix(parseIsomorphicRequest): bypassing cookies properly

### DIFF
--- a/src/utils/request/parseIsomorphicRequest.test.ts
+++ b/src/utils/request/parseIsomorphicRequest.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { IsomorphicRequest } from '@mswjs/interceptors'
+import { Headers } from 'headers-polyfill/lib'
+import { parseIsomorphicRequest } from './parseIsomorphicRequest'
+
+function createIsomorphicRequest(
+  overrides: Partial<IsomorphicRequest> = {},
+): IsomorphicRequest {
+  return {
+    id: '1',
+    url: new URL(location.origin),
+    method: 'GET',
+    headers: new Headers([]),
+    credentials: 'same-origin',
+    ...overrides,
+  }
+}
+
+test('returns an mocked request with credentials=same-origin', () => {
+  const request = createIsomorphicRequest({
+    credentials: 'same-origin',
+    headers: new Headers({
+      Cookie: 'foo=bar',
+    }),
+  })
+  expect(parseIsomorphicRequest(request).credentials).toBe('same-origin')
+  expect(parseIsomorphicRequest(request).cookies).toEqual({ foo: 'bar' })
+})
+
+test('returns an mocked request with credentials=include', () => {
+  const request = createIsomorphicRequest({
+    credentials: 'include',
+    headers: new Headers({
+      Cookie: 'foo=bar',
+    }),
+  })
+  expect(parseIsomorphicRequest(request).credentials).toBe('include')
+  expect(parseIsomorphicRequest(request).cookies).toEqual({ foo: 'bar' })
+})

--- a/src/utils/request/parseIsomorphicRequest.test.ts
+++ b/src/utils/request/parseIsomorphicRequest.test.ts
@@ -9,12 +9,11 @@ function createIsomorphicRequest(
   overrides: Partial<IsomorphicRequest> = {},
 ): IsomorphicRequest {
   return {
-    id: '1',
-    url: new URL(location.origin),
-    method: 'GET',
-    headers: new Headers([]),
-    credentials: 'same-origin',
-    ...overrides,
+    id: overrides.id ?? '1',
+    url: overrides.url ?? new URL(location.origin),
+    method: overrides.method ?? 'GET',
+    headers: overrides.headers ?? new Headers([]),
+    credentials: overrides.credentials ?? 'same-origin',
   }
 }
 

--- a/src/utils/request/parseIsomorphicRequest.ts
+++ b/src/utils/request/parseIsomorphicRequest.ts
@@ -17,6 +17,9 @@ export function parseIsomorphicRequest(
     method: request.method,
     body: parseBody(request.body, request.headers),
     credentials: request.credentials || 'same-origin',
+
+    // The `setRequestCookies` will modify the `Headers` object but we don't want to modify the original header field.
+    // So we create new `Headers` instance here.
     headers: new Headers(Array.from(request.headers.entries())),
     cookies: {},
     redirect: 'manual',

--- a/src/utils/request/parseIsomorphicRequest.ts
+++ b/src/utils/request/parseIsomorphicRequest.ts
@@ -1,4 +1,5 @@
 import * as cookieUtils from 'cookie'
+import { Headers } from 'headers-polyfill/lib'
 import { IsomorphicRequest } from '@mswjs/interceptors'
 import { MockedRequest } from '../../handlers/RequestHandler'
 import { parseBody } from './parseBody'
@@ -15,7 +16,8 @@ export function parseIsomorphicRequest(
     url: request.url,
     method: request.method,
     body: parseBody(request.body, request.headers),
-    headers: request.headers,
+    credentials: request.credentials,
+    headers: new Headers(Array.from(request.headers.entries())),
     cookies: {},
     redirect: 'manual',
     referrer: '',
@@ -26,7 +28,6 @@ export function parseIsomorphicRequest(
     integrity: '',
     destination: 'document',
     bodyUsed: false,
-    credentials: 'same-origin',
   }
 
   // Set mocked request cookies from the `cookie` header of the original request.

--- a/src/utils/request/parseIsomorphicRequest.ts
+++ b/src/utils/request/parseIsomorphicRequest.ts
@@ -16,7 +16,7 @@ export function parseIsomorphicRequest(
     url: request.url,
     method: request.method,
     body: parseBody(request.body, request.headers),
-    credentials: request.credentials,
+    credentials: request.credentials || 'same-origin',
     headers: new Headers(Array.from(request.headers.entries())),
     cookies: {},
     redirect: 'manual',

--- a/src/utils/request/setRequestCookies.test.ts
+++ b/src/utils/request/setRequestCookies.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+import { Headers } from 'headers-polyfill/lib'
+import { setRequestCookies } from './setRequestCookies'
+import { createMockedRequest } from '../../../test/support/utils'
+
+beforeAll(() => {
+  document.cookie = ''
+})
+
+afterEach(() => {
+  document.cookie = ''
+})
+
+test('preserves request cookies when there are no document cookies to infer', () => {
+  const request = createMockedRequest({
+    headers: new Headers({
+      Cookie: 'token=abc-123',
+    }),
+  })
+  setRequestCookies(request)
+
+  expect(request.cookies).toEqual({
+    token: 'abc-123',
+  })
+  expect(request.headers.get('cookie')).toEqual('token=abc-123')
+})
+
+test('infers document cookies for request with "same-origin" credentials', () => {
+  // Emulate cookies already present on the document.
+  document.cookie = 'documentCookie=yes'
+
+  const request = createMockedRequest({
+    // Make the request to the same origin as the document location.
+    url: new URL('/resource', location.href),
+    headers: new Headers({
+      Cookie: 'token=abc-123',
+    }),
+    credentials: 'same-origin',
+  })
+  setRequestCookies(request)
+
+  expect(request.headers.get('cookie')).toEqual(
+    'token=abc-123, documentCookie=yes',
+  )
+  expect(request.cookies).toEqual({
+    // Cookies present in the document must be forwarded.
+    documentCookie: 'yes',
+    token: 'abc-123',
+  })
+})
+
+test('does not infer document cookies for request with "same-origin" credentials made to extraneous origin', () => {
+  // Emulate cookies already present on the document.
+  document.cookie = 'documentCookie=yes'
+
+  const request = createMockedRequest({
+    // Make the request to a different origin as the document location.
+    url: new URL('/resource', 'https://example.com'),
+    headers: new Headers({
+      Cookie: 'token=abc-123',
+    }),
+    credentials: 'same-origin',
+  })
+  setRequestCookies(request)
+
+  expect(request.headers.get('cookie')).toEqual('token=abc-123')
+  expect(request.cookies).toEqual({
+    token: 'abc-123',
+  })
+})
+
+test('infers document cookies for request with "include" credentials', () => {
+  // Emulate cookies already present on the document.
+  document.cookie = 'documentCookie=yes'
+
+  const request = createMockedRequest({
+    // Make the request to a different origin as the document location.
+    url: new URL('/resource', location.href),
+    headers: new Headers({
+      Cookie: 'token=abc-123',
+    }),
+    credentials: 'include',
+  })
+  setRequestCookies(request)
+
+  expect(request.headers.get('cookie')).toEqual(
+    'token=abc-123, documentCookie=yes',
+  )
+  expect(request.cookies).toEqual({
+    // Cookies present in the document must be forwarded regardless.
+    documentCookie: 'yes',
+    token: 'abc-123',
+  })
+})
+
+test('infers document cookies for request with "include" credentials made to extraneous origin', () => {
+  // Emulate cookies already present on the document.
+  document.cookie = 'documentCookie=yes'
+
+  const request = createMockedRequest({
+    // Make the request to a different origin as the document location.
+    url: new URL('/resource', 'https://example.com'),
+    headers: new Headers({
+      Cookie: 'token=abc-123',
+    }),
+    credentials: 'include',
+  })
+  setRequestCookies(request)
+
+  expect(request.headers.get('cookie')).toEqual(
+    'token=abc-123, documentCookie=yes',
+  )
+  expect(request.cookies).toEqual({
+    // Cookies present in the document must be forwarded regardless.
+    documentCookie: 'yes',
+    token: 'abc-123',
+  })
+})

--- a/src/utils/request/setRequestCookies.ts
+++ b/src/utils/request/setRequestCookies.ts
@@ -1,23 +1,53 @@
+import * as cookieUtils from 'cookie'
 import { store } from '@mswjs/cookies'
 import { MockedRequest } from '../../handlers/RequestHandler'
 import { getRequestCookies } from './getRequestCookies'
 
-export function setRequestCookies(request: MockedRequest) {
+/**
+ * Sets relevant cookies on the request.
+ * Request cookies are taken from the following sources:
+ * - Immediate (own) request cookies (those in the "Cookie" request header);
+ * - From the `document.cookie` based on the request's `credentials` value;
+ * - From the internal cookie store that persists/hydrates cookies in Node.js
+ */
+export function setRequestCookies(request: MockedRequest): void {
+  // Set mocked request cookies from the `cookie` header of the original request.
+  // No need to take `credentials` into account, because in Node.js requests are intercepted
+  // _after_ they happen. Request issuer should have already taken care of sending relevant cookies.
+  // Unlike browser, where interception is on the worker level, _before_ the request happens.
+  const requestCookiesString = request.headers.get('cookie')
+
   store.hydrate()
-  request.cookies = {
-    ...getRequestCookies(request),
-    ...Array.from(
-      store.get({ ...request, url: request.url.toString() })?.entries(),
-    ).reduce(
-      (cookies, [name, { value }]) => Object.assign(cookies, { [name]: value }),
-      {},
-    ),
+
+  const cookiesFromStore = Array.from(
+    store.get({ ...request, url: request.url.toString() })?.entries(),
+  ).reduce((cookies, [name, { value }]) => {
+    return Object.assign(cookies, { [name.trim()]: value })
+  }, {})
+
+  const cookiesFromDocument = getRequestCookies(request)
+
+  const forwardedCookies = {
+    ...cookiesFromDocument,
+    ...cookiesFromStore,
   }
 
-  request.headers.set(
-    'cookie',
-    Object.entries(request.cookies)
-      .map(([name, value]) => `${name}=${value}`)
-      .join('; '),
-  )
+  // Ensure the persisted (document) cookies are propagated to the request.
+  // Propagated the cookies persisted in the Cookuie Store to the request headers.
+  // This forwards relevant request cookies based on the request's credentials.
+  for (const [name, value] of Object.entries(forwardedCookies)) {
+    request.headers.append('cookie', `${name}=${value}`)
+  }
+
+  const ownCookies = requestCookiesString
+    ? cookieUtils.parse(requestCookiesString)
+    : {}
+
+  console.log({ cookiesFromDocument, cookiesFromStore, ownCookies, request })
+
+  request.cookies = {
+    ...request.cookies,
+    ...forwardedCookies,
+    ...ownCookies,
+  }
 }

--- a/test/support/utils.ts
+++ b/test/support/utils.ts
@@ -3,6 +3,7 @@ import { Headers } from 'headers-polyfill'
 import { MockedRequest } from './../../src'
 import { uuidv4 } from '../../src/utils/internal/uuidv4'
 import { ChildProcess } from 'child_process'
+import { IsomorphicRequest } from '@mswjs/interceptors'
 
 export function sleep(duration: number) {
   return new Promise((resolve) => {
@@ -37,6 +38,19 @@ export function createMockedRequest(
     keepalive: true,
     cookies: {},
     ...init,
+  }
+}
+
+export function createIsomorphicRequest(
+  initialValues: Partial<IsomorphicRequest> = {},
+): IsomorphicRequest {
+  return {
+    id: uuidv4(),
+    method: 'GET',
+    url: new URL('/', location.href),
+    headers: new Headers(),
+    credentials: 'same-origin',
+    ...initialValues,
   }
 }
 


### PR DESCRIPTION
Fix #1154

This PR aims to bypass correctly APIs that require cookies.

I've created the [msw-snapshot](https://github.com/hrsh7th/msw-snapshot) package for testing that will response from actual server or disk-cache.
I met this problem in the test with the API that requires the login session.
