### PR TITLE
chore: list semantic-release plugins explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache: yarn
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Unit tests
         run: yarn test:unit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.14.0
           cache: yarn
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Unit tests
         run: yarn test:unit
@@ -34,5 +34,7 @@ jobs:
       - name: Publish
         run: yarn release
         env:
+          GIT_COMMITTER_NAME: kettanaito
+          GIT_COMMITTER_EMAIL: kettanaito@gmail.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'footer-max-line-length': [1, 'always'],
+  },
 }

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,11 @@
 /** @type {import('semantic-release').GlobalConfig} */
 module.exports = {
   branches: ['main'],
-  plugins: ['@semantic-release/git'],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/npm',
+    '@semantic-release/github',
+    '@semantic-release/git',
+  ],
 }


### PR DESCRIPTION
Fixes a broken release pipeline where it executes only the `@semantic-release/git` plugin and nothing else (no publishing). 