### PR TITLE
ci(workflows): upgrade actions/checkout and actions/setup-node to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         node: [14, 16]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: yarn

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.14.0
           cache: yarn


### PR DESCRIPTION
# Description
* `ci.yml`
  * Upgrade `actions/checkout` from `v2` to `v3`
  * Upgrade `actions/setup-node` from `v2` to `v3`
* `smoke.yml`
  * Upgrade `actions/checkout` from `v2` to `v3`
  * Upgrade `actions/setup-node` from `v2` to `v3`