### PR TITLE
feat: add service worker scope and worker script URL to "Mocking enabled" message

### DIFF
--- a/src/setupWorker/start/createFallbackStart.ts
+++ b/src/setupWorker/start/createFallbackStart.ts
@@ -11,7 +11,7 @@ export function createFallbackStart(
       options,
     )
 
-    printStartMessage({
+    printStartMessage(context, {
       message: 'Mocking enabled (fallback mode).',
       quiet: options.quiet,
     })

--- a/src/setupWorker/start/createFallbackStart.ts
+++ b/src/setupWorker/start/createFallbackStart.ts
@@ -11,7 +11,7 @@ export function createFallbackStart(
       options,
     )
 
-    printStartMessage(context, {
+    printStartMessage({
       message: 'Mocking enabled (fallback mode).',
       quiet: options.quiet,
     })

--- a/src/setupWorker/start/utils/enableMocking.ts
+++ b/src/setupWorker/start/utils/enableMocking.ts
@@ -10,6 +10,8 @@ export async function enableMocking(
 ) {
   context.workerChannel.send('MOCK_ACTIVATE')
   return context.events.once('MOCKING_ENABLED').then(() => {
-    printStartMessage({ quiet: options.quiet })
+    printStartMessage(context, {
+      quiet: options.quiet,
+    })
   })
 }

--- a/src/setupWorker/start/utils/enableMocking.ts
+++ b/src/setupWorker/start/utils/enableMocking.ts
@@ -10,8 +10,10 @@ export async function enableMocking(
 ) {
   context.workerChannel.send('MOCK_ACTIVATE')
   return context.events.once('MOCKING_ENABLED').then(() => {
-    printStartMessage(context, {
+    printStartMessage({
       quiet: options.quiet,
+      workerScope: context.registration?.scope,
+      workerUrl: context.worker?.scriptURL,
     })
   })
 }

--- a/src/setupWorker/start/utils/printStartMessage.test.ts
+++ b/src/setupWorker/start/utils/printStartMessage.test.ts
@@ -1,4 +1,3 @@
-import { SetupWorkerInternalContext } from '../../glossary'
 import { printStartMessage } from './printStartMessage'
 
 beforeAll(() => {
@@ -15,11 +14,10 @@ afterAll(() => {
 })
 
 test('prints out a default start message into console', () => {
-  const context = {
-    registration: { scope: 'scopeValue' },
-    worker: { scriptURL: 'scriptURLValue' },
-  } as SetupWorkerInternalContext
-  printStartMessage(context)
+  printStartMessage({
+    workerScope: 'http://localhost:3000/',
+    workerUrl: 'http://localhost:3000/worker.js',
+  })
 
   expect(console.groupCollapsed).toHaveBeenCalledWith(
     '%c[MSW] Mocking enabled.',
@@ -39,18 +37,20 @@ test('prints out a default start message into console', () => {
   )
 
   // Includes service worker scope.
-  expect(console.log).toHaveBeenCalledWith('Scope:', 'scopeValue')
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker scope:',
+    'http://localhost:3000/',
+  )
 
   // Includes service worker script location.
   expect(console.log).toHaveBeenCalledWith(
-    'Worker script location:',
-    'scriptURLValue',
+    'Worker script URL:',
+    'http://localhost:3000/worker.js',
   )
 })
 
 test('supports printing a custom start message', () => {
-  const context = {} as SetupWorkerInternalContext
-  printStartMessage(context, { message: 'Custom start message' })
+  printStartMessage({ message: 'Custom start message' })
 
   expect(console.groupCollapsed).toHaveBeenCalledWith(
     '%c[MSW] Custom start message',
@@ -59,9 +59,30 @@ test('supports printing a custom start message', () => {
 })
 
 test('does not print any messages when log level is quiet', () => {
-  const context = {} as SetupWorkerInternalContext
-  printStartMessage(context, { quiet: true })
+  printStartMessage({ quiet: true })
 
   expect(console.groupCollapsed).not.toHaveBeenCalled()
   expect(console.log).not.toHaveBeenCalled()
+})
+
+test('prints a worker scope in the start message', () => {
+  printStartMessage({
+    workerScope: 'http://localhost:3000/user',
+  })
+
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker scope:',
+    'http://localhost:3000/user',
+  )
+})
+
+test('prints a worker script url in the start message', () => {
+  printStartMessage({
+    workerUrl: 'http://localhost:3000/mockServiceWorker.js',
+  })
+
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker script URL:',
+    'http://localhost:3000/mockServiceWorker.js',
+  )
 })

--- a/src/setupWorker/start/utils/printStartMessage.test.ts
+++ b/src/setupWorker/start/utils/printStartMessage.test.ts
@@ -1,3 +1,4 @@
+import { SetupWorkerInternalContext } from '../../glossary'
 import { printStartMessage } from './printStartMessage'
 
 beforeAll(() => {
@@ -14,7 +15,11 @@ afterAll(() => {
 })
 
 test('prints out a default start message into console', () => {
-  printStartMessage()
+  const context = {
+    registration: { scope: 'scopeValue' },
+    worker: { scriptURL: 'scriptURLValue' },
+  } as SetupWorkerInternalContext
+  printStartMessage(context)
 
   expect(console.groupCollapsed).toHaveBeenCalledWith(
     '%c[MSW] Mocking enabled.',
@@ -32,10 +37,20 @@ test('prints out a default start message into console', () => {
   expect(console.log).toHaveBeenCalledWith(
     'Found an issue? https://github.com/mswjs/msw/issues',
   )
+
+  // Includes service worker scope.
+  expect(console.log).toHaveBeenCalledWith('Scope:', 'scopeValue')
+
+  // Includes service worker script location.
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker script location:',
+    'scriptURLValue',
+  )
 })
 
 test('supports printing a custom start message', () => {
-  printStartMessage({ message: 'Custom start message' })
+  const context = {} as SetupWorkerInternalContext
+  printStartMessage(context, { message: 'Custom start message' })
 
   expect(console.groupCollapsed).toHaveBeenCalledWith(
     '%c[MSW] Custom start message',
@@ -44,7 +59,8 @@ test('supports printing a custom start message', () => {
 })
 
 test('does not print any messages when log level is quiet', () => {
-  printStartMessage({ quiet: true })
+  const context = {} as SetupWorkerInternalContext
+  printStartMessage(context, { quiet: true })
 
   expect(console.groupCollapsed).not.toHaveBeenCalled()
   expect(console.log).not.toHaveBeenCalled()

--- a/src/setupWorker/start/utils/printStartMessage.ts
+++ b/src/setupWorker/start/utils/printStartMessage.ts
@@ -1,20 +1,16 @@
-import { SetupWorkerInternalContext } from '../../glossary'
 import { devUtils } from '../../../utils/internal/devUtils'
 
-interface PrintStartMessageArgs {
+export interface PrintStartMessageArgs {
   quiet?: boolean
   message?: string
-  scope?: string
-  workerLocation?: string
+  workerUrl?: string
+  workerScope?: string
 }
 
 /**
  * Prints a worker activation message in the browser's console.
  */
-export function printStartMessage(
-  context: SetupWorkerInternalContext,
-  args: PrintStartMessageArgs = {},
-) {
+export function printStartMessage(args: PrintStartMessageArgs = {}) {
   if (args.quiet) {
     return
   }
@@ -31,7 +27,14 @@ export function printStartMessage(
     'font-weight:normal',
   )
   console.log('Found an issue? https://github.com/mswjs/msw/issues')
-  console.log('Scope:', context.registration?.scope)
-  console.log('Worker script location:', context.worker?.scriptURL)
+
+  if (args.workerUrl) {
+    console.log('Worker script URL:', args.workerUrl)
+  }
+
+  if (args.workerScope) {
+    console.log('Worker scope:', args.workerScope)
+  }
+
   console.groupEnd()
 }

--- a/src/setupWorker/start/utils/printStartMessage.ts
+++ b/src/setupWorker/start/utils/printStartMessage.ts
@@ -1,14 +1,20 @@
+import { SetupWorkerInternalContext } from '../../glossary'
 import { devUtils } from '../../../utils/internal/devUtils'
 
 interface PrintStartMessageArgs {
   quiet?: boolean
   message?: string
+  scope?: string
+  workerLocation?: string
 }
 
 /**
  * Prints a worker activation message in the browser's console.
  */
-export function printStartMessage(args: PrintStartMessageArgs = {}) {
+export function printStartMessage(
+  context: SetupWorkerInternalContext,
+  args: PrintStartMessageArgs = {},
+) {
   if (args.quiet) {
     return
   }
@@ -25,5 +31,7 @@ export function printStartMessage(args: PrintStartMessageArgs = {}) {
     'font-weight:normal',
   )
   console.log('Found an issue? https://github.com/mswjs/msw/issues')
+  console.log('Scope:', context.registration?.scope)
+  console.log('Worker script location:', context.worker?.scriptURL)
   console.groupEnd()
 }

--- a/test/msw-api/setup-worker/start/start.test.ts
+++ b/test/msw-api/setup-worker/start/start.test.ts
@@ -57,3 +57,25 @@ test('resolves the "start" Promise when the worker has been activated', async ()
   expect(events[2]).toEqual('enabled message')
   expect(events).toHaveLength(3)
 })
+
+test('prints the start message when the worker has been registered', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'start.mocks.ts'),
+    routes(app) {
+      app.get('/worker.js', (req, res) => {
+        res.sendFile(path.resolve(__dirname, 'worker.delayed.js'))
+      })
+    },
+  })
+
+  await runtime.page.evaluate(() => {
+    return window.msw.startWorker()
+  })
+
+  expect(runtime.consoleSpy.get('log')).toContain(
+    `Worker scope: ${runtime.makeUrl('/')}`,
+  )
+  expect(runtime.consoleSpy.get('log')).toContain(
+    `Worker script URL: ${runtime.makeUrl('/worker.js')}`,
+  )
+})


### PR DESCRIPTION
close #1103

As discussed, printing service worker scope & location in "Mocking enabled" message.
Scope and location are found in context to get effective service worker values and not just user raw options.

## Question
Do we need to cover cases where these fields would not be present in context (Eg. worker or registration is null) ? I think it should not happen because mocking would not be enabled in this case anyway so we would not print this message, I would like your opinion on that as this is my first PR here.

## Screenshot
<img width="485" alt="Screenshot 2022-03-17 at 18 18 32" src="https://user-images.githubusercontent.com/15009534/158859446-92dad3e1-b7a1-4629-9986-8378a0e86c03.png">
