### PR TITLE
fix(graphql): prevents REST API requests with a "query" from being treated as GraphQL

### DIFF
--- a/src/utils/internal/parseGraphQLRequest.test.ts
+++ b/src/utils/internal/parseGraphQLRequest.test.ts
@@ -79,3 +79,23 @@ test('returns false given a GraphQL-incompatible request', () => {
   })
   expect(parseGraphQLRequest(postRequest)).toBeUndefined()
 })
+
+test('does not treat a REST API POST request with a "query" property as a GraphQL request', () => {
+  const postRequest = createMockedRequest({
+    method: 'POST',
+    url: new URL('http://localhost:8080/graphql'),
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    body: {
+      query: `manager:["yarn"]`,
+    },
+  })
+  expect(parseGraphQLRequest(postRequest)).toBeUndefined()
+})
+
+test('does not treat a REST API GET request with a "query" parameter as a GraphQL request', () => {
+  const getRequest = createMockedRequest({
+    method: 'GET',
+    url: new URL('http://localhost:8080/graphql?query={"manager":["yarn"]}'),
+  })
+  expect(parseGraphQLRequest(getRequest)).toBeUndefined()
+})

--- a/test/graphql-api/operation.test.ts
+++ b/test/graphql-api/operation.test.ts
@@ -1,8 +1,8 @@
 import * as path from 'path'
 import { pageWith } from 'page-with'
 import { executeGraphQLQuery } from './utils/executeGraphQLQuery'
-import { sleep } from '../support/utils'
 import { gql } from '../support/graphql'
+import { waitFor } from '../support/waitFor'
 
 function createRuntime() {
   return pageWith({
@@ -128,7 +128,6 @@ test('intercepts and mocks a GraphQL mutation', async () => {
 test('propagates parsing errors from the invalid GraphQL requests', async () => {
   const { page, consoleSpy } = await createRuntime()
   const INVALID_QUERY = `
-    # Intentionally invalid GraphQL query.
     query GetUser() {
       user { id
     }
@@ -139,15 +138,15 @@ test('propagates parsing errors from the invalid GraphQL requests', async () => 
   })
 
   // Await the console message, because you cannot await a failed response.
-  await sleep(500)
-
-  expect(consoleSpy.get('error')).toEqual(
-    expect.arrayContaining([
-      expect.stringContaining(
-        'Failed to intercept a GraphQL request to "POST http://localhost:8080/graphql": cannot parse query. See the error message from the parser below.\n\nSyntax Error: Expected "$", found ")".',
-      ),
-    ]),
-  )
+  await waitFor(() => {
+    expect(consoleSpy.get('error')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'Failed to intercept a GraphQL request to "POST http://localhost:8080/graphql": cannot parse query. See the error message from the parser below.\n\nSyntax Error: Expected "$", found ")".',
+        ),
+      ]),
+    )
+  })
 })
 
 test('bypasses seemingly compatible REST requests', async () => {


### PR DESCRIPTION
Fixes #1184 