### PR TITLE
feat: add "unhandledException" life-cycle event

### DIFF
--- a/src/sharedOptions.ts
+++ b/src/sharedOptions.ts
@@ -21,6 +21,7 @@ export interface LifeCycleEventsMap<ResponseType> {
   'request:end': (request: MockedRequest) => void
   'response:mocked': (response: ResponseType, requestId: string) => void
   'response:bypass': (response: ResponseType, requestId: string) => void
+  unhandledException: (error: Error, request: MockedRequest) => void
 }
 
 export type LifeCycleEventEmitter<ResponseType> = Pick<

--- a/test/msw-api/setup-worker/life-cycle-events/on.mocks.ts
+++ b/test/msw-api/setup-worker/life-cycle-events/on.mocks.ts
@@ -8,6 +8,9 @@ const worker = setupWorker(
   rest.post('/no-response', () => {
     return
   }),
+  rest.get('/unhandled-exception', () => {
+    throw new Error('Unhandled resolver error')
+  }),
 )
 
 worker.events.on('request:start', (req) => {
@@ -35,6 +38,12 @@ worker.events.on('response:mocked', async (res, requestId) => {
 worker.events.on('response:bypass', async (res, requestId) => {
   const body = await res.text()
   console.warn(`[response:bypass] ${body} ${requestId}`)
+})
+
+worker.events.on('unhandledException', (error, req) => {
+  console.warn(
+    `[unhandledException] ${req.method} ${req.url.href} ${req.id} ${error.message}`,
+  )
 })
 
 worker.start({

--- a/test/msw-api/setup-worker/life-cycle-events/on.test.ts
+++ b/test/msw-api/setup-worker/life-cycle-events/on.test.ts
@@ -92,6 +92,17 @@ test('emits events for an unhandled request', async () => {
   ])
 })
 
+test('emits unhandled exceptions in the request handler', async () => {
+  const runtime = await createRuntime()
+  const url = runtime.makeUrl('/unhandled-exception')
+  await runtime.request(url)
+  const requestId = getRequestId(runtime.consoleSpy)
+
+  expect(runtime.consoleSpy.get('warning')).toContain(
+    `[unhandledException] GET ${url} ${requestId} Unhandled resolver error`,
+  )
+})
+
 test('stops emitting events once the worker is stopped', async () => {
   const runtime = await createRuntime()
 


### PR DESCRIPTION
- Closes https://github.com/mswjs/msw/issues/754

Users can now react to errors thrown in their RequestHandlers. Before this PR all errors were silently converted into a 500 response (only in the browser). Now users can subscribe to a new event:

```js
worker.events.on('unhandledException', (error, request) => {})
```

