### PR TITLE
feat: add "req.passthrough"

### DIFF
--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -1,15 +1,13 @@
 import { DocumentNode, OperationTypeNode } from 'graphql'
 import { SerializedResponse } from '../setupWorker/glossary'
-import { set } from '../context/set'
-import { status } from '../context/status'
-import { delay } from '../context/delay'
-import { fetch } from '../context/fetch'
 import { data } from '../context/data'
 import { extensions } from '../context/extensions'
 import { errors } from '../context/errors'
 import { GraphQLPayloadContext } from '../typeUtils'
 import { cookie } from '../context/cookie'
 import {
+  defaultContext,
+  DefaultContext,
   MockedRequest,
   RequestHandler,
   RequestHandlerDefaultInfo,
@@ -36,22 +34,16 @@ export type GraphQLHandlerNameSelector = DocumentNode | RegExp | string
 // GraphQL related context should contain utility functions
 // useful for GraphQL. Functions like `xml()` bear no value
 // in the GraphQL universe.
-export type GraphQLContext<QueryType extends Record<string, unknown>> = {
-  set: typeof set
-  status: typeof status
-  delay: typeof delay
-  fetch: typeof fetch
-  data: GraphQLPayloadContext<QueryType>
-  extensions: GraphQLPayloadContext<QueryType>
-  errors: typeof errors
-  cookie: typeof cookie
-}
+export type GraphQLContext<QueryType extends Record<string, unknown>> =
+  DefaultContext & {
+    data: GraphQLPayloadContext<QueryType>
+    extensions: GraphQLPayloadContext<QueryType>
+    errors: typeof errors
+    cookie: typeof cookie
+  }
 
 export const graphqlContext: GraphQLContext<any> = {
-  set,
-  status,
-  delay,
-  fetch,
+  ...defaultContext,
   data,
   extensions,
   errors,

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -9,7 +9,14 @@ import { fetch } from '../context/fetch'
 import { ResponseResolutionContext } from '../utils/getResponse'
 import { SerializedResponse } from '../setupWorker/glossary'
 
-export const defaultContext = {
+export type DefaultContext = {
+  status: typeof status
+  set: typeof set
+  delay: typeof delay
+  fetch: typeof fetch
+}
+
+export const defaultContext: DefaultContext = {
   status,
   set,
   delay,

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -1,14 +1,4 @@
-import {
-  body,
-  cookie,
-  delay,
-  fetch,
-  json,
-  set,
-  status,
-  text,
-  xml,
-} from '../context'
+import { body, cookie, json, text, xml } from '../context'
 import { SerializedResponse } from '../setupWorker/glossary'
 import { ResponseResolutionContext } from '../utils/getResponse'
 import { devUtils } from '../utils/internal/devUtils'
@@ -28,6 +18,8 @@ import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromReques
 import { cleanUrl, getSearchParams } from '../utils/url/cleanUrl'
 import {
   DefaultBodyType,
+  defaultContext,
+  DefaultContext,
   MockedRequest,
   RequestHandler,
   RequestHandlerDefaultInfo,
@@ -54,28 +46,21 @@ export enum RESTMethods {
 
 // Declaring a context interface infers
 // JSDoc description of the referenced utils.
-export type RestContext = {
-  set: typeof set
-  status: typeof status
+export type RestContext = DefaultContext & {
   cookie: typeof cookie
   text: typeof text
   body: typeof body
   json: typeof json
   xml: typeof xml
-  delay: typeof delay
-  fetch: typeof fetch
 }
 
 export const restContext: RestContext = {
-  set,
-  status,
+  ...defaultContext,
   cookie,
   body,
   text,
   json,
   xml,
-  delay,
-  fetch,
 }
 
 export type RequestQuery = {

--- a/src/response.ts
+++ b/src/response.ts
@@ -2,6 +2,8 @@ import { Headers } from 'headers-polyfill'
 import { compose } from './utils/internal/compose'
 import { NetworkError } from './utils/NetworkError'
 
+export type MaybePromise<ValueType = any> = ValueType | Promise<ValueType>
+
 /**
  * Internal representation of a mocked response instance.
  */
@@ -11,6 +13,7 @@ export interface MockedResponse<BodyType = any> {
   statusText: string
   headers: Headers
   once: boolean
+  passthrough: boolean
   delay?: number
 }
 
@@ -19,11 +22,11 @@ export type ResponseTransformer<
   TransformerBodyType = any,
 > = (
   res: MockedResponse<TransformerBodyType>,
-) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
+) => MaybePromise<MockedResponse<BodyType>>
 
 export type ResponseFunction<BodyType = any> = (
   ...transformers: ResponseTransformer<BodyType>[]
-) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
+) => MaybePromise<MockedResponse<BodyType>>
 
 export type ResponseComposition<BodyType = any> = ResponseFunction<BodyType> & {
   /**
@@ -40,6 +43,7 @@ export const defaultResponse: Omit<MockedResponse, 'headers'> = {
   body: null,
   delay: 0,
   once: false,
+  passthrough: false,
 }
 
 export type ResponseCompositionOptions<BodyType> = {

--- a/src/utils/logging/prepareRequest.test.ts
+++ b/src/utils/logging/prepareRequest.test.ts
@@ -1,4 +1,5 @@
 import { Headers } from 'headers-polyfill'
+import { passthrough } from '../../handlers/RequestHandler'
 import { prepareRequest } from './prepareRequest'
 
 test('converts request headers into an object', () => {
@@ -22,6 +23,7 @@ test('converts request headers into an object', () => {
     body: 'text-body',
     bodyUsed: false,
     cookies: {},
+    passthrough,
   })
 
   // Converts `Headers` instance into inspectable object

--- a/src/utils/request/parseIsomorphicRequest.test.ts
+++ b/src/utils/request/parseIsomorphicRequest.test.ts
@@ -4,7 +4,7 @@
 import { Headers } from 'headers-polyfill/lib'
 import { parseIsomorphicRequest } from './parseIsomorphicRequest'
 import { createIsomorphicRequest } from '../../../test/support/utils'
-import { MockedRequest } from '../../handlers/RequestHandler'
+import { MockedRequest, passthrough } from '../../handlers/RequestHandler'
 
 test('parses an isomorphic request', () => {
   const request = parseIsomorphicRequest(
@@ -46,6 +46,7 @@ test('parses an isomorphic request', () => {
     body: {
       id: 'user-1',
     },
+    passthrough,
   })
 })
 

--- a/src/utils/request/parseIsomorphicRequest.ts
+++ b/src/utils/request/parseIsomorphicRequest.ts
@@ -1,5 +1,5 @@
 import { IsomorphicRequest } from '@mswjs/interceptors'
-import { MockedRequest } from '../../handlers/RequestHandler'
+import { MockedRequest, passthrough } from '../../handlers/RequestHandler'
 import { parseBody } from './parseBody'
 import { setRequestCookies } from './setRequestCookies'
 
@@ -26,6 +26,7 @@ export function parseIsomorphicRequest(
     integrity: '',
     destination: 'document',
     bodyUsed: false,
+    passthrough,
   }
 
   // Attach all the cookies from the virtual cookie store.

--- a/src/utils/request/parseWorkerRequest.ts
+++ b/src/utils/request/parseWorkerRequest.ts
@@ -1,4 +1,5 @@
 import { Headers } from 'headers-polyfill'
+import { passthrough } from '../../handlers/RequestHandler'
 import { RestRequest } from '../../handlers/RestHandler'
 import { ServiceWorkerIncomingRequest } from '../../setupWorker/glossary'
 import { setRequestCookies } from './setRequestCookies'
@@ -30,6 +31,7 @@ export function parseWorkerRequest(
     body: pruneGetRequestBody(rawRequest),
     bodyUsed: rawRequest.bodyUsed,
     headers: new Headers(rawRequest.headers),
+    passthrough,
   }
 
   // Set document cookies on the request.

--- a/src/utils/worker/createRequestListener.ts
+++ b/src/utils/worker/createRequestListener.ts
@@ -41,7 +41,7 @@ export const createRequestListener = (
               headers: response.headers.all(),
             }
           },
-          onBypassResponse() {
+          onPassthroughResponse() {
             return channel.send({
               type: 'MOCK_NOT_FOUND',
             })

--- a/test/msw-api/req/passthrough.mocks.ts
+++ b/test/msw-api/req/passthrough.mocks.ts
@@ -1,0 +1,15 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.post('/', (req) => {
+    return req.passthrough()
+  }),
+)
+
+worker.start()
+
+// @ts-ignore
+window.msw = {
+  worker,
+  rest,
+}

--- a/test/msw-api/req/passthrough.node.test.ts
+++ b/test/msw-api/req/passthrough.node.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { ServerApi, createServer } from '@open-draft/test-server'
+
+let httpServer: ServerApi
+const server = setupServer()
+
+interface ResponseBody {
+  name: string
+}
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.post<never, ResponseBody>('/user', (req, res) => {
+      res.json({ name: 'John' })
+    })
+  })
+
+  server.listen()
+
+  jest.spyOn(console, 'warn').mockImplementation()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  jest.resetAllMocks()
+})
+
+afterAll(async () => {
+  server.close()
+  jest.restoreAllMocks()
+  await httpServer.close()
+})
+
+it('performs request as-is when returning "req.passthrough" call in the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, (req) => {
+      return req.passthrough()
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
+it('does not allow fall-through when returning "req.passthrough" call in the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, (req) => {
+      return req.passthrough()
+    }),
+    rest.post<never, ResponseBody>(endpointUrl, (req, res, ctx) => {
+      return res(ctx.json({ name: 'Kate' }))
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
+it('prints a warning and performs a request as-is if nothing was returned from the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, () => {
+      return
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+
+  const warning = (console.warn as any as jest.SpyInstance).mock.calls[0][0]
+
+  expect(warning).toContain(
+    '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
+  )
+  expect(warning).toContain(`POST ${endpointUrl}`)
+  expect(console.warn).toHaveBeenCalledTimes(1)
+})

--- a/test/msw-api/req/passthrough.test.ts
+++ b/test/msw-api/req/passthrough.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { rest, SetupWorkerApi } from 'msw'
+import { createServer, ServerApi } from '@open-draft/test-server'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorkerApi
+    rest: typeof rest
+  }
+}
+
+interface ResponseBody {
+  name: string
+}
+
+function prepareRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'passthrough.mocks.ts'),
+  })
+}
+
+let httpServer: ServerApi
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.post<never, ResponseBody>('/user', (req, res) => {
+      res.json({ name: 'John' })
+    })
+  })
+})
+
+afterAll(async () => {
+  await httpServer.close()
+})
+
+it('performs request as-is when returning "req.passthrough" call in the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, (req) => {
+        return req.passthrough()
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+  expect(runtime.consoleSpy.get('warning')).toBeUndefined()
+})
+
+it('does not allow fall-through when returning "req.passthrough" call in the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, (req) => {
+        return req.passthrough()
+      }),
+      rest.post<never, ResponseBody>(endpointUrl, (req, res, ctx) => {
+        return res(ctx.json({ name: 'Kate' }))
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+  expect(runtime.consoleSpy.get('warning')).toBeUndefined()
+})
+
+it('prints a warning and performs a request as-is if nothing was returned from the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, () => {
+        return
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+
+  expect(runtime.consoleSpy.get('warning')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
+      ),
+    ]),
+  )
+})

--- a/test/support/utils.ts
+++ b/test/support/utils.ts
@@ -4,6 +4,7 @@ import { MockedRequest } from './../../src'
 import { uuidv4 } from '../../src/utils/internal/uuidv4'
 import { ChildProcess } from 'child_process'
 import { IsomorphicRequest } from '@mswjs/interceptors'
+import { passthrough } from '../../src/handlers/RequestHandler'
 
 export function sleep(duration: number) {
   return new Promise((resolve) => {
@@ -37,6 +38,7 @@ export function createMockedRequest(
     integrity: '',
     keepalive: true,
     cookies: {},
+    passthrough,
     ...init,
   }
 }


### PR DESCRIPTION
> This is a breaking change.

- Originates from #655
- Closes #676
- Closes #1180 
- Closes #962 
- Closes #923

## Changes

- Adds `req.passthrough` to explicitly instruct MSW to perform an intercepted request as-is.
- Returning `undefined`/`null` from handlers now treats the request as unhandled. 