### PR TITLE
chore: fail fast on failed ci tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  bail: true,
   roots: ['<rootDir>/src', '<rootDir>/cli'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',

--- a/test/msw-api/setup-worker/scenarios/iframe/iframe.test.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe/iframe.test.ts
@@ -10,6 +10,10 @@ function findFrame(frame: Frame) {
   return frame.name() === ''
 }
 
+// This has proven to be a rather flaky test.
+// Retry it a couple of times before failing the entire CI.
+jest.retryTimes(3)
+
 beforeAll(() => {
   jest.spyOn(global.console, 'warn')
 })


### PR DESCRIPTION
There's no need to wait 10 minutes to find out a test in the beginning of CI has failed. 