### PR TITLE
chore: fix TS 4.7 compatibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': [
       1,
       {
+        varsIgnorePattern: '^_',
         argsIgnorePattern: '^_',
       },
     ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
         run: yarn build
 
       - name: Integration tests
-        run: yarn test:integration test/rest-api/basic.test.ts
+        run: yarn test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         node: [14, 16]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,5 +36,6 @@ jobs:
         env:
           GIT_COMMITTER_NAME: kettanaito
           GIT_COMMITTER_EMAIL: kettanaito@gmail.com
-          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          GH_TOKE: ${{ secrets.GH_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.14.0
           cache: yarn

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ stats.html
 .vscode
 msw-*.tgz
 .husky/_
+.env

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  bail: true,
   roots: ['<rootDir>/src', '<rootDir>/cli'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "path-to-regexp": "^6.2.0",
     "statuses": "^2.0.0",
     "strict-event-emitter": "^0.2.0",
-    "type-fest": "^1.2.2",
+    "type-fest": "^2.12.2",
     "yargs": "^17.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:unit": "cross-env BABEL_ENV=test jest --maxWorkers=3",
     "test:integration": "jest --config=test/jest.config.js --maxWorkers=1",
     "test:smoke": "config/scripts/smoke.sh",
-    "test:ts": "tsc -p test/typings/tsconfig.json",
+    "test:ts": "tsc -p test-d.tsconfig.json",
     "prepare": "yarn simple-git-hooks init",
     "prepack": "yarn build",
     "release": "semantic-release",

--- a/release.config.js
+++ b/release.config.js
@@ -5,7 +5,13 @@ module.exports = {
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     '@semantic-release/npm',
+    [
+      '@semantic-release/git',
+      {
+        message:
+          'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+      },
+    ],
     '@semantic-release/github',
-    '@semantic-release/git',
   ],
 }

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -1,15 +1,13 @@
 import { DocumentNode, OperationTypeNode } from 'graphql'
 import { SerializedResponse } from '../setupWorker/glossary'
-import { set } from '../context/set'
-import { status } from '../context/status'
-import { delay } from '../context/delay'
-import { fetch } from '../context/fetch'
 import { data } from '../context/data'
 import { extensions } from '../context/extensions'
 import { errors } from '../context/errors'
 import { GraphQLPayloadContext } from '../typeUtils'
 import { cookie } from '../context/cookie'
 import {
+  defaultContext,
+  DefaultContext,
   MockedRequest,
   RequestHandler,
   RequestHandlerDefaultInfo,
@@ -36,22 +34,16 @@ export type GraphQLHandlerNameSelector = DocumentNode | RegExp | string
 // GraphQL related context should contain utility functions
 // useful for GraphQL. Functions like `xml()` bear no value
 // in the GraphQL universe.
-export type GraphQLContext<QueryType extends Record<string, unknown>> = {
-  set: typeof set
-  status: typeof status
-  delay: typeof delay
-  fetch: typeof fetch
-  data: GraphQLPayloadContext<QueryType>
-  extensions: GraphQLPayloadContext<QueryType>
-  errors: typeof errors
-  cookie: typeof cookie
-}
+export type GraphQLContext<QueryType extends Record<string, unknown>> =
+  DefaultContext & {
+    data: GraphQLPayloadContext<QueryType>
+    extensions: GraphQLPayloadContext<QueryType>
+    errors: typeof errors
+    cookie: typeof cookie
+  }
 
 export const graphqlContext: GraphQLContext<any> = {
-  set,
-  status,
-  delay,
-  fetch,
+  ...defaultContext,
   data,
   extensions,
   errors,

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -21,7 +21,7 @@ export type DefaultRequestMultipartBody = Record<
   string | File | (string | File)[]
 >
 
-export type DefaultRequestBody =
+export type DefaultBodyType =
   | Record<string, any>
   | DefaultRequestMultipartBody
   | string
@@ -30,7 +30,7 @@ export type DefaultRequestBody =
   | null
   | undefined
 
-export interface MockedRequest<Body = DefaultRequestBody> {
+export interface MockedRequest<Body extends DefaultBodyType = DefaultBodyType> {
   id: string
   url: URL
   method: Request['method']
@@ -77,9 +77,9 @@ export type AsyncResponseResolverReturnType<ReturnType> =
     >
 
 export type ResponseResolver<
-  RequestType = MockedRequest,
+  RequestType extends MockedRequest = MockedRequest,
   ContextType = typeof defaultContext,
-  BodyType = any,
+  BodyType extends DefaultBodyType = any,
 > = (
   req: RequestType,
   res: ResponseComposition<BodyType>,

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -1,5 +1,10 @@
 import { Headers } from 'headers-polyfill'
-import { MockedResponse, response, ResponseComposition } from '../response'
+import {
+  MaybePromise,
+  MockedResponse,
+  response,
+  ResponseComposition,
+} from '../response'
 import { getCallFrame } from '../utils/internal/getCallFrame'
 import { isIterable } from '../utils/internal/isIterable'
 import { status } from '../context/status'
@@ -9,7 +14,14 @@ import { fetch } from '../context/fetch'
 import { ResponseResolutionContext } from '../utils/getResponse'
 import { SerializedResponse } from '../setupWorker/glossary'
 
-export const defaultContext = {
+export type DefaultContext = {
+  status: typeof status
+  set: typeof set
+  delay: typeof delay
+  fetch: typeof fetch
+}
+
+export const defaultContext: DefaultContext = {
   status,
   set,
   delay,
@@ -47,6 +59,7 @@ export interface MockedRequest<Body extends DefaultBodyType = DefaultBodyType> {
   referrerPolicy: Request['referrerPolicy']
   body: Body
   bodyUsed: Request['bodyUsed']
+  passthrough: typeof passthrough
 }
 
 export interface RequestHandlerDefaultInfo {
@@ -64,9 +77,9 @@ export type ResponseResolverReturnType<ReturnType> =
   | undefined
   | void
 
-export type MaybeAsyncResponseResolverReturnType<ReturnType> =
-  | ResponseResolverReturnType<ReturnType>
-  | Promise<ResponseResolverReturnType<ReturnType>>
+export type MaybeAsyncResponseResolverReturnType<ReturnType> = MaybePromise<
+  ResponseResolverReturnType<ReturnType>
+>
 
 export type AsyncResponseResolverReturnType<ReturnType> =
   | MaybeAsyncResponseResolverReturnType<ReturnType>
@@ -270,5 +283,24 @@ export abstract class RequestHandler<
       request,
       response: response || null,
     }
+  }
+}
+
+/**
+ * Bypass this intercepted request.
+ * This will make a call to the actual endpoint requested.
+ */
+export function passthrough(): MockedResponse<null> {
+  // Constructing a dummy "101 Continue" mocked response
+  // to keep the return type of the resolver consistent.
+  return {
+    status: 101,
+    statusText: 'Continue',
+    headers: new Headers(),
+    body: null,
+    // Setting "passthrough" to true will signal the response pipeline
+    // to perform this intercepted request as-is.
+    passthrough: true,
+    once: false,
   }
 }

--- a/src/handlers/RestHandler.test-d.ts
+++ b/src/handlers/RestHandler.test-d.ts
@@ -1,0 +1,18 @@
+import { RestHandler, RESTMethods } from './RestHandler'
+
+/**
+ * Path parameter inference.
+ */
+new RestHandler(RESTMethods.GET, '/user/:id', (req) => {
+  req.params.id.trim()
+})
+
+new RestHandler(RESTMethods.POST, '/user/:id', (req) => {
+  // @ts-expect-error Property "foo" doesn't exist in path params.
+  req.params.foo
+})
+
+new RestHandler(RESTMethods.PUT, '/:service/user/:id/message/:id', (req) => {
+  req.params.service.trim()
+  req.params.id.map
+})

--- a/src/handlers/RestHandler.test.ts
+++ b/src/handlers/RestHandler.test.ts
@@ -1,17 +1,27 @@
 /**
  * @jest-environment jsdom
  */
-import { RestHandler, RestRequest, RestContext } from './RestHandler'
+import {
+  RestHandler,
+  RestRequest,
+  RestContext,
+  RESTMethods,
+} from './RestHandler'
 import { createMockedRequest } from '../../test/support/utils'
 import { response } from '../response'
 import { context } from '..'
 import { ResponseResolver } from './RequestHandler'
 
-const resolver: ResponseResolver<
-  RestRequest<{ userId: string }>,
-  RestContext
-> = (req, res, ctx) => {
-  return res(ctx.json({ userId: req.params.userId }))
+const resolver: ResponseResolver<RestRequest, RestContext> = (
+  req,
+  res,
+  ctx,
+) => {
+  return res(
+    ctx.json({
+      userId: req.params.userId,
+    }),
+  )
 }
 
 const generatorResolver: ResponseResolver<
@@ -28,7 +38,7 @@ const generatorResolver: ResponseResolver<
 
 describe('info', () => {
   test('exposes request handler information', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     expect(handler.info.header).toEqual('GET /user/:userId')
     expect(handler.info.method).toEqual('GET')
     expect(handler.info.path).toEqual('/user/:userId')
@@ -37,7 +47,7 @@ describe('info', () => {
 
 describe('parse', () => {
   test('parses a URL given a matching request', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const request = createMockedRequest({
       url: new URL('/user/abc-123', location.href),
     })
@@ -51,7 +61,7 @@ describe('parse', () => {
   })
 
   test('parses a URL and ignores the request method', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const request = createMockedRequest({
       method: 'POST',
       url: new URL('/user/def-456', location.href),
@@ -66,7 +76,7 @@ describe('parse', () => {
   })
 
   test('returns negative match result given a non-matching request', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const request = createMockedRequest({
       url: new URL('/login', location.href),
     })
@@ -80,7 +90,7 @@ describe('parse', () => {
 
 describe('predicate', () => {
   test('returns true given a matching request', () => {
-    const handler = new RestHandler('POST', '/login', resolver)
+    const handler = new RestHandler(RESTMethods.POST, '/login', resolver)
     const request = createMockedRequest({
       method: 'POST',
       url: new URL('/login', location.href),
@@ -109,7 +119,7 @@ describe('predicate', () => {
   })
 
   test('returns false given a non-matching request', () => {
-    const handler = new RestHandler('POST', '/login', resolver)
+    const handler = new RestHandler(RESTMethods.POST, '/login', resolver)
     const request = createMockedRequest({
       url: new URL('/user/abc-123', location.href),
     })
@@ -120,7 +130,7 @@ describe('predicate', () => {
 
 describe('test', () => {
   test('returns true given a matching request', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const firstTest = handler.test(
       createMockedRequest({
         url: new URL('/user/abc-123', location.href),
@@ -137,7 +147,7 @@ describe('test', () => {
   })
 
   test('returns false given a non-matching request', () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const firstTest = handler.test(
       createMockedRequest({
         url: new URL('/login', location.href),
@@ -162,7 +172,7 @@ describe('test', () => {
 
 describe('run', () => {
   test('returns a mocked response given a matching request', async () => {
-    const handler = new RestHandler('GET', '/user/:userId', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/user/:userId', resolver)
     const request = createMockedRequest({
       url: new URL('/user/abc-123', location.href),
     })
@@ -187,7 +197,7 @@ describe('run', () => {
   })
 
   test('returns null given a non-matching request', async () => {
-    const handler = new RestHandler('POST', '/login', resolver)
+    const handler = new RestHandler(RESTMethods.POST, '/login', resolver)
     const result = await handler.run(
       createMockedRequest({
         method: 'GET',
@@ -199,7 +209,7 @@ describe('run', () => {
   })
 
   test('returns an empty object as "req.params" given request with no URL parameters', async () => {
-    const handler = new RestHandler('GET', '/users', resolver)
+    const handler = new RestHandler(RESTMethods.GET, '/users', resolver)
     const result = await handler.run(
       createMockedRequest({
         url: new URL('/users', location.href),
@@ -212,7 +222,11 @@ describe('run', () => {
 
 describe('run with generator', () => {
   test('Resolver runs until generator completes', async () => {
-    const handler = new RestHandler('GET', '/users', generatorResolver)
+    const handler = new RestHandler(
+      RESTMethods.GET,
+      '/users',
+      generatorResolver,
+    )
     const run = async () => {
       const result = await handler.run(
         createMockedRequest({

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -1,14 +1,4 @@
-import {
-  body,
-  cookie,
-  delay,
-  fetch,
-  json,
-  set,
-  status,
-  text,
-  xml,
-} from '../context'
+import { body, cookie, json, text, xml } from '../context'
 import { SerializedResponse } from '../setupWorker/glossary'
 import { ResponseResolutionContext } from '../utils/getResponse'
 import { devUtils } from '../utils/internal/devUtils'
@@ -28,6 +18,8 @@ import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromReques
 import { cleanUrl, getSearchParams } from '../utils/url/cleanUrl'
 import {
   DefaultBodyType,
+  defaultContext,
+  DefaultContext,
   MockedRequest,
   RequestHandler,
   RequestHandlerDefaultInfo,
@@ -54,28 +46,21 @@ export enum RESTMethods {
 
 // Declaring a context interface infers
 // JSDoc description of the referenced utils.
-export type RestContext = {
-  set: typeof set
-  status: typeof status
+export type RestContext = DefaultContext & {
   cookie: typeof cookie
   text: typeof text
   body: typeof body
   json: typeof json
   xml: typeof xml
-  delay: typeof delay
-  fetch: typeof fetch
 }
 
 export const restContext: RestContext = {
-  set,
-  status,
+  ...defaultContext,
   cookie,
   body,
   text,
   json,
   xml,
-  delay,
-  fetch,
 }
 
 export type RequestQuery = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export type {
   ResponseResolver,
   ResponseResolverReturnType,
   AsyncResponseResolverReturnType,
-  DefaultRequestBody,
+  DefaultBodyType,
   DefaultRequestMultipartBody,
 } from './handlers/RequestHandler'
 
@@ -46,10 +46,12 @@ export type {
 } from './response'
 
 export type {
+  RestMethodType,
   RestContext,
   RequestQuery,
   RestRequest,
   ParsedRestRequest,
+  RestResponseResolver,
 } from './handlers/RestHandler'
 
 export type {
@@ -60,6 +62,11 @@ export type {
   GraphQLJsonRequestBody,
 } from './handlers/GraphQLHandler'
 
-export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
+export type {
+  Path,
+  Match,
+  ExtractPathParams,
+  DefaultParamsType,
+} from './utils/matching/matchRequestUrl'
 export type { DelayMode } from './context/delay'
 export { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'

--- a/src/response.ts
+++ b/src/response.ts
@@ -2,6 +2,8 @@ import { Headers } from 'headers-polyfill'
 import { compose } from './utils/internal/compose'
 import { NetworkError } from './utils/NetworkError'
 
+export type MaybePromise<ValueType = any> = ValueType | Promise<ValueType>
+
 /**
  * Internal representation of a mocked response instance.
  */
@@ -11,6 +13,7 @@ export interface MockedResponse<BodyType = any> {
   statusText: string
   headers: Headers
   once: boolean
+  passthrough: boolean
   delay?: number
 }
 
@@ -19,11 +22,11 @@ export type ResponseTransformer<
   TransformerBodyType = any,
 > = (
   res: MockedResponse<TransformerBodyType>,
-) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
+) => MaybePromise<MockedResponse<BodyType>>
 
 export type ResponseFunction<BodyType = any> = (
   ...transformers: ResponseTransformer<BodyType>[]
-) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
+) => MaybePromise<MockedResponse<BodyType>>
 
 export type ResponseComposition<BodyType = any> = ResponseFunction<BodyType> & {
   /**
@@ -40,6 +43,7 @@ export const defaultResponse: Omit<MockedResponse, 'headers'> = {
   body: null,
   delay: 0,
   once: false,
+  passthrough: false,
 }
 
 export type ResponseCompositionOptions<BodyType> = {

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,33 +1,33 @@
-import { DefaultRequestBody, ResponseResolver } from './handlers/RequestHandler'
+import { DefaultBodyType } from './handlers/RequestHandler'
 import {
   RESTMethods,
-  RestContext,
   RestHandler,
-  RestRequest,
+  RestResponseResolver,
 } from './handlers/RestHandler'
-import { Path, PathParams } from './utils/matching/matchRequestUrl'
+import { Path, ExtractPathParams } from './utils/matching/matchRequestUrl'
 
-function createRestHandler<Method extends RESTMethods | RegExp>(
-  method: Method,
+function createRestHandler<MethodType extends RESTMethods | RegExp>(
+  method: MethodType,
 ) {
   return <
-    RequestBodyType extends DefaultRequestBody = DefaultRequestBody,
-    Params extends PathParams = PathParams,
-    ResponseBody extends DefaultRequestBody = DefaultRequestBody,
+    RequestBodyType extends DefaultBodyType = DefaultBodyType,
+    ResponseBodyType extends DefaultBodyType = DefaultBodyType,
+    PathType extends Path = Path,
   >(
-    path: Path,
-    resolver: ResponseResolver<
-      RestRequest<
-        Method extends RESTMethods.HEAD | RESTMethods.GET
-          ? never
-          : RequestBodyType,
-        Params
-      >,
-      RestContext,
-      ResponseBody
+    path: PathType,
+    resolver: RestResponseResolver<
+      MethodType,
+      RequestBodyType,
+      ExtractPathParams<PathType>,
+      ResponseBodyType
     >,
   ) => {
-    return new RestHandler(method, path, resolver)
+    return new RestHandler<
+      MethodType,
+      PathType,
+      RequestBodyType,
+      ResponseBodyType
+    >(method, path, resolver as any)
   }
 }
 

--- a/src/setupWorker/start/utils/enableMocking.ts
+++ b/src/setupWorker/start/utils/enableMocking.ts
@@ -10,6 +10,10 @@ export async function enableMocking(
 ) {
   context.workerChannel.send('MOCK_ACTIVATE')
   return context.events.once('MOCKING_ENABLED').then(() => {
-    printStartMessage({ quiet: options.quiet })
+    printStartMessage({
+      quiet: options.quiet,
+      workerScope: context.registration?.scope,
+      workerUrl: context.worker?.scriptURL,
+    })
   })
 }

--- a/src/setupWorker/start/utils/printStartMessage.test.ts
+++ b/src/setupWorker/start/utils/printStartMessage.test.ts
@@ -14,7 +14,10 @@ afterAll(() => {
 })
 
 test('prints out a default start message into console', () => {
-  printStartMessage()
+  printStartMessage({
+    workerScope: 'http://localhost:3000/',
+    workerUrl: 'http://localhost:3000/worker.js',
+  })
 
   expect(console.groupCollapsed).toHaveBeenCalledWith(
     '%c[MSW] Mocking enabled.',
@@ -32,6 +35,18 @@ test('prints out a default start message into console', () => {
   expect(console.log).toHaveBeenCalledWith(
     'Found an issue? https://github.com/mswjs/msw/issues',
   )
+
+  // Includes service worker scope.
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker scope:',
+    'http://localhost:3000/',
+  )
+
+  // Includes service worker script location.
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker script URL:',
+    'http://localhost:3000/worker.js',
+  )
 })
 
 test('supports printing a custom start message', () => {
@@ -48,4 +63,26 @@ test('does not print any messages when log level is quiet', () => {
 
   expect(console.groupCollapsed).not.toHaveBeenCalled()
   expect(console.log).not.toHaveBeenCalled()
+})
+
+test('prints a worker scope in the start message', () => {
+  printStartMessage({
+    workerScope: 'http://localhost:3000/user',
+  })
+
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker scope:',
+    'http://localhost:3000/user',
+  )
+})
+
+test('prints a worker script url in the start message', () => {
+  printStartMessage({
+    workerUrl: 'http://localhost:3000/mockServiceWorker.js',
+  })
+
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker script URL:',
+    'http://localhost:3000/mockServiceWorker.js',
+  )
 })

--- a/src/setupWorker/start/utils/printStartMessage.ts
+++ b/src/setupWorker/start/utils/printStartMessage.ts
@@ -1,8 +1,10 @@
 import { devUtils } from '../../../utils/internal/devUtils'
 
-interface PrintStartMessageArgs {
+export interface PrintStartMessageArgs {
   quiet?: boolean
   message?: string
+  workerUrl?: string
+  workerScope?: string
 }
 
 /**
@@ -25,5 +27,14 @@ export function printStartMessage(args: PrintStartMessageArgs = {}) {
     'font-weight:normal',
   )
   console.log('Found an issue? https://github.com/mswjs/msw/issues')
+
+  if (args.workerUrl) {
+    console.log('Worker script URL:', args.workerUrl)
+  }
+
+  if (args.workerScope) {
+    console.log('Worker scope:', args.workerScope)
+  }
+
   console.groupEnd()
 }

--- a/src/sharedOptions.ts
+++ b/src/sharedOptions.ts
@@ -23,7 +23,9 @@ export interface LifeCycleEventsMap<ResponseType> {
   'response:bypass': (response: ResponseType, requestId: string) => void
 }
 
-export type LifeCycleEventEmitter<ResponseType> = Pick<
+export type LifeCycleEventEmitter<
+  ResponseType extends Record<string | symbol, any>,
+> = Pick<
   StrictEventEmitter<ResponseType>,
   'on' | 'removeListener' | 'removeAllListeners'
 >

--- a/src/utils/logging/prepareRequest.test.ts
+++ b/src/utils/logging/prepareRequest.test.ts
@@ -1,4 +1,5 @@
 import { Headers } from 'headers-polyfill'
+import { passthrough } from '../../handlers/RequestHandler'
 import { prepareRequest } from './prepareRequest'
 
 test('converts request headers into an object', () => {
@@ -22,6 +23,7 @@ test('converts request headers into an object', () => {
     body: 'text-body',
     bodyUsed: false,
     cookies: {},
+    passthrough,
   })
 
   // Converts `Headers` instance into inspectable object

--- a/src/utils/matching/matchRequestUrl.test-d.ts
+++ b/src/utils/matching/matchRequestUrl.test-d.ts
@@ -1,0 +1,16 @@
+import { matchRequestUrl } from './matchRequestUrl'
+
+const url = new URL('')
+
+// Path parameter type is inferred from the path string.
+matchRequestUrl(url, '/user/:id').params.id.trim()
+
+// @ts-expect-error Property "foo" doesn't exist in path params.
+matchRequestUrl(url, '/user/:id').params.foo
+
+// Multiple occurrences of the same path parameter
+// are inferred as a readonly array of strings.
+matchRequestUrl(url, '/:a/chunk/:a').params.a.map
+
+// Path parameter modifiers are stripped from the path names.
+matchRequestUrl(url, '/path/:chunks+').params.chunks.trim()

--- a/src/utils/request/parseIsomorphicRequest.test.ts
+++ b/src/utils/request/parseIsomorphicRequest.test.ts
@@ -4,7 +4,7 @@
 import { Headers } from 'headers-polyfill/lib'
 import { parseIsomorphicRequest } from './parseIsomorphicRequest'
 import { createIsomorphicRequest } from '../../../test/support/utils'
-import { MockedRequest } from '../../handlers/RequestHandler'
+import { MockedRequest, passthrough } from '../../handlers/RequestHandler'
 
 test('parses an isomorphic request', () => {
   const request = parseIsomorphicRequest(
@@ -46,6 +46,7 @@ test('parses an isomorphic request', () => {
     body: {
       id: 'user-1',
     },
+    passthrough,
   })
 })
 

--- a/src/utils/request/parseIsomorphicRequest.ts
+++ b/src/utils/request/parseIsomorphicRequest.ts
@@ -1,5 +1,5 @@
 import { IsomorphicRequest } from '@mswjs/interceptors'
-import { MockedRequest } from '../../handlers/RequestHandler'
+import { MockedRequest, passthrough } from '../../handlers/RequestHandler'
 import { parseBody } from './parseBody'
 import { setRequestCookies } from './setRequestCookies'
 
@@ -26,6 +26,7 @@ export function parseIsomorphicRequest(
     integrity: '',
     destination: 'document',
     bodyUsed: false,
+    passthrough,
   }
 
   // Attach all the cookies from the virtual cookie store.

--- a/src/utils/request/parseWorkerRequest.ts
+++ b/src/utils/request/parseWorkerRequest.ts
@@ -1,4 +1,5 @@
 import { Headers } from 'headers-polyfill'
+import { passthrough } from '../../handlers/RequestHandler'
 import { RestRequest } from '../../handlers/RestHandler'
 import { ServiceWorkerIncomingRequest } from '../../setupWorker/glossary'
 import { setRequestCookies } from './setRequestCookies'
@@ -30,6 +31,7 @@ export function parseWorkerRequest(
     body: pruneGetRequestBody(rawRequest),
     bodyUsed: rawRequest.bodyUsed,
     headers: new Headers(rawRequest.headers),
+    passthrough,
   }
 
   // Set document cookies on the request.

--- a/src/utils/worker/createRequestListener.ts
+++ b/src/utils/worker/createRequestListener.ts
@@ -41,7 +41,7 @@ export const createRequestListener = (
               headers: response.headers.all(),
             }
           },
-          onBypassResponse() {
+          onPassthroughResponse() {
             return channel.send({
               type: 'MOCK_NOT_FOUND',
             })

--- a/test-d.tsconfig.json
+++ b/test-d.tsconfig.json
@@ -9,9 +9,9 @@
     "baseUrl": ".",
     "typeRoots": ["node_modules/@types"],
     "paths": {
-      "msw": ["../../"]
+      "msw": ["."]
     }
   },
-  "include": ["../../global.d.ts", "**/*.test-d.ts"],
+  "include": ["global.d.ts", "**/*.test-d.ts"],
   "exclude": ["node_modules"]
 }

--- a/test/msw-api/req/passthrough.mocks.ts
+++ b/test/msw-api/req/passthrough.mocks.ts
@@ -1,0 +1,15 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.post('/', (req) => {
+    return req.passthrough()
+  }),
+)
+
+worker.start()
+
+// @ts-ignore
+window.msw = {
+  worker,
+  rest,
+}

--- a/test/msw-api/req/passthrough.node.test.ts
+++ b/test/msw-api/req/passthrough.node.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { ServerApi, createServer } from '@open-draft/test-server'
+
+let httpServer: ServerApi
+const server = setupServer()
+
+interface ResponseBody {
+  name: string
+}
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.post<never, ResponseBody>('/user', (req, res) => {
+      res.json({ name: 'John' })
+    })
+  })
+
+  server.listen()
+
+  jest.spyOn(console, 'warn').mockImplementation()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  jest.resetAllMocks()
+})
+
+afterAll(async () => {
+  server.close()
+  jest.restoreAllMocks()
+  await httpServer.close()
+})
+
+it('performs request as-is when returning "req.passthrough" call in the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, (req) => {
+      return req.passthrough()
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
+it('does not allow fall-through when returning "req.passthrough" call in the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, (req) => {
+      return req.passthrough()
+    }),
+    rest.post<never, ResponseBody>(endpointUrl, (req, res, ctx) => {
+      return res(ctx.json({ name: 'Kate' }))
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
+it('prints a warning and performs a request as-is if nothing was returned from the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, () => {
+      return
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+
+  const warning = (console.warn as any as jest.SpyInstance).mock.calls[0][0]
+
+  expect(warning).toContain(
+    '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
+  )
+  expect(warning).toContain(`POST ${endpointUrl}`)
+  expect(console.warn).toHaveBeenCalledTimes(1)
+})

--- a/test/msw-api/req/passthrough.test.ts
+++ b/test/msw-api/req/passthrough.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { rest, SetupWorkerApi } from 'msw'
+import { createServer, ServerApi } from '@open-draft/test-server'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorkerApi
+    rest: typeof rest
+  }
+}
+
+interface ResponseBody {
+  name: string
+}
+
+function prepareRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'passthrough.mocks.ts'),
+  })
+}
+
+let httpServer: ServerApi
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.post<never, ResponseBody>('/user', (req, res) => {
+      res.json({ name: 'John' })
+    })
+  })
+})
+
+afterAll(async () => {
+  await httpServer.close()
+})
+
+it('performs request as-is when returning "req.passthrough" call in the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, (req) => {
+        return req.passthrough()
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+  expect(runtime.consoleSpy.get('warning')).toBeUndefined()
+})
+
+it('does not allow fall-through when returning "req.passthrough" call in the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, (req) => {
+        return req.passthrough()
+      }),
+      rest.post<never, ResponseBody>(endpointUrl, (req, res, ctx) => {
+        return res(ctx.json({ name: 'Kate' }))
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+  expect(runtime.consoleSpy.get('warning')).toBeUndefined()
+})
+
+it('prints a warning and performs a request as-is if nothing was returned from the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, () => {
+        return
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+
+  expect(runtime.consoleSpy.get('warning')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
+      ),
+    ]),
+  )
+})

--- a/test/msw-api/setup-server/scenarios/generator.node.test.ts
+++ b/test/msw-api/setup-server/scenarios/generator.node.test.ts
@@ -2,61 +2,51 @@ import fetch from 'node-fetch'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 
-type RequestParams = {
-  maxCount: string
-}
-
 const server = setupServer(
-  rest.get<never, RequestParams>(
-    '/polling/:maxCount',
-    function* (req, res, ctx) {
-      const maxCount = parseInt(req.params.maxCount)
-      let count = 0
+  rest.get('/polling/:maxCount', function* (req, res, ctx) {
+    const maxCount = parseInt(req.params.maxCount)
+    let count = 0
 
-      while (count < maxCount) {
-        count += 1
-        yield res(
-          ctx.json({
-            status: 'pending',
-            count,
-          }),
-        )
-      }
-
-      return res(
+    while (count < maxCount) {
+      count += 1
+      yield res(
         ctx.json({
-          status: 'complete',
+          status: 'pending',
           count,
         }),
       )
-    },
-  ),
+    }
 
-  rest.get<never, RequestParams>(
-    '/polling/once/:maxCount',
-    function* (req, res, ctx) {
-      const maxCount = parseInt(req.params.maxCount)
-      let count = 0
+    return res(
+      ctx.json({
+        status: 'complete',
+        count,
+      }),
+    )
+  }),
 
-      while (count < maxCount) {
-        count += 1
-        yield res(
-          ctx.json({
-            status: 'pending',
-            count,
-          }),
-        )
-      }
+  rest.get('/polling/once/:maxCount', function* (req, res, ctx) {
+    const maxCount = parseInt(req.params.maxCount)
+    let count = 0
 
-      return res.once(
+    while (count < maxCount) {
+      count += 1
+      yield res(
         ctx.json({
-          status: 'complete',
+          status: 'pending',
           count,
         }),
       )
-    },
-  ),
-  rest.get<never, RequestParams>('/polling/once/:maxCount', (req, res, ctx) => {
+    }
+
+    return res.once(
+      ctx.json({
+        status: 'complete',
+        count,
+      }),
+    )
+  }),
+  rest.get('/polling/once/:maxCount', (req, res, ctx) => {
     return res(ctx.json({ status: 'done' }))
   }),
 )

--- a/test/msw-api/setup-worker/scenarios/iframe/iframe.test.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe/iframe.test.ts
@@ -10,6 +10,10 @@ function findFrame(frame: Frame) {
   return frame.name() === ''
 }
 
+// This has proven to be a rather flaky test.
+// Retry it a couple of times before failing the entire CI.
+jest.retryTimes(3)
+
 beforeAll(() => {
   jest.spyOn(global.console, 'warn')
 })

--- a/test/msw-api/setup-worker/start/start.test.ts
+++ b/test/msw-api/setup-worker/start/start.test.ts
@@ -57,3 +57,25 @@ test('resolves the "start" Promise when the worker has been activated', async ()
   expect(events[2]).toEqual('enabled message')
   expect(events).toHaveLength(3)
 })
+
+test('prints the start message when the worker has been registered', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'start.mocks.ts'),
+    routes(app) {
+      app.get('/worker.js', (req, res) => {
+        res.sendFile(path.resolve(__dirname, 'worker.delayed.js'))
+      })
+    },
+  })
+
+  await runtime.page.evaluate(() => {
+    return window.msw.startWorker()
+  })
+
+  expect(runtime.consoleSpy.get('log')).toContain(
+    `Worker scope: ${runtime.makeUrl('/')}`,
+  )
+  expect(runtime.consoleSpy.get('log')).toContain(
+    `Worker script URL: ${runtime.makeUrl('/worker.js')}`,
+  )
+})

--- a/test/support/utils.ts
+++ b/test/support/utils.ts
@@ -4,6 +4,7 @@ import { MockedRequest } from './../../src'
 import { uuidv4 } from '../../src/utils/internal/uuidv4'
 import { ChildProcess } from 'child_process'
 import { IsomorphicRequest } from '@mswjs/interceptors'
+import { passthrough } from '../../src/handlers/RequestHandler'
 
 export function sleep(duration: number) {
   return new Promise((resolve) => {
@@ -37,6 +38,7 @@ export function createMockedRequest(
     integrity: '',
     keepalive: true,
     cookies: {},
+    passthrough,
     ...init,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10812,10 +10812,10 @@ type-fest@^1.0.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-type-fest@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.2.2.tgz#1930bc36b2064f7ab4aa307a6d1b65965199c698"
-  integrity sha512-pfkPYCcuV0TJoo/jlsUeWNV8rk7uMU6ocnYNvca1Vu+pyKi8Rl8Zo2scPt9O72gCsXIm+dMxOOWuA3VFDSdzWA==
+type-fest@^2.12.2:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.2.tgz#80a53614e6b9b475eb9077472fb7498dc7aa51d0"
+  integrity sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
As suggeseted in #1210:

* update type-fest
* adjust `LifeCycleEventEmitter` type for TS 4.7