### PR TITLE
feat: rename "DefaultRequestBody" to "DefaultBodyType"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': [
       1,
       {
+        varsIgnorePattern: '^_',
         argsIgnorePattern: '^_',
       },
     ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
         run: yarn build
 
       - name: Integration tests
-        run: yarn test:integration test/rest-api/basic.test.ts
+        run: yarn test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         node: [14, 16]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,5 +36,6 @@ jobs:
         env:
           GIT_COMMITTER_NAME: kettanaito
           GIT_COMMITTER_EMAIL: kettanaito@gmail.com
-          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          GH_TOKE: ${{ secrets.GH_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.14.0
           cache: yarn

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ stats.html
 .vscode
 msw-*.tgz
 .husky/_
+.env

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  bail: true,
   roots: ['<rootDir>/src', '<rootDir>/cli'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',

--- a/release.config.js
+++ b/release.config.js
@@ -5,7 +5,13 @@ module.exports = {
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     '@semantic-release/npm',
+    [
+      '@semantic-release/git',
+      {
+        message:
+          'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+      },
+    ],
     '@semantic-release/github',
-    '@semantic-release/git',
   ],
 }

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -1,15 +1,13 @@
 import { DocumentNode, OperationTypeNode } from 'graphql'
 import { SerializedResponse } from '../setupWorker/glossary'
-import { set } from '../context/set'
-import { status } from '../context/status'
-import { delay } from '../context/delay'
-import { fetch } from '../context/fetch'
 import { data } from '../context/data'
 import { extensions } from '../context/extensions'
 import { errors } from '../context/errors'
 import { GraphQLPayloadContext } from '../typeUtils'
 import { cookie } from '../context/cookie'
 import {
+  defaultContext,
+  DefaultContext,
   MockedRequest,
   RequestHandler,
   RequestHandlerDefaultInfo,
@@ -36,22 +34,16 @@ export type GraphQLHandlerNameSelector = DocumentNode | RegExp | string
 // GraphQL related context should contain utility functions
 // useful for GraphQL. Functions like `xml()` bear no value
 // in the GraphQL universe.
-export type GraphQLContext<QueryType extends Record<string, unknown>> = {
-  set: typeof set
-  status: typeof status
-  delay: typeof delay
-  fetch: typeof fetch
-  data: GraphQLPayloadContext<QueryType>
-  extensions: GraphQLPayloadContext<QueryType>
-  errors: typeof errors
-  cookie: typeof cookie
-}
+export type GraphQLContext<QueryType extends Record<string, unknown>> =
+  DefaultContext & {
+    data: GraphQLPayloadContext<QueryType>
+    extensions: GraphQLPayloadContext<QueryType>
+    errors: typeof errors
+    cookie: typeof cookie
+  }
 
 export const graphqlContext: GraphQLContext<any> = {
-  set,
-  status,
-  delay,
-  fetch,
+  ...defaultContext,
   data,
   extensions,
   errors,

--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -33,7 +33,7 @@ export type DefaultRequestMultipartBody = Record<
   string | File | (string | File)[]
 >
 
-export type DefaultRequestBody =
+export type DefaultBodyType =
   | Record<string, any>
   | DefaultRequestMultipartBody
   | string
@@ -42,7 +42,7 @@ export type DefaultRequestBody =
   | null
   | undefined
 
-export interface MockedRequest<Body = DefaultRequestBody> {
+export interface MockedRequest<Body = DefaultBodyType> {
   id: string
   url: URL
   method: Request['method']

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -1,14 +1,4 @@
-import {
-  body,
-  cookie,
-  delay,
-  fetch,
-  json,
-  set,
-  status,
-  text,
-  xml,
-} from '../context'
+import { body, cookie, json, text, xml } from '../context'
 import { SerializedResponse } from '../setupWorker/glossary'
 import { ResponseResolutionContext } from '../utils/getResponse'
 import { devUtils } from '../utils/internal/devUtils'
@@ -27,6 +17,8 @@ import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromReques
 import { cleanUrl, getSearchParams } from '../utils/url/cleanUrl'
 import {
   DefaultRequestBody,
+  defaultContext,
+  DefaultContext,
   MockedRequest,
   RequestHandler,
   RequestHandlerDefaultInfo,
@@ -52,28 +44,21 @@ export enum RESTMethods {
 
 // Declaring a context interface infers
 // JSDoc description of the referenced utils.
-export type RestContext = {
-  set: typeof set
-  status: typeof status
+export type RestContext = DefaultContext & {
   cookie: typeof cookie
   text: typeof text
   body: typeof body
   json: typeof json
   xml: typeof xml
-  delay: typeof delay
-  fetch: typeof fetch
 }
 
 export const restContext: RestContext = {
-  set,
-  status,
+  ...defaultContext,
   cookie,
   body,
   text,
   json,
   xml,
-  delay,
-  fetch,
 }
 
 export type RequestQuery = {

--- a/src/handlers/RestHandler.ts
+++ b/src/handlers/RestHandler.ts
@@ -16,7 +16,7 @@ import {
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
 import { cleanUrl, getSearchParams } from '../utils/url/cleanUrl'
 import {
-  DefaultRequestBody,
+  DefaultBodyType,
   defaultContext,
   DefaultContext,
   MockedRequest,
@@ -66,7 +66,7 @@ export type RequestQuery = {
 }
 
 export interface RestRequest<
-  BodyType extends DefaultRequestBody = DefaultRequestBody,
+  BodyType extends DefaultBodyType = DefaultBodyType,
   ParamsType extends PathParams = PathParams,
 > extends MockedRequest<BodyType> {
   params: ParamsType
@@ -79,7 +79,7 @@ export type ParsedRestRequest = Match
  * Provides request matching based on method and URL.
  */
 export class RestHandler<
-  RequestType extends MockedRequest<DefaultRequestBody> = MockedRequest<DefaultRequestBody>,
+  RequestType extends MockedRequest<DefaultBodyType> = MockedRequest<DefaultBodyType>,
 > extends RequestHandler<
   RestHandlerInfo,
   RequestType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export type {
   ResponseResolver,
   ResponseResolverReturnType,
   AsyncResponseResolverReturnType,
-  DefaultRequestBody,
+  DefaultBodyType,
   DefaultRequestMultipartBody,
 } from './handlers/RequestHandler'
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -2,6 +2,8 @@ import { Headers } from 'headers-polyfill'
 import { compose } from './utils/internal/compose'
 import { NetworkError } from './utils/NetworkError'
 
+export type MaybePromise<ValueType = any> = ValueType | Promise<ValueType>
+
 /**
  * Internal representation of a mocked response instance.
  */
@@ -11,6 +13,7 @@ export interface MockedResponse<BodyType = any> {
   statusText: string
   headers: Headers
   once: boolean
+  passthrough: boolean
   delay?: number
 }
 
@@ -19,11 +22,11 @@ export type ResponseTransformer<
   TransformerBodyType = any,
 > = (
   res: MockedResponse<TransformerBodyType>,
-) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
+) => MaybePromise<MockedResponse<BodyType>>
 
 export type ResponseFunction<BodyType = any> = (
   ...transformers: ResponseTransformer<BodyType>[]
-) => MockedResponse<BodyType> | Promise<MockedResponse<BodyType>>
+) => MaybePromise<MockedResponse<BodyType>>
 
 export type ResponseComposition<BodyType = any> = ResponseFunction<BodyType> & {
   /**
@@ -40,6 +43,7 @@ export const defaultResponse: Omit<MockedResponse, 'headers'> = {
   body: null,
   delay: 0,
   once: false,
+  passthrough: false,
 }
 
 export type ResponseCompositionOptions<BodyType> = {

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,4 +1,4 @@
-import { DefaultRequestBody, ResponseResolver } from './handlers/RequestHandler'
+import { DefaultBodyType, ResponseResolver } from './handlers/RequestHandler'
 import {
   RESTMethods,
   RestContext,
@@ -11,9 +11,9 @@ function createRestHandler<Method extends RESTMethods | RegExp>(
   method: Method,
 ) {
   return <
-    RequestBodyType extends DefaultRequestBody = DefaultRequestBody,
+    RequestBodyType extends DefaultBodyType = DefaultBodyType,
     Params extends PathParams = PathParams,
-    ResponseBody extends DefaultRequestBody = DefaultRequestBody,
+    ResponseBody extends DefaultBodyType = DefaultBodyType,
   >(
     path: Path,
     resolver: ResponseResolver<

--- a/src/setupWorker/start/utils/enableMocking.ts
+++ b/src/setupWorker/start/utils/enableMocking.ts
@@ -10,6 +10,10 @@ export async function enableMocking(
 ) {
   context.workerChannel.send('MOCK_ACTIVATE')
   return context.events.once('MOCKING_ENABLED').then(() => {
-    printStartMessage({ quiet: options.quiet })
+    printStartMessage({
+      quiet: options.quiet,
+      workerScope: context.registration?.scope,
+      workerUrl: context.worker?.scriptURL,
+    })
   })
 }

--- a/src/setupWorker/start/utils/printStartMessage.test.ts
+++ b/src/setupWorker/start/utils/printStartMessage.test.ts
@@ -14,7 +14,10 @@ afterAll(() => {
 })
 
 test('prints out a default start message into console', () => {
-  printStartMessage()
+  printStartMessage({
+    workerScope: 'http://localhost:3000/',
+    workerUrl: 'http://localhost:3000/worker.js',
+  })
 
   expect(console.groupCollapsed).toHaveBeenCalledWith(
     '%c[MSW] Mocking enabled.',
@@ -32,6 +35,18 @@ test('prints out a default start message into console', () => {
   expect(console.log).toHaveBeenCalledWith(
     'Found an issue? https://github.com/mswjs/msw/issues',
   )
+
+  // Includes service worker scope.
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker scope:',
+    'http://localhost:3000/',
+  )
+
+  // Includes service worker script location.
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker script URL:',
+    'http://localhost:3000/worker.js',
+  )
 })
 
 test('supports printing a custom start message', () => {
@@ -48,4 +63,26 @@ test('does not print any messages when log level is quiet', () => {
 
   expect(console.groupCollapsed).not.toHaveBeenCalled()
   expect(console.log).not.toHaveBeenCalled()
+})
+
+test('prints a worker scope in the start message', () => {
+  printStartMessage({
+    workerScope: 'http://localhost:3000/user',
+  })
+
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker scope:',
+    'http://localhost:3000/user',
+  )
+})
+
+test('prints a worker script url in the start message', () => {
+  printStartMessage({
+    workerUrl: 'http://localhost:3000/mockServiceWorker.js',
+  })
+
+  expect(console.log).toHaveBeenCalledWith(
+    'Worker script URL:',
+    'http://localhost:3000/mockServiceWorker.js',
+  )
 })

--- a/src/setupWorker/start/utils/printStartMessage.ts
+++ b/src/setupWorker/start/utils/printStartMessage.ts
@@ -1,8 +1,10 @@
 import { devUtils } from '../../../utils/internal/devUtils'
 
-interface PrintStartMessageArgs {
+export interface PrintStartMessageArgs {
   quiet?: boolean
   message?: string
+  workerUrl?: string
+  workerScope?: string
 }
 
 /**
@@ -25,5 +27,14 @@ export function printStartMessage(args: PrintStartMessageArgs = {}) {
     'font-weight:normal',
   )
   console.log('Found an issue? https://github.com/mswjs/msw/issues')
+
+  if (args.workerUrl) {
+    console.log('Worker script URL:', args.workerUrl)
+  }
+
+  if (args.workerScope) {
+    console.log('Worker scope:', args.workerScope)
+  }
+
   console.groupEnd()
 }

--- a/src/utils/logging/prepareRequest.test.ts
+++ b/src/utils/logging/prepareRequest.test.ts
@@ -1,4 +1,5 @@
 import { Headers } from 'headers-polyfill'
+import { passthrough } from '../../handlers/RequestHandler'
 import { prepareRequest } from './prepareRequest'
 
 test('converts request headers into an object', () => {
@@ -22,6 +23,7 @@ test('converts request headers into an object', () => {
     body: 'text-body',
     bodyUsed: false,
     cookies: {},
+    passthrough,
   })
 
   // Converts `Headers` instance into inspectable object

--- a/src/utils/request/parseIsomorphicRequest.test.ts
+++ b/src/utils/request/parseIsomorphicRequest.test.ts
@@ -4,7 +4,7 @@
 import { Headers } from 'headers-polyfill/lib'
 import { parseIsomorphicRequest } from './parseIsomorphicRequest'
 import { createIsomorphicRequest } from '../../../test/support/utils'
-import { MockedRequest } from '../../handlers/RequestHandler'
+import { MockedRequest, passthrough } from '../../handlers/RequestHandler'
 
 test('parses an isomorphic request', () => {
   const request = parseIsomorphicRequest(
@@ -46,6 +46,7 @@ test('parses an isomorphic request', () => {
     body: {
       id: 'user-1',
     },
+    passthrough,
   })
 })
 

--- a/src/utils/request/parseIsomorphicRequest.ts
+++ b/src/utils/request/parseIsomorphicRequest.ts
@@ -1,5 +1,5 @@
 import { IsomorphicRequest } from '@mswjs/interceptors'
-import { MockedRequest } from '../../handlers/RequestHandler'
+import { MockedRequest, passthrough } from '../../handlers/RequestHandler'
 import { parseBody } from './parseBody'
 import { setRequestCookies } from './setRequestCookies'
 
@@ -26,6 +26,7 @@ export function parseIsomorphicRequest(
     integrity: '',
     destination: 'document',
     bodyUsed: false,
+    passthrough,
   }
 
   // Attach all the cookies from the virtual cookie store.

--- a/src/utils/request/parseWorkerRequest.ts
+++ b/src/utils/request/parseWorkerRequest.ts
@@ -1,4 +1,5 @@
 import { Headers } from 'headers-polyfill'
+import { passthrough } from '../../handlers/RequestHandler'
 import { RestRequest } from '../../handlers/RestHandler'
 import { ServiceWorkerIncomingRequest } from '../../setupWorker/glossary'
 import { setRequestCookies } from './setRequestCookies'
@@ -30,6 +31,7 @@ export function parseWorkerRequest(
     body: pruneGetRequestBody(rawRequest),
     bodyUsed: rawRequest.bodyUsed,
     headers: new Headers(rawRequest.headers),
+    passthrough,
   }
 
   // Set document cookies on the request.

--- a/src/utils/worker/createRequestListener.ts
+++ b/src/utils/worker/createRequestListener.ts
@@ -41,7 +41,7 @@ export const createRequestListener = (
               headers: response.headers.all(),
             }
           },
-          onBypassResponse() {
+          onPassthroughResponse() {
             return channel.send({
               type: 'MOCK_NOT_FOUND',
             })

--- a/test/msw-api/req/passthrough.mocks.ts
+++ b/test/msw-api/req/passthrough.mocks.ts
@@ -1,0 +1,15 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.post('/', (req) => {
+    return req.passthrough()
+  }),
+)
+
+worker.start()
+
+// @ts-ignore
+window.msw = {
+  worker,
+  rest,
+}

--- a/test/msw-api/req/passthrough.node.test.ts
+++ b/test/msw-api/req/passthrough.node.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { ServerApi, createServer } from '@open-draft/test-server'
+
+let httpServer: ServerApi
+const server = setupServer()
+
+interface ResponseBody {
+  name: string
+}
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.post<never, ResponseBody>('/user', (req, res) => {
+      res.json({ name: 'John' })
+    })
+  })
+
+  server.listen()
+
+  jest.spyOn(console, 'warn').mockImplementation()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  jest.resetAllMocks()
+})
+
+afterAll(async () => {
+  server.close()
+  jest.restoreAllMocks()
+  await httpServer.close()
+})
+
+it('performs request as-is when returning "req.passthrough" call in the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, (req) => {
+      return req.passthrough()
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
+it('does not allow fall-through when returning "req.passthrough" call in the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, (req) => {
+      return req.passthrough()
+    }),
+    rest.post<never, ResponseBody>(endpointUrl, (req, res, ctx) => {
+      return res(ctx.json({ name: 'Kate' }))
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
+it('prints a warning and performs a request as-is if nothing was returned from the resolver', async () => {
+  const endpointUrl = httpServer.http.makeUrl('/user')
+  server.use(
+    rest.post<never, ResponseBody>(endpointUrl, () => {
+      return
+    }),
+  )
+
+  const res = await fetch(endpointUrl, { method: 'POST' })
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+
+  const warning = (console.warn as any as jest.SpyInstance).mock.calls[0][0]
+
+  expect(warning).toContain(
+    '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
+  )
+  expect(warning).toContain(`POST ${endpointUrl}`)
+  expect(console.warn).toHaveBeenCalledTimes(1)
+})

--- a/test/msw-api/req/passthrough.test.ts
+++ b/test/msw-api/req/passthrough.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { rest, SetupWorkerApi } from 'msw'
+import { createServer, ServerApi } from '@open-draft/test-server'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorkerApi
+    rest: typeof rest
+  }
+}
+
+interface ResponseBody {
+  name: string
+}
+
+function prepareRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'passthrough.mocks.ts'),
+  })
+}
+
+let httpServer: ServerApi
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.post<never, ResponseBody>('/user', (req, res) => {
+      res.json({ name: 'John' })
+    })
+  })
+})
+
+afterAll(async () => {
+  await httpServer.close()
+})
+
+it('performs request as-is when returning "req.passthrough" call in the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, (req) => {
+        return req.passthrough()
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+  expect(runtime.consoleSpy.get('warning')).toBeUndefined()
+})
+
+it('does not allow fall-through when returning "req.passthrough" call in the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, (req) => {
+        return req.passthrough()
+      }),
+      rest.post<never, ResponseBody>(endpointUrl, (req, res, ctx) => {
+        return res(ctx.json({ name: 'Kate' }))
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+  expect(runtime.consoleSpy.get('warning')).toBeUndefined()
+})
+
+it('prints a warning and performs a request as-is if nothing was returned from the resolver', async () => {
+  const runtime = await prepareRuntime()
+  const endpointUrl = httpServer.http.makeUrl('/user')
+
+  await runtime.page.evaluate((endpointUrl) => {
+    const { worker, rest } = window.msw
+    worker.use(
+      rest.post<never, ResponseBody>(endpointUrl, () => {
+        return
+      }),
+    )
+  }, endpointUrl)
+
+  const res = await runtime.request(endpointUrl, { method: 'POST' })
+  const headers = await res.allHeaders()
+  const json = await res.json()
+
+  expect(json).toEqual<ResponseBody>({
+    name: 'John',
+  })
+  expect(headers).toHaveProperty('x-powered-by', 'Express')
+
+  expect(runtime.consoleSpy.get('warning')).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining(
+        '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
+      ),
+    ]),
+  )
+})

--- a/test/msw-api/setup-server/scenarios/generator.node.test.ts
+++ b/test/msw-api/setup-server/scenarios/generator.node.test.ts
@@ -2,61 +2,51 @@ import fetch from 'node-fetch'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 
-type RequestParams = {
-  maxCount: string
-}
-
 const server = setupServer(
-  rest.get<never, RequestParams>(
-    '/polling/:maxCount',
-    function* (req, res, ctx) {
-      const maxCount = parseInt(req.params.maxCount)
-      let count = 0
+  rest.get('/polling/:maxCount', function* (req, res, ctx) {
+    const maxCount = parseInt(req.params.maxCount)
+    let count = 0
 
-      while (count < maxCount) {
-        count += 1
-        yield res(
-          ctx.json({
-            status: 'pending',
-            count,
-          }),
-        )
-      }
-
-      return res(
+    while (count < maxCount) {
+      count += 1
+      yield res(
         ctx.json({
-          status: 'complete',
+          status: 'pending',
           count,
         }),
       )
-    },
-  ),
+    }
 
-  rest.get<never, RequestParams>(
-    '/polling/once/:maxCount',
-    function* (req, res, ctx) {
-      const maxCount = parseInt(req.params.maxCount)
-      let count = 0
+    return res(
+      ctx.json({
+        status: 'complete',
+        count,
+      }),
+    )
+  }),
 
-      while (count < maxCount) {
-        count += 1
-        yield res(
-          ctx.json({
-            status: 'pending',
-            count,
-          }),
-        )
-      }
+  rest.get('/polling/once/:maxCount', function* (req, res, ctx) {
+    const maxCount = parseInt(req.params.maxCount)
+    let count = 0
 
-      return res.once(
+    while (count < maxCount) {
+      count += 1
+      yield res(
         ctx.json({
-          status: 'complete',
+          status: 'pending',
           count,
         }),
       )
-    },
-  ),
-  rest.get<never, RequestParams>('/polling/once/:maxCount', (req, res, ctx) => {
+    }
+
+    return res.once(
+      ctx.json({
+        status: 'complete',
+        count,
+      }),
+    )
+  }),
+  rest.get('/polling/once/:maxCount', (req, res, ctx) => {
     return res(ctx.json({ status: 'done' }))
   }),
 )

--- a/test/msw-api/setup-worker/scenarios/iframe/iframe.test.ts
+++ b/test/msw-api/setup-worker/scenarios/iframe/iframe.test.ts
@@ -10,6 +10,10 @@ function findFrame(frame: Frame) {
   return frame.name() === ''
 }
 
+// This has proven to be a rather flaky test.
+// Retry it a couple of times before failing the entire CI.
+jest.retryTimes(3)
+
 beforeAll(() => {
   jest.spyOn(global.console, 'warn')
 })

--- a/test/msw-api/setup-worker/start/start.test.ts
+++ b/test/msw-api/setup-worker/start/start.test.ts
@@ -57,3 +57,25 @@ test('resolves the "start" Promise when the worker has been activated', async ()
   expect(events[2]).toEqual('enabled message')
   expect(events).toHaveLength(3)
 })
+
+test('prints the start message when the worker has been registered', async () => {
+  const runtime = await pageWith({
+    example: path.resolve(__dirname, 'start.mocks.ts'),
+    routes(app) {
+      app.get('/worker.js', (req, res) => {
+        res.sendFile(path.resolve(__dirname, 'worker.delayed.js'))
+      })
+    },
+  })
+
+  await runtime.page.evaluate(() => {
+    return window.msw.startWorker()
+  })
+
+  expect(runtime.consoleSpy.get('log')).toContain(
+    `Worker scope: ${runtime.makeUrl('/')}`,
+  )
+  expect(runtime.consoleSpy.get('log')).toContain(
+    `Worker script URL: ${runtime.makeUrl('/worker.js')}`,
+  )
+})

--- a/test/support/utils.ts
+++ b/test/support/utils.ts
@@ -4,6 +4,7 @@ import { MockedRequest } from './../../src'
 import { uuidv4 } from '../../src/utils/internal/uuidv4'
 import { ChildProcess } from 'child_process'
 import { IsomorphicRequest } from '@mswjs/interceptors'
+import { passthrough } from '../../src/handlers/RequestHandler'
 
 export function sleep(duration: number) {
   return new Promise((resolve) => {
@@ -37,6 +38,7 @@ export function createMockedRequest(
     integrity: '',
     keepalive: true,
     cookies: {},
+    passthrough,
     ...init,
   }
 }


### PR DESCRIPTION
- Closes #1175 
- Related to #1073 

## Motivation

Sadly, we have to revert the path parameters inference because it breaks support for request/response body type generics (see #1175 for explanation). We can adopt path inference once TypeScript properly supports optional generic types. 