### PR TITLE
feat: improve PathParams type to support interface

### DIFF
--- a/src/rest.ts
+++ b/src/rest.ts
@@ -12,7 +12,7 @@ function createRestHandler<Method extends RESTMethods | RegExp>(
 ) {
   return <
     RequestBodyType extends DefaultBodyType = DefaultBodyType,
-    Params extends PathParams = PathParams,
+    Params extends PathParams<Params> = PathParams,
     ResponseBody extends DefaultBodyType = DefaultBodyType,
   >(
     path: Path,

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -12,7 +12,7 @@ function createRestHandler<Method extends RESTMethods | RegExp>(
 ) {
   return <
     RequestBodyType extends DefaultBodyType = DefaultBodyType,
-    Params extends PathParams<Params> = PathParams,
+    Params extends PathParams<keyof Params> = PathParams,
     ResponseBody extends DefaultBodyType = DefaultBodyType,
   >(
     path: Path,

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -4,7 +4,7 @@ import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp
 export type PathParams<K extends keyof any = string> = {
-  [P in K]?: string | ReadonlyArray<string>
+  [P in K]: string | ReadonlyArray<string>
 }
 
 export interface Match {

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -3,8 +3,8 @@ import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
 import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp
-export type PathParams<K extends keyof any = string> = {
-  [P in K]: string | ReadonlyArray<string>
+export type PathParams<KeyType extends keyof any = string> = {
+  [ParamName in KeyType]: string | ReadonlyArray<string>
 }
 
 export interface Match {

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -3,7 +3,9 @@ import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
 import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp
-export type PathParams = Record<string, string | ReadonlyArray<string>>
+export type PathParams<T = Record<string, string | ReadonlyArray<string>>> = {
+  [K in keyof T]?: string | ReadonlyArray<string>
+}
 
 export interface Match {
   matches: boolean

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -3,8 +3,8 @@ import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
 import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp
-export type PathParams<T = Record<string, string | ReadonlyArray<string>>> = {
-  [K in keyof T]?: string | ReadonlyArray<string>
+export type PathParams<K extends keyof any = string> = {
+  [P in K]?: string | ReadonlyArray<string>
 }
 
 export interface Match {

--- a/test/msw-api/setup-server/scenarios/generator.node.test.ts
+++ b/test/msw-api/setup-server/scenarios/generator.node.test.ts
@@ -3,52 +3,61 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 
 const server = setupServer(
-  rest.get('/polling/:maxCount', function* (req, res, ctx) {
-    const maxCount = parseInt(req.params.maxCount)
-    let count = 0
+  rest.get<never, { maxCount: string }>(
+    '/polling/:maxCount',
+    function* (req, res, ctx) {
+      const maxCount = parseInt(req.params.maxCount)
+      let count = 0
 
-    while (count < maxCount) {
-      count += 1
-      yield res(
+      while (count < maxCount) {
+        count += 1
+        yield res(
+          ctx.json({
+            status: 'pending',
+            count,
+          }),
+        )
+      }
+
+      return res(
         ctx.json({
-          status: 'pending',
+          status: 'complete',
           count,
         }),
       )
-    }
+    },
+  ),
 
-    return res(
-      ctx.json({
-        status: 'complete',
-        count,
-      }),
-    )
-  }),
+  rest.get<never, { maxCount: string }>(
+    '/polling/once/:maxCount',
+    function* (req, res, ctx) {
+      const maxCount = parseInt(req.params.maxCount)
+      let count = 0
 
-  rest.get('/polling/once/:maxCount', function* (req, res, ctx) {
-    const maxCount = parseInt(req.params.maxCount)
-    let count = 0
+      while (count < maxCount) {
+        count += 1
+        yield res(
+          ctx.json({
+            status: 'pending',
+            count,
+          }),
+        )
+      }
 
-    while (count < maxCount) {
-      count += 1
-      yield res(
+      return res.once(
         ctx.json({
-          status: 'pending',
+          status: 'complete',
           count,
         }),
       )
-    }
-
-    return res.once(
-      ctx.json({
-        status: 'complete',
-        count,
-      }),
-    )
-  }),
-  rest.get('/polling/once/:maxCount', (req, res, ctx) => {
-    return res(ctx.json({ status: 'done' }))
-  }),
+    },
+  ),
+  rest.get<never, { maxCount: string }>(
+    '/polling/once/:maxCount',
+    (req, res, ctx) => {
+      return res(ctx.json({ status: 'done' }))
+    },
+  ),
 )
 
 beforeAll(() => {

--- a/test/typings/path-params.test-d.ts
+++ b/test/typings/path-params.test-d.ts
@@ -1,0 +1,55 @@
+import { rest } from 'msw'
+
+rest.get<never, { userId: string }>('/user/:userId', (req) => {
+  req.params.userId
+
+  // @ts-expect-error `unknown` is not defined in the request params type.
+  req.params.unknown
+})
+
+rest.get<never>('/user/:id', (req, res, ctx) => {
+  const { userId } = req.params
+
+  return res(
+    ctx.body(
+      // @ts-expect-error "userId" parameter is not annotated
+      // and is ambiguous (string | string[]).
+      userId,
+    ),
+  )
+})
+
+rest.get<
+  never,
+  // @ts-expect-error Path parameters are always strings.
+  // Parse them to numbers in the resolver if necessary.
+  { id: number }
+>('/posts/:id', () => null)
+
+/**
+ * Using interface as path parameters type.
+ */
+interface UserParamsInterface {
+  userId: string
+}
+
+rest.get<never, UserParamsInterface>('/user/:userId', (req) => {
+  req.params.userId.toUpperCase()
+
+  // @ts-expect-error Unknown path parameter "foo".
+  req.params.foo
+})
+
+/**
+ * Using type as path parameters type.
+ */
+type UserParamsType = {
+  userId: string
+}
+
+rest.get<never, UserParamsType>('/user/:userId', (req) => {
+  req.params.userId.toUpperCase()
+
+  // @ts-expect-error Unknown path parameter "foo".
+  req.params.foo
+})

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -17,13 +17,6 @@ rest.get<never, never, { postCount: number }>('/user', (req, res, ctx) => {
   return res(ctx.json({ postCount: 2 }))
 })
 
-rest.get<never, { userId: string }>('/user/:userId', (req) => {
-  req.params.userId
-
-  // @ts-expect-error `unknown` is not defined in the request params type.
-  req.params.unknown
-})
-
 rest.post<// @ts-expect-error `null` is not a valid request body type.
 null>('/submit', () => null)
 
@@ -42,25 +35,6 @@ rest.get<never, never, string | string[]>('/user', (req, res, ctx) =>
   // allow ResponseTransformer to return a narrower type than a given union
   res(ctx.json('hello')),
 )
-
-rest.get<never>('/user/:id', (req, res, ctx) => {
-  const { userId } = req.params
-
-  return res(
-    ctx.body(
-      // @ts-expect-error "userId" parameter is not annotated
-      // and is ambiguous (string | string[]).
-      userId,
-    ),
-  )
-})
-
-rest.get<
-  never,
-  // @ts-expect-error Path parameters are always strings.
-  // Parse them to numbers in the resolver if necessary.
-  { id: number }
->('/posts/:id', () => null)
 
 rest.head('/user', (req) => {
   // @ts-expect-error GET requests cannot have body.
@@ -84,12 +58,4 @@ rest.get<string>('/user', (req) => {
 
 rest.post<{ userId: string }>('/user', (req) => {
   req.body.userId.toUpperCase()
-})
-
-interface Params {
-  userId: string
-}
-
-rest.get<never, Params>('/user', (req) => {
-  req.params
 })

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -85,3 +85,11 @@ rest.get<string>('/user', (req) => {
 rest.post<{ userId: string }>('/user', (req) => {
   req.body.userId.toUpperCase()
 })
+
+interface Params {
+  userId: string
+}
+
+rest.get<never, Params>('/user', (req) => {
+  req.params
+})


### PR DESCRIPTION
Passing an interface to the generics of PathParams causes a type error because interface doesn't have an [implicit index signature](https://github.com/microsoft/TypeScript/pull/7029).

```ts
interface Params {
  userId: string
}

rest.get<never, Params>('/user', (req) => { // Type 'Params' is not assignable to type 'PathParams'. Index signature for type 'string' is missing in type 'Params'.(2322)
  req.params
})
```

I would like to resolve this, but for type safety reasons if you cannot approve this PR please close it 🙏🏻 

