### PR TITLE
fix(deps): make TypeScript peerDep more forgiving

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "peerDependencies": {
-    "typescript": "4.2.x"
+    "typescript": ">=4.2.x"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
Without this I can't upgrade my project beyond 4.2.x and TS is now at 4.6.x