### PR TITLE
fix: pin "@mswjs/interceptors" to 0.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "sideEffects": false,
   "dependencies": {
     "@mswjs/cookies": "^0.2.0",
-    "@mswjs/interceptors": "^0.15.1",
+    "@mswjs/interceptors": "0.15.1",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.1",
     "@types/js-levenshtein": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,7 +1692,7 @@
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"
 
-"@mswjs/interceptors@^0.15.1":
+"@mswjs/interceptors@0.15.1":
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.15.1.tgz#4a0009f56e51bc2cd3176f1507065c7d2f6c0d5e"
   integrity sha512-D5B+ZJNlfvBm6ZctAfRBdNJdCHYAe2Ix4My5qfbHV5WH+3lkt3mmsjiWJzEh5ZwGDauzY487TldI275If7DJVw==


### PR DESCRIPTION
Quick fix for https://github.com/mswjs/interceptors/issues/245. 