### PR TITLE
fix: add "ctx.field()" for GraphQL responses

### DIFF
--- a/src/context/field.test.ts
+++ b/src/context/field.test.ts
@@ -62,11 +62,22 @@ test('throws when trying to set non-serializable values', async () => {
   )
 })
 
-test.each(['', 'data', 'errors', 'exceptions'])(
-  'throws when passing "%s" as field value',
+test('throws when passing an empty string as field name', async () => {
+  await expect(response(field('' as string, 'value'))).rejects.toThrow(
+    `[MSW] Failed to set a custom field on a GraphQL response: field name cannot be empty.`,
+  )
+})
+test('throws when passing an empty string (when trimmed) as field name', async () => {
+  await expect(response(field('   ' as string, 'value'))).rejects.toThrow(
+    `[MSW] Failed to set a custom field on a GraphQL response: field name cannot be empty.`,
+  )
+})
+
+test.each(['data', 'errors', 'extensions'])(
+  'throws when passing "%s" as field name',
   async (fieldName) => {
     await expect(response(field(fieldName, 'value'))).rejects.toThrow(
-      'ctx.field() first argument must not be an element of ["","data","errors","exceptions"]',
+      `[MSW] Failed to set a custom "${fieldName}" field on a mocked GraphQL response: forbidden field name. Did you mean to call "ctx.${fieldName}()" instead?`,
     )
   },
 )

--- a/src/context/field.test.ts
+++ b/src/context/field.test.ts
@@ -67,17 +67,51 @@ test('throws when passing an empty string as field name', async () => {
     `[MSW] Failed to set a custom field on a GraphQL response: field name cannot be empty.`,
   )
 })
+
 test('throws when passing an empty string (when trimmed) as field name', async () => {
   await expect(response(field('   ' as string, 'value'))).rejects.toThrow(
     `[MSW] Failed to set a custom field on a GraphQL response: field name cannot be empty.`,
   )
 })
 
-test.each(['data', 'errors', 'extensions'])(
-  'throws when passing "%s" as field name',
-  async (fieldName) => {
-    await expect(response(field(fieldName, 'value'))).rejects.toThrow(
-      `[MSW] Failed to set a custom "${fieldName}" field on a mocked GraphQL response: forbidden field name. Did you mean to call "ctx.${fieldName}()" instead?`,
-    )
-  },
-)
+test('throws when using "data" as the field name', async () => {
+  await expect(
+    response(
+      field(
+        // @ts-expect-error Test runtime value.
+        'data',
+        'value',
+      ),
+    ),
+  ).rejects.toThrow(
+    '[MSW] Failed to set a custom "data" field on a mocked GraphQL response: forbidden field name. Did you mean to call "ctx.data()" instead?',
+  )
+})
+
+test('throws when using "errors" as the field name', async () => {
+  await expect(
+    response(
+      field(
+        // @ts-expect-error Test runtime value.
+        'errors',
+        'value',
+      ),
+    ),
+  ).rejects.toThrow(
+    '[MSW] Failed to set a custom "errors" field on a mocked GraphQL response: forbidden field name. Did you mean to call "ctx.errors()" instead?',
+  )
+})
+
+test('throws when using "extensions" as the field name', async () => {
+  await expect(
+    response(
+      field(
+        // @ts-expect-error Test runtime value.
+        'extensions',
+        'value',
+      ),
+    ),
+  ).rejects.toThrow(
+    '[MSW] Failed to set a custom "extensions" field on a mocked GraphQL response: forbidden field name. Did you mean to call "ctx.extensions()" instead?',
+  )
+})

--- a/src/context/field.test.ts
+++ b/src/context/field.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import { field } from './field'
+import { response } from '../response'
+import { data } from './data'
+import { errors } from './errors'
+
+test('sets a given field value string on the response JSON body', async () => {
+  const result = await response(field('field', 'value'))
+
+  expect(result.headers.get('content-type')).toBe('application/json')
+  expect(result).toHaveProperty('body', JSON.stringify({ field: 'value' }))
+})
+
+test('sets a given field value object on the response JSON body', async () => {
+  const result = await response(
+    field('metadata', {
+      date: new Date('2022-05-27'),
+      comment: 'nice metadata',
+    }),
+  )
+
+  expect(result.headers.get('content-type')).toBe('application/json')
+  expect(result).toHaveProperty(
+    'body',
+    JSON.stringify({
+      metadata: { date: new Date('2022-05-27'), comment: 'nice metadata' },
+    }),
+  )
+})
+
+test('combines with data, errors and other field in the response JSON body', async () => {
+  const result = await response(
+    data({ name: 'msw' }),
+    errors([{ message: 'exceeds the limit of awesomeness' }]),
+    field('field', { errorCode: 'value' }),
+    field('field2', 123),
+  )
+
+  expect(result.headers.get('content-type')).toEqual('application/json')
+  expect(result).toHaveProperty(
+    'body',
+    JSON.stringify({
+      field2: 123,
+      field: { errorCode: 'value' },
+      errors: [
+        {
+          message: 'exceeds the limit of awesomeness',
+        },
+      ],
+      data: {
+        name: 'msw',
+      },
+    }),
+  )
+})
+
+test('throws when trying to set non-serializable values', async () => {
+  await expect(response(field('metadata', BigInt(1)))).rejects.toThrow(
+    'Do not know how to serialize a BigInt',
+  )
+})
+
+test.each(['', 'data', 'errors', 'exceptions'])(
+  'throws when passing "%s" as field value',
+  async (fieldName) => {
+    await expect(response(field(fieldName, 'value'))).rejects.toThrow(
+      'ctx.field() first argument must not be an element of ["","data","errors","exceptions"]',
+    )
+  },
+)

--- a/src/context/field.ts
+++ b/src/context/field.ts
@@ -1,0 +1,36 @@
+import { ResponseTransformer } from '../response'
+import { jsonParse } from '../utils/internal/jsonParse'
+import { mergeRight } from '../utils/internal/mergeRight'
+import { json } from './json'
+
+const forbiddenFieldNamesList = ['', 'data', 'errors', 'exceptions'] as const
+type ForbiddenFieldNames = typeof forbiddenFieldNamesList[number]
+
+/**
+ * Set a custom field on the GraphQL mocked response.
+ * @example res(ctx.fields('customField', value))
+ * @see {@link https://mswjs.io/docs/api/context/field}
+ */
+export const field = <FieldNameType extends string, FieldValueType>(
+  fieldName: FieldNameType extends ForbiddenFieldNames ? never : FieldNameType,
+  fieldValue: FieldValueType,
+): ResponseTransformer<string> => {
+  return (res) => {
+    assertFieldNameIsValid(fieldName)
+
+    const prevBody = jsonParse(res.body) || {}
+    const nextBody = mergeRight(prevBody, { [fieldName]: fieldValue })
+
+    return json(nextBody)(res as any) as any
+  }
+}
+
+function assertFieldNameIsValid(fieldName: string) {
+  if (forbiddenFieldNamesList.includes(fieldName as ForbiddenFieldNames)) {
+    throw new Error(
+      `ctx.field() first argument must not be an element of ${JSON.stringify(
+        forbiddenFieldNamesList,
+      )}`,
+    )
+  }
+}

--- a/src/context/field.ts
+++ b/src/context/field.ts
@@ -16,7 +16,7 @@ export const field = <FieldNameType extends string, FieldValueType>(
   fieldValue: FieldValueType,
 ): ResponseTransformer<string> => {
   return (res) => {
-    assertFieldNameIsValid(fieldName)
+    validateFieldName(fieldName)
 
     const prevBody = jsonParse(res.body) || {}
     const nextBody = mergeRight(prevBody, { [fieldName]: fieldValue })
@@ -25,7 +25,7 @@ export const field = <FieldNameType extends string, FieldValueType>(
   }
 }
 
-function assertFieldNameIsValid(fieldName: string) {
+function validateFieldName(fieldName: string) {
   if (forbiddenFieldNamesList.includes(fieldName as ForbiddenFieldNames)) {
     throw new Error(
       `ctx.field() first argument must not be an element of ${JSON.stringify(

--- a/src/context/field.ts
+++ b/src/context/field.ts
@@ -1,10 +1,11 @@
+import { invariant } from 'outvariant'
 import { ResponseTransformer } from '../response'
+import { devUtils } from '../utils/internal/devUtils'
 import { jsonParse } from '../utils/internal/jsonParse'
 import { mergeRight } from '../utils/internal/mergeRight'
 import { json } from './json'
 
-const forbiddenFieldNamesList = ['', 'data', 'errors', 'exceptions'] as const
-type ForbiddenFieldNames = typeof forbiddenFieldNamesList[number]
+type ForbiddenFieldNames = '' | 'data' | 'errors' | 'extensions'
 
 /**
  * Set a custom field on the GraphQL mocked response.
@@ -26,11 +27,31 @@ export const field = <FieldNameType extends string, FieldValueType>(
 }
 
 function validateFieldName(fieldName: string) {
-  if (forbiddenFieldNamesList.includes(fieldName as ForbiddenFieldNames)) {
-    throw new Error(
-      `ctx.field() first argument must not be an element of ${JSON.stringify(
-        forbiddenFieldNamesList,
-      )}`,
-    )
-  }
+  invariant(
+    fieldName.trim() !== '',
+    devUtils.formatMessage(
+      'Failed to set a custom field on a GraphQL response: field name cannot be empty.',
+    ),
+  )
+  invariant(
+    fieldName !== 'data',
+    devUtils.formatMessage(
+      'Failed to set a custom "%s" field on a mocked GraphQL response: forbidden field name. Did you mean to call "ctx.data()" instead?',
+      fieldName,
+    ),
+  )
+  invariant(
+    fieldName !== 'errors',
+    devUtils.formatMessage(
+      'Failed to set a custom "%s" field on a mocked GraphQL response: forbidden field name. Did you mean to call "ctx.errors()" instead?',
+      fieldName,
+    ),
+  )
+  invariant(
+    fieldName !== 'extensions',
+    devUtils.formatMessage(
+      'Failed to set a custom "%s" field on a mocked GraphQL response: forbidden field name. Did you mean to call "ctx.extensions()" instead?',
+      fieldName,
+    ),
+  )
 }

--- a/src/context/field.ts
+++ b/src/context/field.ts
@@ -33,6 +33,7 @@ function validateFieldName(fieldName: string) {
       'Failed to set a custom field on a GraphQL response: field name cannot be empty.',
     ),
   )
+
   invariant(
     fieldName !== 'data',
     devUtils.formatMessage(
@@ -40,6 +41,7 @@ function validateFieldName(fieldName: string) {
       fieldName,
     ),
   )
+
   invariant(
     fieldName !== 'errors',
     devUtils.formatMessage(
@@ -47,6 +49,7 @@ function validateFieldName(fieldName: string) {
       fieldName,
     ),
   )
+
   invariant(
     fieldName !== 'extensions',
     devUtils.formatMessage(

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -3,6 +3,7 @@ import { SerializedResponse } from '../setupWorker/glossary'
 import { data } from '../context/data'
 import { extensions } from '../context/extensions'
 import { errors } from '../context/errors'
+import { field } from '../context/field'
 import { GraphQLPayloadContext } from '../typeUtils'
 import { cookie } from '../context/cookie'
 import {
@@ -40,6 +41,7 @@ export type GraphQLContext<QueryType extends Record<string, unknown>> =
     extensions: GraphQLPayloadContext<QueryType>
     errors: typeof errors
     cookie: typeof cookie
+    field: typeof field
   }
 
 export const graphqlContext: GraphQLContext<any> = {
@@ -48,6 +50,7 @@ export const graphqlContext: GraphQLContext<any> = {
   extensions,
   errors,
   cookie,
+  field: field,
 }
 
 export type GraphQLVariables = Record<string, any>

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -50,7 +50,7 @@ export const graphqlContext: GraphQLContext<any> = {
   extensions,
   errors,
   cookie,
-  field: field,
+  field,
 }
 
 export type GraphQLVariables = Record<string, any>


### PR DESCRIPTION
- Closes #1200

As discussed in the issues, this PR adds a `field(fieldName, fieldValue)` method to graphQL response context.

`fieldName` is typed in a way to prevent using `errors`, `data`, `extensions` and `<empty string>` as a value. Is then any other value we should forbid ?
`fieldName` is also validated at runtime level.

![Screenshot 2022-06-02 at 15 44 22](https://user-images.githubusercontent.com/15009534/171646574-de5bd25c-8c67-43c4-89b1-77858563f28f.png)

~@kentcdodds In the issue you mentioned [`invariant`](https://www.npmjs.com/package/outvariant) as a solution to make sure this field is valid, but I am not sure how it could be use here as we need to check for specific values, not if the value is undefined. Could you tell me how you thought this coule be used here ?~

## TODO

- [ ] Update the documentation, new page : `https://mswjs.io/docs/api/context/field`