### PR TITLE
chore: describe "delay" on "SerializedResponse" type

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -1,4 +1,5 @@
 import { Headers } from 'headers-polyfill'
+import { DefaultBodyType } from './handlers/RequestHandler'
 import { compose } from './utils/internal/compose'
 import { NetworkError } from './utils/NetworkError'
 
@@ -7,7 +8,7 @@ export type MaybePromise<ValueType = any> = ValueType | Promise<ValueType>
 /**
  * Internal representation of a mocked response instance.
  */
-export interface MockedResponse<BodyType = any> {
+export interface MockedResponse<BodyType extends DefaultBodyType = any> {
   body: BodyType
   status: number
   statusText: string

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -6,7 +6,7 @@ import {
   SharedOptions,
 } from '../sharedOptions'
 import { ServiceWorkerMessage } from '../utils/createBroadcastChannel'
-import { RequestHandler } from '../handlers/RequestHandler'
+import { DefaultBodyType, RequestHandler } from '../handlers/RequestHandler'
 import { InterceptorApi } from '@mswjs/interceptors'
 import { Path } from '../utils/matching/matchRequestUrl'
 import { RequiredDeep } from '../typeUtils'
@@ -181,11 +181,12 @@ export interface StartOptions extends SharedOptions {
   findWorker?: FindWorker
 }
 
-export interface SerializedResponse<BodyType = any> {
+export interface SerializedResponse<BodyType extends DefaultBodyType = any> {
   status: number
   statusText: string
   headers: FlatHeadersObject
   body: BodyType
+  delay?: number
 }
 
 export type StartReturnType = Promise<ServiceWorkerRegistration | undefined>

--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -128,6 +128,7 @@ Expected response resolver to return a mocked response Object, but got %s. The o
   return new Promise((resolve) => {
     const requiredLookupResult =
       lookupResult as RequiredDeep<ResponseLookupResult>
+
     const transformedResponse =
       handleRequestOptions?.transformResponse?.(response) ||
       (response as any as ResponseType)

--- a/src/utils/worker/createFallbackRequestListener.ts
+++ b/src/utils/worker/createFallbackRequestListener.ts
@@ -31,6 +31,7 @@ export function createFallbackRequestListener(
               statusText: response.statusText,
               headers: response.headers.all(),
               body: response.body,
+              delay: response.delay,
             }
           },
           onMockedResponseSent(


### PR DESCRIPTION
- Originated from #1258 

## Changes

- Describes `delay` on the `SerializedResponse` type to be clear. 

The property is missing from the type:

https://github.com/mswjs/msw/blob/cc596c4535e02cc3bf45f45f25b4f89251845dd1/src/setupWorker/glossary.ts#L184-L189

But it is relied upon by the worker:

https://github.com/mswjs/msw/blob/cc596c4535e02cc3bf45f45f25b4f89251845dd1/src/mockServiceWorker.js#L199-L204