### PR TITLE
fix(setupServer): reference interceptors to support fast refresh

### DIFF
--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -3,4 +3,4 @@ import { createSetupServer } from '../node/createSetupServer'
 
 // Provision request interception via patching the `XMLHttpRequest` class only
 // in React Native. There is no `http`/`https` modules in that environment.
-export const setupServer = createSetupServer(new XMLHttpRequestInterceptor())
+export const setupServer = createSetupServer(XMLHttpRequestInterceptor)

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -27,7 +27,7 @@ const DEFAULT_LISTEN_OPTIONS: RequiredDeep<SharedOptions> = {
  * Useful to generate identical API using different patches to request issuing modules.
  */
 export function createSetupServer(
-  ...interceptors: Interceptor<HttpRequestEventMap>[]
+  ...interceptors: { new (): Interceptor<HttpRequestEventMap> }[]
 ) {
   const emitter = new StrictEventEmitter<ServerLifecycleEventsMap>()
   const publicEmitter = new StrictEventEmitter<ServerLifecycleEventsMap>()
@@ -62,7 +62,7 @@ export function createSetupServer(
 
     const interceptor = new BatchInterceptor({
       name: 'setup-server',
-      interceptors,
+      interceptors: interceptors.map((Interceptor) => new Interceptor()),
     })
 
     interceptor.on('request', async function setupServerListener(request) {

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -10,6 +10,6 @@ import { createSetupServer } from './createSetupServer'
 export const setupServer = createSetupServer(
   // List each interceptor separately instead of using the "node" preset
   // so that MSW wouldn't bundle the unnecessary classes (i.e. "SocketPolyfill").
-  new ClientRequestInterceptor(),
-  new XMLHttpRequestInterceptor(),
+  ClientRequestInterceptor,
+  XMLHttpRequestInterceptor,
 )


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/1271
- Closes https://github.com/mswjs/interceptors/pull/262

## Changes

Since the interceptors for Node were instantiated in a different module, the HMR path never touched that module, resulting in those interceptor instances (and their listeners) persisting across hot reloads. 

In this change, I'm passing the interceptors class references to the `createSetupServer` factory instead of accepting instances, and instantiating them in the `setupServer` call itself. 

I've tested this on a fresh `with-msw` Next template and the issue about responding to the same request twice is resolved with this change. 