### PR TITLE
fix: apply response delay conditionally

### DIFF
--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -125,27 +125,23 @@ Expected response resolver to return a mocked response Object, but got %s. The o
 
   emitter.emit('request:match', request)
 
-  return new Promise((resolve) => {
-    const requiredLookupResult =
-      lookupResult as RequiredDeep<ResponseLookupResult>
+  const requiredLookupResult =
+    lookupResult as RequiredDeep<ResponseLookupResult>
 
-    const transformedResponse =
-      handleRequestOptions?.transformResponse?.(response) ||
-      (response as any as ResponseType)
+  const transformedResponse =
+    handleRequestOptions?.transformResponse?.(response) ||
+    (response as any as ResponseType)
 
-    handleRequestOptions?.onMockedResponse?.(
-      transformedResponse,
-      requiredLookupResult,
-    )
+  handleRequestOptions?.onMockedResponse?.(
+    transformedResponse,
+    requiredLookupResult,
+  )
 
-    setTimeout(() => {
-      handleRequestOptions?.onMockedResponseSent?.(
-        transformedResponse,
-        requiredLookupResult,
-      )
-      emitter.emit('request:end', request)
+  handleRequestOptions?.onMockedResponseSent?.(
+    transformedResponse,
+    requiredLookupResult,
+  )
+  emitter.emit('request:end', request)
 
-      resolve(transformedResponse as ResponseType)
-    }, response.delay ?? 0)
-  })
+  return transformedResponse
 }

--- a/test/msw-api/context/delay.node.test.ts
+++ b/test/msw-api/context/delay.node.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { performance } from 'perf_hooks'
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+async function makeRequest(url: string) {
+  const requestStart = performance.now()
+  const res = await fetch(url)
+  const requestEnd = performance.now()
+  const responseTime = requestEnd - requestStart
+
+  return { res, responseTime }
+}
+
+test('uses explicit server response time', async () => {
+  server.use(
+    rest.get('http://localhost/user', (req, res, ctx) => {
+      return res(ctx.delay(500), ctx.text('john'))
+    }),
+  )
+
+  const { res, responseTime } = await makeRequest('http://localhost/user')
+
+  expect(responseTime).toBeGreaterThanOrEqual(500)
+  expect(await res.text()).toBe('john')
+})
+
+test('uses realistic server response time when no duration is provided', async () => {
+  server.use(
+    rest.get('http://localhost/user', (req, res, ctx) => {
+      return res(ctx.delay(), ctx.text('john'))
+    }),
+  )
+
+  const { res, responseTime } = await makeRequest('http://localhost/user')
+
+  // Realistic server response time in Node.js is set to 5ms.
+  expect(responseTime).toBeGreaterThan(5)
+  expect(responseTime).toBeLessThan(100)
+  expect(await res.text()).toBe('john')
+})
+
+test('uses realistic server response time when "real" mode is provided', async () => {
+  server.use(
+    rest.get('http://localhost/user', (req, res, ctx) => {
+      return res(ctx.delay('real'), ctx.text('john'))
+    }),
+  )
+
+  const { res, responseTime } = await makeRequest('http://localhost/user')
+
+  // Realistic server response time in Node.js is set to 5ms.
+  expect(responseTime).toBeGreaterThan(5)
+  expect(await res.text()).toBe('john')
+})


### PR DESCRIPTION
- Fixes #966
- Extracted from #1288

## Changes

- Removes `setTimeout` from the `handleRequest` so that response lookup is not concerned with actually applying a response (delaying it is, in fact, a part of applying it). 
- Manually delays mocked responses in Node.js only if delay has been set. 
- Adds a new integration test for `ctx.delaty` in Node.js.