### PR TITLE
ci(smoke): use node-version 16

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 16
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
instead of 16.14. For consistency with other workflows using node.

Fixes #1304 