### PR TITLE
chore: fix types in "custom-request-handler" test

### DIFF
--- a/test/rest-api/custom-request-handler.mocks.ts
+++ b/test/rest-api/custom-request-handler.mocks.ts
@@ -10,7 +10,10 @@ import {
 
 // This is an example of a custom request handler that matches requests
 // based on the presence of a given header.
-class HeaderHandler extends RequestHandler<{ headerName: string }> {
+class HeaderHandler extends RequestHandler<{
+  header: string
+  headerName: string
+}> {
   constructor(headerName: string, resolver: ResponseResolver) {
     super({
       info: {
@@ -36,7 +39,7 @@ interface CustomContext {
   halJson: (body: Record<string, any>) => ResponseTransformer
 }
 
-class UrlHandler extends RequestHandler<{ url: string }> {
+class UrlHandler extends RequestHandler<{ header: string; url: string }> {
   constructor(
     url: string,
     resolver: ResponseResolver<MockedRequest, CustomContext>,


### PR DESCRIPTION
Spotted these types got de-synced after RequestHandler updates. 