### PR TITLE
feat: make GraphQL a peer dependency, support GraphQL v15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "chalk": "4.1.1",
     "chokidar": "^3.4.2",
     "cookie": "^0.4.2",
-    "graphql": "^16.3.0",
     "headers-polyfill": "^3.0.4",
     "inquirer": "^8.2.0",
     "is-node-process": "^1.0.1",
@@ -116,6 +115,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "fs-extra": "^10.0.0",
     "fs-teardown": "^0.3.0",
+    "graphql": "^16.3.0",
     "jest": "26",
     "json-bigint": "^1.0.0",
     "lint-staged": "^11.0.1",
@@ -134,6 +134,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "peerDependencies": {
+    "graphql": "^15.0.0 || ^16.0.0",
     "typescript": ">= 4.2.x <= 4.7.x"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,9 @@
     "typescript": ">= 4.2.x <= 4.7.x"
   },
   "peerDependenciesMeta": {
+    "graphql": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }

--- a/src/context/errors.ts
+++ b/src/context/errors.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql'
+import type { GraphQLError } from 'graphql'
 import { ResponseTransformer } from '../response'
 import { jsonParse } from '../utils/internal/jsonParse'
 import { mergeRight } from '../utils/internal/mergeRight'

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -83,7 +83,7 @@ const standardGraphQLHandlers = {
    * })
    * @see {@link https://mswjs.io/docs/api/graphql/query `graphql.query()`}
    */
-  query: createScopedGraphQLHandler(OperationTypeNode.QUERY, '*'),
+  query: createScopedGraphQLHandler('query' as OperationTypeNode, '*'),
 
   /**
    * Captures a GraphQL mutation by a given name.
@@ -93,14 +93,14 @@ const standardGraphQLHandlers = {
    * })
    * @see {@link https://mswjs.io/docs/api/graphql/mutation `graphql.mutation()`}
    */
-  mutation: createScopedGraphQLHandler(OperationTypeNode.MUTATION, '*'),
+  mutation: createScopedGraphQLHandler('mutation' as OperationTypeNode, '*'),
 }
 
 function createGraphQLLink(url: Path): typeof standardGraphQLHandlers {
   return {
     operation: createGraphQLOperationHandler(url),
-    query: createScopedGraphQLHandler(OperationTypeNode.QUERY, url),
-    mutation: createScopedGraphQLHandler(OperationTypeNode.MUTATION, url),
+    query: createScopedGraphQLHandler('query' as OperationTypeNode, url),
+    mutation: createScopedGraphQLHandler('mutation' as OperationTypeNode, url),
   }
 }
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,4 +1,4 @@
-import { DocumentNode, OperationTypeNode } from 'graphql'
+import type { DocumentNode, OperationTypeNode } from 'graphql'
 import { ResponseResolver } from './handlers/RequestHandler'
 import {
   GraphQLHandler,

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -1,4 +1,4 @@
-import { DocumentNode, OperationTypeNode } from 'graphql'
+import type { DocumentNode, OperationTypeNode } from 'graphql'
 import { SerializedResponse } from '../setupWorker/glossary'
 import { data } from '../context/data'
 import { extensions } from '../context/extensions'

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -1,8 +1,7 @@
-import {
+import type {
   DocumentNode,
   OperationDefinitionNode,
   OperationTypeNode,
-  parse,
 } from 'graphql'
 import { GraphQLVariables } from '../../handlers/GraphQLHandler'
 import { getPublicUrlFromRequest } from '../request/getPublicUrlFromRequest'
@@ -41,6 +40,9 @@ export function parseDocumentNode(node: DocumentNode): ParsedGraphQLQuery {
 
 function parseQuery(query: string): ParsedGraphQLQuery | Error {
   try {
+    // Since 'graphql' is an optional peer dependency,
+    // we'll attempt to import it dynamically
+    const { parse } = require('graphql')
     const ast = parse(query)
     return parseDocumentNode(ast)
   } catch (error) {


### PR DESCRIPTION
The `graphql` package throws errors if it's not treated as a [singleton dependency](https://github.com/graphql/graphql-js/blob/94234c8ce0a33cd8d884d0fced3d7d107db8f8aa/src/jsutils/instanceOf.js#L32). It's recommended for libraries to install it as a peer dependency (see: https://github.com/graphql/graphql-js/issues/594#issuecomment-1189850052).

To allow MSW to work with projects that are using `graphql` v15, I've made a few small changes to the code to avoid using `OperationTypeNode` as an enum. The updated code is compatible with both v15 and v16 of the `graphql` package.