### PR TITLE
fix: add "listHandlers" method to server and worker

### DIFF
--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -17,6 +17,7 @@ import { devUtils } from '../utils/internal/devUtils'
 import { pipeEvents } from '../utils/internal/pipeEvents'
 import { RequiredDeep } from '../typeUtils'
 import { MockedRequest } from '../utils/request/MockedRequest'
+import { toReadonlyArray } from '../utils/internal/toReadonlyArray'
 
 const DEFAULT_LISTEN_OPTIONS: RequiredDeep<SharedOptions> = {
   onUnhandledRequest: 'warn',
@@ -138,11 +139,13 @@ export function createSetupServer(
       },
 
       listHandlers() {
-        return currentHandlers
+        return toReadonlyArray(currentHandlers)
       },
 
       printHandlers() {
-        currentHandlers.forEach((handler) => {
+        const handlers = this.listHandlers()
+
+        handlers.forEach((handler) => {
           const { header, callFrame } = handler.info
 
           const pragma = handler.info.hasOwnProperty('operationType')

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -137,6 +137,10 @@ export function createSetupServer(
         )
       },
 
+      listHandlers() {
+        return currentHandlers
+      },
+
       printHandlers() {
         currentHandlers.forEach((handler) => {
           const { header, callFrame } = handler.info

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,7 +1,10 @@
-
 import type { PartialDeep } from 'type-fest'
 import type { IsomorphicResponse } from '@mswjs/interceptors'
-import { DefaultBodyType, RequestHandler, RequestHandlerDefaultInfo } from '../handlers/RequestHandler'
+import {
+  DefaultBodyType,
+  RequestHandler,
+  RequestHandlerDefaultInfo,
+} from '../handlers/RequestHandler'
 import {
   LifeCycleEventEmitter,
   LifeCycleEventsMap,
@@ -43,10 +46,17 @@ export interface SetupServerApi {
   resetHandlers(...nextHandlers: RequestHandler[]): void
 
   /**
- * Returns lists of all active request handlers.
- * @see {@link https://mswjs.io/docs/api/setup-server/list-handlers `server.list-handlers()`}
- */
-  listHandlers(): RequestHandler<RequestHandlerDefaultInfo, MockedRequest<DefaultBodyType>, any, MockedRequest<DefaultBodyType>>[]
+   * Returns a readonly list of cyurrently active request handlers.
+   * @see {@link https://mswjs.io/docs/api/setup-server/list-handlers `server.listHandlers()`}
+   */
+  listHandlers(): ReadonlyArray<
+    RequestHandler<
+      RequestHandlerDefaultInfo,
+      MockedRequest<DefaultBodyType>,
+      any,
+      MockedRequest<DefaultBodyType>
+    >
+  >
 
   /**
    * Lists all active request handlers.

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,11 +1,13 @@
+
 import type { PartialDeep } from 'type-fest'
 import type { IsomorphicResponse } from '@mswjs/interceptors'
-import { RequestHandler } from '../handlers/RequestHandler'
+import { DefaultBodyType, RequestHandler, RequestHandlerDefaultInfo } from '../handlers/RequestHandler'
 import {
   LifeCycleEventEmitter,
   LifeCycleEventsMap,
   SharedOptions,
 } from '../sharedOptions'
+import { MockedRequest } from '../utils/request/MockedRequest'
 
 export type ServerLifecycleEventsMap = LifeCycleEventsMap<IsomorphicResponse>
 
@@ -39,6 +41,12 @@ export interface SetupServerApi {
    * @see {@link https://mswjs.io/docs/api/setup-server/reset-handlers `server.reset-handlers()`}
    */
   resetHandlers(...nextHandlers: RequestHandler[]): void
+
+  /**
+ * Returns lists of all active request handlers.
+ * @see {@link https://mswjs.io/docs/api/setup-server/list-handlers `server.list-handlers()`}
+ */
+  listHandlers(): RequestHandler<RequestHandlerDefaultInfo, MockedRequest<DefaultBodyType>, any, MockedRequest<DefaultBodyType>>[]
 
   /**
    * Lists all active request handlers.

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -6,10 +6,15 @@ import {
   SharedOptions,
 } from '../sharedOptions'
 import { ServiceWorkerMessage } from './start/utils/createMessageChannel'
-import { DefaultBodyType, RequestHandler } from '../handlers/RequestHandler'
+import {
+  DefaultBodyType,
+  RequestHandler,
+  RequestHandlerDefaultInfo,
+} from '../handlers/RequestHandler'
 import type { HttpRequestEventMap, Interceptor } from '@mswjs/interceptors'
 import { Path } from '../utils/matching/matchRequestUrl'
 import { RequiredDeep } from '../typeUtils'
+import { MockedRequest } from '../utils/request/MockedRequest'
 
 export type ResolvedPath = Path | URL
 
@@ -236,6 +241,19 @@ export interface SetupWorkerApi {
    * @see {@link https://mswjs.io/docs/api/setup-worker/reset-handlers `worker.resetHandlers()`}
    */
   resetHandlers: (...nextHandlers: RequestHandler[]) => void
+
+  /**
+   * Returns a readonly list of currently active request handlers.
+   * @see {@link https://mswjs.io/docs/api/setup-worker/list-handlers `worker.listHandlers()`}
+   */
+  listHandlers(): ReadonlyArray<
+    RequestHandler<
+      RequestHandlerDefaultInfo,
+      MockedRequest<DefaultBodyType>,
+      any,
+      MockedRequest<DefaultBodyType>
+    >
+  >
 
   /**
    * Lists all active request handlers.

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -17,6 +17,7 @@ import { createFallbackStart } from './start/createFallbackStart'
 import { createFallbackStop } from './stop/createFallbackStop'
 import { devUtils } from '../utils/internal/devUtils'
 import { pipeEvents } from '../utils/internal/pipeEvents'
+import { toReadonlyArray } from '../utils/internal/toReadonlyArray'
 
 interface Listener {
   target: EventTarget
@@ -190,8 +191,14 @@ export function setupWorker(
       )
     },
 
+    listHandlers() {
+      return toReadonlyArray(context.requestHandlers)
+    },
+
     printHandlers() {
-      context.requestHandlers.forEach((handler) => {
+      const handlers = this.listHandlers()
+
+      handlers.forEach((handler) => {
         const { header, callFrame } = handler.info
         const pragma = handler.info.hasOwnProperty('operationType')
           ? '[graphql]'

--- a/src/utils/internal/toReadonlyArray.test.ts
+++ b/src/utils/internal/toReadonlyArray.test.ts
@@ -4,6 +4,14 @@ it('creates a copy of an array', () => {
   expect(toReadonlyArray([1, 2, 3])).toEqual([1, 2, 3])
 })
 
+it('does not affect the source array', () => {
+  const source = ['a', 'b', 'c']
+  toReadonlyArray(source)
+
+  expect(source.push('d')).toBe(4)
+  expect(source).toEqual(['a', 'b', 'c', 'd'])
+})
+
 it('forbids modifying the array copy', () => {
   const source = [1, 2, 3]
   const copy = toReadonlyArray(source)

--- a/src/utils/internal/toReadonlyArray.test.ts
+++ b/src/utils/internal/toReadonlyArray.test.ts
@@ -1,0 +1,22 @@
+import { toReadonlyArray } from './toReadonlyArray'
+
+it('creates a copy of an array', () => {
+  expect(toReadonlyArray([1, 2, 3])).toEqual([1, 2, 3])
+})
+
+it('forbids modifying the array copy', () => {
+  const source = [1, 2, 3]
+  const copy = toReadonlyArray(source)
+
+  expect(() => {
+    // @ts-expect-error Intentional runtime misusage.
+    copy[2] = 1
+  }).toThrow(/Cannot assign to read only property '\d+' of object/)
+
+  expect(() => {
+    // @ts-expect-error Intentional runtime misusage.
+    copy.push(4)
+  }).toThrow(/Cannot add property \d+, object is not extensible/)
+
+  expect(source).toEqual([1, 2, 3])
+})

--- a/src/utils/internal/toReadonlyArray.ts
+++ b/src/utils/internal/toReadonlyArray.ts
@@ -1,0 +1,8 @@
+/**
+ * Creates an immutable copy of the given array.
+ */
+export function toReadonlyArray<T>(source: Array<T>): ReadonlyArray<T> {
+  const clone = [...source] as Array<T>
+  Object.freeze(clone)
+  return clone
+}

--- a/test/msw-api/setup-server/listHandlers.test.ts
+++ b/test/msw-api/setup-server/listHandlers.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { rest, graphql } from 'msw'
 import { setupServer } from 'msw/node'
 

--- a/test/msw-api/setup-server/listHandlers.test.ts
+++ b/test/msw-api/setup-server/listHandlers.test.ts
@@ -1,0 +1,45 @@
+import { rest, graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+const resolver = () => null
+const github = graphql.link('https://api.github.com')
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/book/:bookId', resolver),
+  graphql.query('GetUser', resolver),
+  graphql.mutation('UpdatePost', resolver),
+  graphql.operation(resolver),
+  github.query('GetRepo', resolver),
+  github.operation(resolver),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+test('lists all current request handlers', () => {
+  const handlers = server.listHandlers()
+
+  expect(handlers.length).toEqual(6)
+})
+
+test('respects runtime request handlers when listing handlers', () => {
+  server.use(
+    rest.get('https://test.mswjs.io/book/:bookId', resolver),
+    graphql.query('GetRandomNumber', resolver),
+  )
+
+  const handlers = server.listHandlers()
+
+  // Runtime handlers are prepended to the list of handlers
+  // and they DON'T remove the handlers they may override.
+  expect(handlers.length).toEqual(8)
+})

--- a/test/msw-api/setup-worker/listHandlers.mocks.ts
+++ b/test/msw-api/setup-worker/listHandlers.mocks.ts
@@ -1,0 +1,21 @@
+import { setupWorker, rest, graphql } from 'msw'
+
+const resolver = () => null
+
+const github = graphql.link('https://api.github.com')
+
+const worker = setupWorker(
+  rest.get('https://test.mswjs.io/book/:bookId', resolver),
+  graphql.query('GetUser', resolver),
+  graphql.mutation('UpdatePost', resolver),
+  graphql.operation(resolver),
+  github.query('GetRepo', resolver),
+  github.operation(resolver),
+)
+
+// @ts-ignore
+window.msw = {
+  worker,
+  rest,
+  graphql,
+}

--- a/test/msw-api/setup-worker/listHandlers.test.ts
+++ b/test/msw-api/setup-worker/listHandlers.test.ts
@@ -1,0 +1,76 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { SetupWorkerApi, rest, graphql } from 'msw'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorkerApi
+    rest: typeof rest
+    graphql: typeof graphql
+  }
+}
+
+function createRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'printHandlers.mocks.ts'),
+  })
+}
+
+test('lists all current request handlers', async () => {
+  const runtime = await createRuntime()
+
+  const handlerHeaders = await runtime.page.evaluate(() => {
+    const handlers = window.msw.worker.listHandlers()
+    return handlers.map((handler) => handler.info.header)
+  })
+
+  expect(handlerHeaders).toEqual([
+    'GET https://test.mswjs.io/book/:bookId',
+    'query GetUser (origin: *)',
+    'mutation UpdatePost (origin: *)',
+    'all (origin: *)',
+    'query GetRepo (origin: https://api.github.com)',
+    'all (origin: https://api.github.com)',
+  ])
+})
+
+test('forbids from modifying the list of handlers', async () => {
+  const runtime = await createRuntime()
+
+  /**
+   * @note For some reason, property assignment on frozen object
+   * does not throw an error: handlers[0] = 1
+   */
+  await expect(
+    runtime.page.evaluate(() => {
+      const handlers = window.msw.worker.listHandlers()
+      // @ts-expect-error Intentional runtime misusage.
+      handlers.push(1)
+    }),
+  ).rejects.toThrow(/Cannot add property \d+, object is not extensible/)
+})
+
+test('includes runtime request handlers when listing handlers', async () => {
+  const runtime = await createRuntime()
+
+  const handlerHeaders = await runtime.page.evaluate(() => {
+    const { worker, rest, graphql } = window.msw
+    worker.use(
+      rest.get('https://test.mswjs.io/book/:bookId', () => void 0),
+      graphql.query('GetRandomNumber', () => void 0),
+    )
+    const handlers = worker.listHandlers()
+    return handlers.map((handler) => handler.info.header)
+  })
+
+  expect(handlerHeaders).toEqual([
+    'GET https://test.mswjs.io/book/:bookId',
+    'query GetRandomNumber (origin: *)',
+    'GET https://test.mswjs.io/book/:bookId',
+    'query GetUser (origin: *)',
+    'mutation UpdatePost (origin: *)',
+    'all (origin: *)',
+    'query GetRepo (origin: https://api.github.com)',
+    'all (origin: https://api.github.com)',
+  ])
+})

--- a/test/msw-api/setup-worker/printHandlers.test.ts
+++ b/test/msw-api/setup-worker/printHandlers.test.ts
@@ -49,7 +49,7 @@ test('lists rest request handlers', async () => {
   ])
 })
 
-test('respects runtime request handlers', async () => {
+test('includes runtime request handlers', async () => {
   const { page, consoleSpy } = await createRuntime()
 
   await page.evaluate(() => {


### PR DESCRIPTION
@kettanaito is something like this what you had in mind? 

**Change overview**

This PR adds a `listHandlers()` method that returns a list of currently active handlers as suggested in https://github.com/mswjs/msw/issues/474#issuecomment-1225571039.

> You can list currently active handlers via [server.printHandlers()](https://mswjs.io/docs/api/setup-server/print-handlers). Alas, it prints the handlers summary stdout instead of returning a list. If you are interested, it'd be awesome to have a change where printHandlers() returns a list of handlers:

**Additional change proposal**

Now that devs would have access to individual handlers, handlers would benefit from having a `.toString()` or `.stringSummary()` to easily see a string summary of the handler. The logging logic within `printHandlers` could be moved to `handler.toString()`, then `printHandlers` would simply be:

```typescript
 printHandlers() {
        currentHandlers.forEach((handler) => {
          console.log(handler.toString())
        })
      }
```

