### PR TITLE
test(concurrency): add a failing concurrency test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "cross-env BABEL_ENV=test jest --maxWorkers=3",
     "test:integration": "jest --config=./test/jest.config.js --maxWorkers=1",
+    "test:concurrency": "jest --config=./test/jest.config.js test/msw-api/setup-server/scenarios/concurrency/process-one.test.ts --maxWorkers=1",
     "test:smoke": "./config/scripts/smoke.sh",
     "test:ts": "yarn tsc -p ./test/typings/tsconfig.json",
     "prepare": "yarn simple-git-hooks init",

--- a/test/msw-api/setup-server/listHandlers.test.ts
+++ b/test/msw-api/setup-server/listHandlers.test.ts
@@ -1,0 +1,43 @@
+import { rest, graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+const resolver = () => null
+const github = graphql.link('https://api.github.com')
+
+const server = setupServer(
+  rest.get('https://test.mswjs.io/book/:bookId', resolver),
+  graphql.query('GetUser', resolver),
+  graphql.mutation('UpdatePost', resolver),
+  graphql.operation(resolver),
+  github.query('GetRepo', resolver),
+  github.operation(resolver),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+test('lists all current request handlers', () => {
+  const handlers = server.listHandlers()
+  expect(handlers.length).toEqual(6)
+})
+
+test('respects runtime request handlers when listing handlers', () => {
+  server.use(
+    rest.get('https://test.mswjs.io/book/:bookId', resolver),
+    graphql.query('GetRandomNumber', resolver),
+  )
+
+  const handlers = server.listHandlers()
+  // Runtime handlers are prepended to the list of handlers
+  // and they DON'T remove the handlers they may override.
+  expect(handlers.length).toEqual(8)
+})

--- a/test/msw-api/setup-server/scenarios/concurrency/README.md
+++ b/test/msw-api/setup-server/scenarios/concurrency/README.md
@@ -1,0 +1,71 @@
+# msw single file concurrency failing 
+
+### Goal 
+Create a test suite to reliably show tests involving msw failing when executed in parallel.
+
+###  Method
+- Create a shared server to be consumed by two seperate tests
+- Define tests within one describe block with `it.concurrent()`
+  - Using serial execution via `it()` syntax will make the tests pass.
+  - `beforeAll()` is not officially supported with `.concurrent()` syntax so I use [this method](https://github.com/facebook/jest/issues/7997#issuecomment-796965078) to ensure `beforeAll()` is triggered before tests are run.
+- use `async await sleep` to ensure operations upon the server happen in the precise order despite being in different tests.
+- Assert that a request made in _test suite A_ is erroneously handled by a handler attached in _test suite B_.
+-  Use a request param to distinguish between requests from both test suites `one` and `two`.
+
+## Expected logs, if msw supported concurrency:
+
+- `step 1 - process one attach handler to server`
+- `step 2 - process two attach handler to server`
+- `step 3 - process one make request`
+- `step 4 - process one handler resolver triggered`
+- `step 5 - process two make request`
+- `step 6 - process two handler resolver triggered`
+
+
+## Actual Logs
+
+- `step 1 - process one attach handler to server`
+- `step 2 - process two attach handler to server`
+- `step 3 - process one make request`
+
+  - **this is where it goes wrong**
+- `step 6 - process two handler resolver triggered`
+- `step 5 - process two make request`
+- `step 6 - process two handler resolver triggered`
+
+
+**Explanation:** 
+- Process two was the most recent place where a dynamic handler was added to the server via `server.use()`. 
+- Therefor all requests are routed to that implementation since it is at the front of the list of handlers.
+- Two handlers are attached at this time, however only the newest one gets all of the API requests.
+
+
+
+
+## Observations
+
+Response to @kettanaito proposal [here](https://github.com/mswjs/msw/issues/474#issuecomment-1072567085) 
+
+> Similar to requests identity, I propose to add moduleId/modulePath only to runtime handlers (those defined via server.use()). As long as the request and the runtime handler share the moduleId, it guarantees that they were issued/prepended in the same module and can affect each other.
+
+
+Supporting parallization of testing within one file, in addition to by `moduleId` could be something worth striving towards.
+
+
+## Runtime handler identity
+
+I noticed the `callFrame` property from within `handler.info` exposes not only the module, but also the exact line number from which it was called. 
+
+Add a `lineNumber` to the identity of requests and handlers.
+
+1. Use `moduleId/modulePath` to narrow down the list of possibly valid runtime handlers to this module.
+2. When more than one remains:
+  a. find the one that has the closest line number **BEFORE** the `lineNumber` within the request.
+
+```typescript 
+{
+  id: "uuid-of-request",
+  modulePath: "/User/octocat/GitHub/test/Profile.test.tsx"
+  lineNumber: 337
+}
+```

--- a/test/msw-api/setup-server/scenarios/concurrency/api.ts
+++ b/test/msw-api/setup-server/scenarios/concurrency/api.ts
@@ -1,0 +1,12 @@
+import fetch from 'node-fetch'
+
+export const makeRequest = async (endpoint: string) => {
+  const res = await fetch(endpoint, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+
+  return res
+}

--- a/test/msw-api/setup-server/scenarios/concurrency/process-one.test.ts
+++ b/test/msw-api/setup-server/scenarios/concurrency/process-one.test.ts
@@ -1,0 +1,89 @@
+import { rest, graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { makeRequest } from './api'
+import {
+  sharedServer,
+  sleep,
+  endpoint,
+  getNow,
+  beforeAllResolve,
+  beforeAllPromise,
+  sleepDelay,
+} from './shared-server'
+
+describe('concurrency test', () => {
+  beforeAll(async () => {
+    sharedServer.listen()
+    beforeAllResolve()
+  })
+
+  afterAll(async () => {
+    sharedServer.close()
+  })
+
+  it.concurrent('process one tests', async () => {
+    await beforeAllPromise
+
+    const mockFn = jest.fn()
+
+    console.log('step 1 - process one attach handler to server: '),
+      sharedServer.use(
+        rest.get(`${endpoint}/:processId`, (req, res, ctx) => {
+          console.log(
+            'step 4 - process one handler resolver triggered: ',
+            getNow(),
+          )
+
+          mockFn(req.params.processId)
+
+          return res(
+            ctx.json({
+              text: 'process one handler resolver response',
+            }),
+          )
+        }),
+      )
+
+    const handlers = sharedServer.listHandlers()
+
+    await sleep(sleepDelay)
+
+    console.log('step 3 - process one make request: ')
+
+    await makeRequest(`${endpoint}/one`)
+
+    expect(mockFn).toHaveBeenCalledWith('one')
+
+    console.log('process one end: ', handlers)
+  })
+
+  it.concurrent('process two tests', async () => {
+    await beforeAllPromise
+
+    const mockFn = jest.fn()
+
+    console.log('step 2 - process two attach handler to server: '),
+      sharedServer.use(
+        rest.get(`${endpoint}/:processId`, (req, res, ctx) => {
+          console.log(
+            'step 6 - process two handler resolver triggered: ',
+            req.params.processId,
+          )
+
+          mockFn(req.params.processId)
+
+          return res(
+            ctx.json({
+              text: 'process two handler resolver response',
+            }),
+          )
+        }),
+      )
+    await sleep(sleepDelay)
+
+    console.log('step 5 - process two make request: ')
+
+    await makeRequest(`${endpoint}/two`)
+    expect(mockFn).toHaveBeenCalledWith('two')
+  })
+})

--- a/test/msw-api/setup-server/scenarios/concurrency/shared-server.ts
+++ b/test/msw-api/setup-server/scenarios/concurrency/shared-server.ts
@@ -1,0 +1,43 @@
+import { setupServer } from 'msw/node'
+
+export const sharedServer = setupServer()
+
+export const sleepDelay = 3000
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+export const getNow = () => {
+  const today = new Date()
+  const time =
+    today.getHours() +
+    ':' +
+    today.getMinutes() +
+    ':' +
+    today.getSeconds() +
+    ':' +
+    today.getMilliseconds()
+
+  return time
+}
+
+export const endpoint = 'https://test.mswjs.io/book'
+
+export let beforeAllResolve
+
+export const beforeAllPromise = new Promise((resolve) => {
+  beforeAllResolve = resolve
+})
+
+// beforeAll(() => {
+//   console.log('before all triggering')
+//   sharedServer.listen()
+// })
+
+// // do not invoke resetHandlers
+// // afterEach(() => {
+// //   server.resetHandlers()
+// // })
+
+// afterAll(() => {
+//   console.log('after all triggering')
+//   sharedServer.close()
+// })


### PR DESCRIPTION
Goal: create a test that reliably fails when msw is used with tests running in parallel.

Execute `yarn test:concurrency` in terminal to run only the concurrency test.

###  Method
- Create a shared server to be consumed by two seperate tests
- Define tests within one describe block with `it.concurrent()`
  - Using serial execution via `it()` syntax will make the tests pass.
  - `beforeAll()` is not officially supported with `.concurrent()` syntax so I use [this method](https://github.com/facebook/jest/issues/7997#issuecomment-796965078) to ensure `beforeAll()` is triggered before tests are run.
- use `async await sleep` to ensure operations upon the server happen in the precise order despite being in different tests.
- Assert that a request made in _test suite A_ is erroneously handled by a handler attached in _test suite B_.
-  Use a request param to distinguish between requests from both test suites `one` and `two`.

## Expected logs, if msw supported concurrency:

- `step 1 - process one attach handler to server`
- `step 2 - process two attach handler to server`
- `step 3 - process one make request`
- `step 4 - process one handler resolver triggered`
- `step 5 - process two make request`
- `step 6 - process two handler resolver triggered`


## Actual Logs

- `step 1 - process one attach handler to server`
- `step 2 - process two attach handler to server`
- `step 3 - process one make request`

  - **this is where it goes wrong**
- `step 6 - process two handler resolver triggered`
- `step 5 - process two make request`
- `step 6 - process two handler resolver triggered`


**Explanation:** 
- Process two was the most recent place where a dynamic handler was added to the server via `server.use()`. 
- Therefor all requests are routed to that implementation since it is at the front of the list of handlers.
- Two handlers are attached at this time, however only the newest one gets all of the API requests.




## Observations

Response to @kettanaito  proposal https://github.com/mswjs/msw/issues/474#issuecomment-1225571039

> Similar to requests identity, I propose to add moduleId/modulePath only to runtime handlers (those defined via server.use()). As long as the request and the runtime handler share the moduleId, it guarantees that they were issued/prepended in the same module and can affect each other.


Supporting parallization of testing within one file, in addition to by `moduleId` could be something worth striving towards.


## Runtime handler identity

I noticed the `callFrame` property from within `handler.info` exposes not only the module, but also the exact line number from which it was called. 

Idea is to add a `lineNumber` to the identity of requests and handlers.

1. Use `moduleId/modulePath` to narrow down the list of possibly valid runtime handlers to this module.
2. When more than one remains:
  a. find the one that has the closest line number **BEFORE** the `lineNumber` within the request.

```typescript 
{
  id: "uuid-of-request",
  modulePath: "/User/octocat/GitHub/test/Profile.test.tsx"
  lineNumber: 337
}
```
