### PR TITLE
chore: support typescript 4.8.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7']
+        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -128,14 +128,14 @@
     "ts-loader": "^9.2.6",
     "ts-node": "^10.1.0",
     "tsup": "^5.12.8",
-    "typescript": "^4.7.2",
+    "typescript": "^4.8.2",
     "url-loader": "^4.1.1",
     "webpack": "^5.68.0",
     "webpack-dev-server": "^3.11.2"
   },
   "peerDependencies": {
     "graphql": "^15.0.0 || ^16.0.0",
-    "typescript": ">= 4.2.x <= 4.7.x"
+    "typescript": ">= 4.2.x <= 4.8.x"
   },
   "peerDependenciesMeta": {
     "graphql": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9664,10 +9664,10 @@ typescript@^4.4.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
   integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
-typescript@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
-  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+typescript@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Based upon the work in https://github.com/mswjs/msw/pull/1256 I've taken a shot at seeing if this can be upgraded cleanly to 4.8.2