### PR TITLE
fix(deps): include "graphql" as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,9 +138,6 @@
     "typescript": ">= 4.2.x <= 4.8.x"
   },
   "peerDependenciesMeta": {
-    "graphql": {
-      "optional": true
-    },
     "typescript": {
       "optional": true
     }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "chalk": "4.1.1",
     "chokidar": "^3.4.2",
     "cookie": "^0.4.2",
+    "graphql": "^15.0.0 || ^16.0.0",
     "headers-polyfill": "^3.0.4",
     "inquirer": "^8.2.0",
     "is-node-process": "^1.0.1",
@@ -115,7 +116,6 @@
     "eslint-plugin-prettier": "^3.4.0",
     "fs-extra": "^10.0.0",
     "fs-teardown": "^0.3.0",
-    "graphql": "^16.3.0",
     "jest": "26",
     "json-bigint": "^1.0.0",
     "lint-staged": "^11.0.1",
@@ -134,7 +134,6 @@
     "webpack-dev-server": "^3.11.2"
   },
   "peerDependencies": {
-    "graphql": "^15.0.0 || ^16.0.0",
     "typescript": ">= 4.2.x <= 4.8.x"
   },
   "peerDependenciesMeta": {

--- a/src/utils/internal/parseGraphQLRequest.ts
+++ b/src/utils/internal/parseGraphQLRequest.ts
@@ -3,6 +3,7 @@ import type {
   OperationDefinitionNode,
   OperationTypeNode,
 } from 'graphql'
+import { parse } from 'graphql'
 import { GraphQLVariables } from '../../handlers/GraphQLHandler'
 import { getPublicUrlFromRequest } from '../request/getPublicUrlFromRequest'
 import { MockedRequest } from '../request/MockedRequest'
@@ -40,9 +41,6 @@ export function parseDocumentNode(node: DocumentNode): ParsedGraphQLQuery {
 
 function parseQuery(query: string): ParsedGraphQLQuery | Error {
   try {
-    // Since 'graphql' is an optional peer dependency,
-    // we'll attempt to import it dynamically
-    const { parse } = require('graphql')
     const ast = parse(query)
     return parseDocumentNode(ast)
   } catch (error) {

--- a/test/graphql-api/compatibility.node.test.ts
+++ b/test/graphql-api/compatibility.node.test.ts
@@ -1,6 +1,5 @@
 import fetch from 'cross-fetch'
-import { graphql as executeGraphql } from 'graphql'
-import { buildSchema } from 'graphql/utilities'
+import { graphql as executeGraphql, buildSchema } from 'graphql'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { createGraphQLClient, gql } from '../support/graphql'

--- a/test/graphql-api/extensions.node.test.ts
+++ b/test/graphql-api/extensions.node.test.ts
@@ -1,14 +1,11 @@
 /**
  * @jest-environment node
  */
-import fetch from 'node-fetch'
-import {
-  graphql as executeGraphql,
-  buildSchema,
-  ExecutionResult,
-} from 'graphql'
+import type { ExecutionResult } from 'graphql'
+import { buildSchema, graphql as executeGraphql } from 'graphql'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
+import fetch from 'node-fetch'
 import { gql } from '../support/graphql'
 
 const schema = gql`

--- a/test/graphql-api/extensions.test.ts
+++ b/test/graphql-api/extensions.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import { pageWith } from 'page-with'
-import { ExecutionResult } from 'graphql'
+import type { ExecutionResult } from 'graphql'
 import { executeGraphQLQuery } from './utils/executeGraphQLQuery'
 import { gql } from '../support/graphql'
 

--- a/test/graphql-api/response-patching.node.test.ts
+++ b/test/graphql-api/response-patching.node.test.ts
@@ -4,8 +4,7 @@
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import fetch from 'cross-fetch'
-import { graphql as executeGraphql } from 'graphql'
-import { buildSchema } from 'graphql/utilities'
+import { graphql as executeGraphql, buildSchema } from 'graphql'
 import { ServerApi, createServer } from '@open-draft/test-server'
 import { createGraphQLClient, gql } from '../support/graphql'
 

--- a/test/graphql-api/response-patching.test.ts
+++ b/test/graphql-api/response-patching.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 import { pageWith } from 'page-with'
-import { ExecutionResult, buildSchema, graphql } from 'graphql'
+import type { ExecutionResult } from 'graphql'
+import { buildSchema, graphql } from 'graphql'
 import { ServerApi, createServer } from '@open-draft/test-server'
 import { SetupWorkerApi } from 'msw'
 import { gql } from '../support/graphql'

--- a/test/support/graphql.ts
+++ b/test/support/graphql.ts
@@ -1,4 +1,4 @@
-import { ExecutionResult } from 'graphql'
+import type { ExecutionResult } from 'graphql'
 
 /**
  * Identity function that returns a given template string array.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5345,10 +5345,10 @@ graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
-graphql@^16.3.0:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
-  integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
+"graphql@^15.0.0 || ^16.0.0":
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
this makes the graphql peer dependency required. While the hope is to eventually avoid the need to require the graphql library for users who don't declare graphql requests directly, the current architecture means that many tools fails to properly compile without error/warning without this.

Since NPM 7, npm will automatically install peer dependencies, which should avoid consumers of msw having to manually install graphql.

While ideally we'd avoid this now - this PR may be a reasonable stopgap that avoids frustration/confusion in the interim

I also reverted the change to `require('graphql')`.  The semantics of lazily requiring are a bit off imo, and given that it doesn't provide the desired effect, there's a bit more clarity maintaining import syntax. 

A follow-up that separates the package/bundle in a way that allows to properly treeshake the graphql imports (or provide them from a different import specifier), so they aren't required dependencies would be ideal.

Totally get it, if the goal is to try a fail forward approach instead of trying to smooth out the current usage, until a more holistic fix can be merged - but figured this might avoid some annoyance in the meantime (both on consumers and avoid issues like #1371 and the handful of duplicates that have popped up over the last week)

- Fixes #1371