### PR TITLE
feat: add explicit `exports` map in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
-    ".": "./lib/index.js",
+    ".": {
+      "default": "./lib/index.js"
+    },
     "./native": "./lib/native/index.js",
     "./node": {
-      "import": "./lib/node/index.mjs",
-      "require": "./lib/node/index.js"
+      "require": "./lib/node/index.js",
+      "default": "./lib/node/index.mjs"
     }
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "description": "Seamless REST/GraphQL API mocking library for browser and Node.js.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "exports": {
+    ".": "./lib/index.js",
+    "./iife": "./lib/iife/index.js",
+    "./native": "./lib/native/index.js",
+    "./node": {
+      "import": "./lib/node/index.mjs",
+      "require": "./lib/node/index.js"
+    }
+  },
   "bin": {
     "msw": "cli/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     ".": {
       "default": "./lib/index.js"
     },
-    "./native": "./lib/native/index.js",
+    "./native": {
+      "default": "./lib/native/index.js"
+    },
     "./node": {
       "require": "./lib/node/index.js",
       "default": "./lib/node/index.mjs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": "./lib/index.js",
-    "./iife": "./lib/iife/index.js",
     "./native": "./lib/native/index.js",
     "./node": {
       "import": "./lib/node/index.mjs",


### PR DESCRIPTION
This PR adds the missing `exports` field to the `package.json`.
This makes `msw` compatible with `TypeScript` projects using the `moduleResolution` set to `node16`.

https://www.typescriptlang.org/docs/handbook/esm-node.html