### PR TITLE
feat: makes the library esm-compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "node-fetch": "^2.6.7",
     "outvariant": "^1.3.0",
     "path-to-regexp": "^6.2.0",
-    "statuses": "^2.0.0",
     "strict-event-emitter": "^0.2.0",
     "type-fest": "^2.19.0",
     "yargs": "^17.3.1"
@@ -139,6 +138,7 @@
     "regenerator-runtime": "^0.13.9",
     "rimraf": "^3.0.2",
     "simple-git-hooks": "^2.8.0",
+    "statuses": "^2.0.0",
     "ts-jest": "26",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.1.0",

--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -3,7 +3,12 @@ import { Headers } from 'headers-polyfill'
 import { MockedRequest } from '../utils/request/MockedRequest'
 
 const useFetch: (input: RequestInfo, init?: RequestInit) => Promise<Response> =
-  isNodeProcess() ? require('node-fetch') : window.fetch
+  isNodeProcess()
+    ? (input, init) =>
+        import('node-fetch').then(({ default: nodeFetch }) =>
+          (nodeFetch as unknown as typeof window.fetch)(input, init),
+        )
+    : window.fetch
 
 export const augmentRequestInit = (requestInit: RequestInit): RequestInit => {
   const headers = new Headers(requestInit.headers)

--- a/src/context/status.ts
+++ b/src/context/status.ts
@@ -1,4 +1,4 @@
-import statuses from 'statuses/codes.json' assert { type: 'json' }
+import statuses from 'statuses/codes.json'
 import { ResponseTransformer } from '../response'
 
 /**

--- a/src/context/status.ts
+++ b/src/context/status.ts
@@ -1,4 +1,4 @@
-import statuses from 'statuses/codes.json'
+import statuses from 'statuses/codes.json' assert { type: 'json' }
 import { ResponseTransformer } from '../response'
 
 /**

--- a/src/node/createSetupServer.ts
+++ b/src/node/createSetupServer.ts
@@ -1,4 +1,5 @@
-import { bold } from 'chalk'
+import chalk from 'chalk'
+const { bold } = chalk
 import { isNodeProcess } from 'is-node-process'
 import { StrictEventEmitter } from 'strict-event-emitter'
 import {

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,5 +1,5 @@
-import { ClientRequestInterceptor } from '@mswjs/interceptors/lib/interceptors/ClientRequest'
-import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/lib/interceptors/XMLHttpRequest'
+import { ClientRequestInterceptor } from '@mswjs/interceptors/lib/interceptors/ClientRequest/index.js'
+import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/lib/interceptors/XMLHttpRequest/index.js'
 import { createSetupServer } from './createSetupServer'
 
 /**

--- a/src/utils/matching/matchRequestUrl.ts
+++ b/src/utils/matching/matchRequestUrl.ts
@@ -1,5 +1,5 @@
 import { match } from 'path-to-regexp'
-import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl'
+import { getCleanUrl } from '@mswjs/interceptors/lib/utils/getCleanUrl.js'
 import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp


### PR DESCRIPTION
fixes #1267

I have investigated #1267 a bit. There are a few road blocks to make `msw/node` work in a `.mjs` file:
 - [x] reference `lib/index.js` instead of `'lib'` in a few files (easy to achive)
 - [x] ~`tsup` does not support import assertions (needed here https://github.com/mswjs/msw/blob/main/src/context/status.ts#L1) https://github.com/egoist/tsup/issues/714~
    workaround: https://github.com/mswjs/msw/pull/1399#discussion_r968360168
 - [x] ~dynamic import of `node-fetch` (https://github.com/mswjs/msw/blob/main/src/context/fetch.ts#L6) is not supported in esm context. https://github.com/evanw/esbuild/issues/1921~
    workaround: https://github.com/mswjs/msw/pull/1399#issuecomment-1243681143