### PR TITLE
fix: remove duplicate response logging in the browser console

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "outvariant": "^1.3.0",
     "path-to-regexp": "^6.2.0",
     "statuses": "^2.0.0",
-    "strict-event-emitter": "^0.2.0",
+    "strict-event-emitter": "^0.2.5",
     "type-fest": "^2.19.0",
     "yargs": "^17.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "outvariant": "^1.3.0",
     "path-to-regexp": "^6.2.0",
     "statuses": "^2.0.0",
-    "strict-event-emitter": "^0.2.5",
+    "strict-event-emitter": "^0.2.6",
     "type-fest": "^2.19.0",
     "yargs": "^17.3.1"
   },

--- a/test/msw-api/setup-worker/response-logging.test.ts
+++ b/test/msw-api/setup-worker/response-logging.test.ts
@@ -1,0 +1,46 @@
+import { pageWith } from 'page-with'
+import { waitFor } from '../../support/waitFor'
+
+function createResponseLogRegexp(username: string): RegExp {
+  return new RegExp(
+    `^\\[MSW\\] \\d{2}:\\d{2}:\\d{2} GET https://api\\.github\\.com/users/${username} 200 OK$`,
+  )
+}
+
+test('prints the response info to the console', async () => {
+  const runtime = await pageWith({
+    example: require.resolve('../../rest-api/basic.mocks.ts'),
+  })
+
+  const waitForResponseLog = async (exp: RegExp) => {
+    await waitFor(() => {
+      expect(runtime.consoleSpy.get('startGroupCollapsed')).toEqual(
+        expect.arrayContaining([expect.stringMatching(exp)]),
+      )
+    })
+  }
+
+  const getResponseLogs = (exp: RegExp) => {
+    return runtime.consoleSpy.get('startGroupCollapsed').filter((log) => {
+      return exp.test(log)
+    })
+  }
+
+  const firstResponseLogRegexp = createResponseLogRegexp('octocat')
+  await runtime.request('https://api.github.com/users/octocat')
+  await waitForResponseLog(firstResponseLogRegexp)
+
+  // Must print the response summary to the console.
+  expect(getResponseLogs(firstResponseLogRegexp)).toHaveLength(1)
+
+  const secondResopnseLogRegexp = createResponseLogRegexp('john.doe')
+  await runtime.request('https://api.github.com/users/john.doe')
+  await waitForResponseLog(secondResopnseLogRegexp)
+
+  /**
+   * Must not duplicate response logs for the current and previous requests.
+   * @see https://github.com/mswjs/msw/issues/1411
+   */
+  expect(getResponseLogs(secondResopnseLogRegexp)).toHaveLength(1)
+  expect(getResponseLogs(firstResponseLogRegexp)).toHaveLength(1)
+})

--- a/test/rest-api/body.mocks.ts
+++ b/test/rest-api/body.mocks.ts
@@ -16,27 +16,29 @@ const handleRequestBody: ResponseResolver<MockedRequest, RestContext> = (
   return res(ctx.json({ body }))
 }
 
-const handleMultipartRequestBody: ResponseResolver<MockedRequest, RestContext> =
-  async (req, res, ctx) => {
-    const { body } = req
+const handleMultipartRequestBody: ResponseResolver<
+  MockedRequest,
+  RestContext
+> = async (req, res, ctx) => {
+  const { body } = req
 
-    if (typeof body !== 'object') {
-      throw new Error(
-        'Expected multipart request body to be parsed but got string',
-      )
-    }
-
-    const resBody: Record<string, string> = {}
-    for (const [name, value] of Object.entries(body)) {
-      if (value instanceof File) {
-        resBody[name] = await value.text()
-      } else {
-        resBody[name] = value as string
-      }
-    }
-
-    return res(ctx.json({ body: resBody }))
+  if (typeof body !== 'object') {
+    throw new Error(
+      'Expected multipart request body to be parsed but got string',
+    )
   }
+
+  const resBody: Record<string, string> = {}
+  for (const [name, value] of Object.entries(body)) {
+    if (value instanceof File) {
+      resBody[name] = await value.text()
+    } else {
+      resBody[name] = value as string
+    }
+  }
+
+  return res(ctx.json({ body: resBody }))
+}
 
 const worker = setupWorker(
   rest.get('/login', handleRequestBody),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9138,10 +9138,10 @@ strict-event-emitter@^0.2.4:
   dependencies:
     events "^3.3.0"
 
-strict-event-emitter@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.5.tgz#682894279b50c159f51ca91dec33a0ccb049b013"
-  integrity sha512-BmJ3GQ3APBr6bKOWBrdvLmazOYeIZWfemtr7a5D8wgzMoys6Kp6HvnGq8G3LCPFv6iWao7WO85KTWf2I8A/1RA==
+strict-event-emitter@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.6.tgz#7bb2022bdabcbf0058cec7118a7bbbfd64367366"
+  integrity sha512-qDZOqEBoNtKLPb/qAutkXUt7hs3zXgYA1xX4pVa+gZHCZZVLr2r81AzHsK5YrQQhRNphMtkOUyAyOr9e1IxJTw==
   dependencies:
     events "^3.3.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9131,17 +9131,17 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
-strict-event-emitter@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz#78e2f75dc6ea502e5d8a877661065a1e2deedecd"
-  integrity sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==
-  dependencies:
-    events "^3.3.0"
-
 strict-event-emitter@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.4.tgz#365714f0c95f059db31064ca745d5b33e5b30f6e"
   integrity sha512-xIqTLS5azUH1djSUsLH9DbP6UnM/nI18vu8d43JigCQEoVsnY+mrlE+qv6kYqs6/1OkMnMIiL6ffedQSZStuoQ==
+  dependencies:
+    events "^3.3.0"
+
+strict-event-emitter@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.5.tgz#682894279b50c159f51ca91dec33a0ccb049b013"
+  integrity sha512-BmJ3GQ3APBr6bKOWBrdvLmazOYeIZWfemtr7a5D8wgzMoys6Kp6HvnGq8G3LCPFv6iWao7WO85KTWf2I8A/1RA==
   dependencies:
     events "^3.3.0"
 


### PR DESCRIPTION
Update `strict-event-emitter` version that to resolve log duplicates.

- Fixes #1411
- https://github.com/open-draft/strict-event-emitter/pull/2