### PR TITLE
chore: fixes tests on Windows using Unix-style path

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
+    'body-max-line-length': [0, 'always', Infinity],
     'footer-max-line-length': [1, 'always'],
   },
 }

--- a/src/utils/internal/getCallFrame.ts
+++ b/src/utils/internal/getCallFrame.ts
@@ -1,5 +1,5 @@
 // Ignore the source files traces for local testing.
-const SOURCE_FRAME = /\/msw\/src\/(.+)/
+const SOURCE_FRAME = /[\/\\]msw[\/\\]src[\/\\](.+)/
 
 const BUILD_FRAME =
   /(node_modules)?[\/\\]lib[\/\\](umd|esm|iief|cjs)[\/\\]|^[^\/\\]*$/

--- a/test/msw-api/cli/init.test.ts
+++ b/test/msw-api/cli/init.test.ts
@@ -161,7 +161,7 @@ test('does not produce eslint errors or warnings', async () => {
   expect(init.stderr).toEqual('')
 
   const eslint = await promisifyChildProcess(
-    exec(`node_modules/.bin/eslint ${fsMock.resolve()}`),
+    exec(path.resolve(`node_modules/.bin/eslint ${fsMock.resolve()}`)),
   )
   expect(eslint.stdout).toEqual('')
   expect(eslint.stderr).toEqual('')


### PR DESCRIPTION
## Description

I noticed that tests weren't passing on Windows and went ahead and fixed them. All unit and integration tests are now passing on Windows, too.

**Note**: This also contains a controversial change to the commitlint.config.js which **removes** the line length limitations from commit bodies. I've made that change because I wasn't able to commit. Of course this isn't my repository so I'm happily removing this change if it's unwanted. However, I'd like to take this opportunity to argue against such rules: Nowadays, there just isn't a good reason for hard-wrapping code or natural language content (which I believe is the main reason these rules exist). Editors have capabilities to soft-wrap as a user likes per file type/language. Additionally, I've come to really like writing up a commit's changes in ... the commit itself. This saves from needing to do so in two places: the commit and the inadvertent pull/merge request.

In any case, this is not for me to decide, so please let me know whether I should be reverting this.

## Changes

Fixes a test passing a Unix-style path to child_process.exec which failed on Windows by wrapping it in `path.resolve`.

Fixes a test relying on some internal logic which only took Unix-style paths into account.

Changes the commitlint configuration to allow commit bodies of any length.