### PR TITLE
fix: prevent corruption of binary request bodies (#929)

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -247,7 +247,7 @@ async function getResponse(event, client, requestId) {
       redirect: request.redirect,
       referrer: request.referrer,
       referrerPolicy: request.referrerPolicy,
-      body: await request.text(),
+      body: await request.arrayBuffer(),
       bodyUsed: request.bodyUsed,
       keepalive: request.keepalive,
     },

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -43,9 +43,9 @@ export interface ServiceWorkerIncomingRequest extends RequestWithoutMethods {
   id: string
 
   /**
-   * Text response body.
+   * Request body.
    */
-  body?: string
+  body?: ArrayBuffer
 }
 
 export type ServiceWorkerIncomingResponse = Pick<

--- a/src/utils/request/parseWorkerRequest.ts
+++ b/src/utils/request/parseWorkerRequest.ts
@@ -1,4 +1,3 @@
-import { encodeBuffer } from '@mswjs/interceptors'
 import { Headers } from 'headers-polyfill'
 import { ServiceWorkerIncomingRequest } from '../../setupWorker/glossary'
 import { MockedRequest } from './MockedRequest'
@@ -15,7 +14,7 @@ export function parseWorkerRequest(
 
   return new MockedRequest(url, {
     ...rawRequest,
-    body: encodeBuffer(rawRequest.body || ''),
+    body: rawRequest.body || new ArrayBuffer(0),
     headers,
   })
 }

--- a/src/utils/request/pruneGetRequestBody.ts
+++ b/src/utils/request/pruneGetRequestBody.ts
@@ -12,7 +12,7 @@ export function pruneGetRequestBody(
   if (
     request.method &&
     isStringEqual(request.method, 'GET') &&
-    request.body === ''
+    request.body?.byteLength === 0
   ) {
     return undefined
   }

--- a/test/rest-api/binary.mocks.ts
+++ b/test/rest-api/binary.mocks.ts
@@ -1,0 +1,14 @@
+import { setupWorker, rest } from 'msw'
+
+const worker = setupWorker(
+  rest.post('https://test.mswjs.io/api/binary', async (req, res, ctx) => {
+    const body = await req.arrayBuffer()
+    const hexNumbers = Array.from(new Uint8Array(body))
+      .map((byte) => byte.toString(16))
+      .join(' ')
+
+    return res(ctx.json({ result: hexNumbers }))
+  }),
+)
+
+worker.start()

--- a/test/rest-api/binary.test.ts
+++ b/test/rest-api/binary.test.ts
@@ -1,0 +1,33 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+
+function createRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'binary.mocks.ts'),
+  })
+}
+
+test('transfers binary data without corruption', async () => {
+  const runtime = await createRuntime()
+
+  const payload = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]
+  const expectedResult = payload.map((byte) => byte.toString(16)).join(' ')
+
+  runtime.page.evaluate((payload) => {
+    return fetch('https://test.mswjs.io/api/binary', {
+      method: 'POST',
+      body: new Uint8Array(payload).buffer,
+    })
+  }, payload)
+
+  const res = await runtime.page.waitForResponse(
+    'https://test.mswjs.io/api/binary',
+  )
+  const status = res.status()
+  const headers = await res.allHeaders()
+  const body = await res.json()
+
+  expect(status).toBe(200)
+  expect(headers).toHaveProperty('x-powered-by', 'msw')
+  expect(body).toEqual({ result: expectedResult })
+})


### PR DESCRIPTION
Use `request.arrayBuffer` in worker-message rather than `request.text()`. This prevents re-encoding and the resulting corruption