### PR TITLE
docs: fix jsdoc default value for worker url

### DIFF
--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -167,7 +167,7 @@ export interface StartOptions extends SharedOptions {
   serviceWorker?: {
     /**
      * Custom url to the worker script.
-     * @default "./mockServiceWorker.js"
+     * @default "/mockServiceWorker.js"
      */
     url?: string
     options?: RegistrationOptions


### PR DESCRIPTION
Fixes the JSDoc default value for the service worker URL on the `StartOptions` interface.

Actual default value is `'/mockServiceWorker.js'` ([check here](https://github.com/mswjs/msw/blob/main/src/setupWorker/start/utils/prepareStartHandler.ts#L12)) but on JSDoc it was `'./mockServiceWorker.js'`.