### PR TITLE
feat: do not interfere with shared workers

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -174,7 +174,7 @@ async function handleRequest(event, requestId) {
 async function resolveMainClient(event) {
   const client = await self.clients.get(event.clientId)
 
-  if (client.frameType === 'top-level') {
+  if (client?.frameType === 'top-level') {
     return client
   }
 

--- a/test/msw-api/setup-worker/scenarios/shared-worker/shared-worker.mocks.ts
+++ b/test/msw-api/setup-worker/scenarios/shared-worker/shared-worker.mocks.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from 'msw'
+
+const worker = setupWorker()
+
+worker.start()

--- a/test/msw-api/setup-worker/scenarios/shared-worker/shared-worker.test.ts
+++ b/test/msw-api/setup-worker/scenarios/shared-worker/shared-worker.test.ts
@@ -14,16 +14,20 @@ test('supports shared workers', async () => {
 
   await page.evaluate(() => {
     const worker = new SharedWorker('/worker.js')
+
     worker.addEventListener('error', () =>
       console.error('There is an error with worker'),
     )
-    worker.port.onmessage = (e) => {
-      console.log(e.data)
+
+    worker.port.onmessage = (event) => {
+      console.log(event.data)
     }
-    worker.port.postMessage('Message posted to worker')
+
+    worker.port.postMessage('john')
   })
+
   await waitFor(() => {
     expect(consoleSpy.get('error')).toBeUndefined()
-    expect(consoleSpy.get('log')).toContain('Message received from worker')
+    expect(consoleSpy.get('log')).toContain('hello, john')
   })
 })

--- a/test/msw-api/setup-worker/scenarios/shared-worker/shared-worker.test.ts
+++ b/test/msw-api/setup-worker/scenarios/shared-worker/shared-worker.test.ts
@@ -1,0 +1,29 @@
+import * as path from 'path'
+import { pageWith } from 'page-with'
+import { waitFor } from '../../../../support/waitFor'
+
+function createRuntime() {
+  return pageWith({
+    example: path.resolve(__dirname, 'shared-worker.mocks.ts'),
+    contentBase: path.resolve(__dirname),
+  })
+}
+
+test('supports shared workers', async () => {
+  const { page, consoleSpy } = await createRuntime()
+
+  await page.evaluate(() => {
+    const worker = new SharedWorker('/worker.js')
+    worker.addEventListener('error', () =>
+      console.error('There is an error with worker'),
+    )
+    worker.port.onmessage = (e) => {
+      console.log(e.data)
+    }
+    worker.port.postMessage('Message posted to worker')
+  })
+  await waitFor(() => {
+    expect(consoleSpy.get('error')).toBeUndefined()
+    expect(consoleSpy.get('log')).toContain('Message received from worker')
+  })
+})

--- a/test/msw-api/setup-worker/scenarios/shared-worker/shared-worker.test.ts
+++ b/test/msw-api/setup-worker/scenarios/shared-worker/shared-worker.test.ts
@@ -9,7 +9,7 @@ function createRuntime() {
   })
 }
 
-test('supports shared workers', async () => {
+test('does not interfere with a shared worker', async () => {
   const { page, consoleSpy } = await createRuntime()
 
   await page.evaluate(() => {

--- a/test/msw-api/setup-worker/scenarios/shared-worker/worker.js
+++ b/test/msw-api/setup-worker/scenarios/shared-worker/worker.js
@@ -1,6 +1,7 @@
 onconnect = (event) => {
   const port = event.ports[0]
 
-  port.onmessage = (e) =>
-    port.postMessage(e.data.replace('posted to', 'received from'))
+  port.onmessage = (event) => {
+    port.postMessage(`hello, ${event.data}`)
+  }
 }

--- a/test/msw-api/setup-worker/scenarios/shared-worker/worker.js
+++ b/test/msw-api/setup-worker/scenarios/shared-worker/worker.js
@@ -1,0 +1,6 @@
+onconnect = (event) => {
+  const port = event.ports[0]
+
+  port.onmessage = (e) =>
+    port.postMessage(e.data.replace('posted to', 'received from'))
+}


### PR DESCRIPTION
- Closes #1350
- Fixes #1354 

Here I am adding support for shared workers.

The issue is that in case of shared workers the request event doesn't contain `clientId`.
Due to that the `client` is `undefined` which breaks the code here

```tsx
if (client.frameType === 'top-level') {
    return client
  }
```