### PR TITLE
fix: resolve absolute worker url against the current path

### DIFF
--- a/src/utils/url/getAbsoluteWorkerUrl.test.ts
+++ b/src/utils/url/getAbsoluteWorkerUrl.test.ts
@@ -3,12 +3,29 @@
  */
 import { getAbsoluteWorkerUrl } from './getAbsoluteWorkerUrl'
 
-describe('getAbsoluteWorkerUrl', () => {
-  describe('given a relative worker URL', () => {
-    it('should return an absolute URL against the current location', () => {
-      expect(getAbsoluteWorkerUrl('./mockServiceWorker.js')).toEqual(
-        'http://localhost/mockServiceWorker.js',
-      )
-    })
+const rawLocation = window.location
+
+afterAll(() => {
+  Object.defineProperty(window, 'location', {
+    value: rawLocation,
   })
+})
+
+it('returns absolute worker url relatively to the root', () => {
+  expect(getAbsoluteWorkerUrl('./worker.js')).toBe('http://localhost/worker.js')
+})
+
+it('returns an absolute worker url relatively to the current path', () => {
+  Object.defineProperty(window, 'location', {
+    value: {
+      href: 'http://localhost/path/to/page',
+    },
+  })
+
+  expect(getAbsoluteWorkerUrl('./worker.js')).toBe(
+    'http://localhost/path/to/worker.js',
+  )
+
+  // Leading slash must still resolve to the root.
+  expect(getAbsoluteWorkerUrl('/worker.js')).toBe('http://localhost/worker.js')
 })

--- a/src/utils/url/getAbsoluteWorkerUrl.ts
+++ b/src/utils/url/getAbsoluteWorkerUrl.ts
@@ -2,6 +2,6 @@
  * Returns an absolute Service Worker URL based on the given
  * relative URL (known during the registration).
  */
-export function getAbsoluteWorkerUrl(relativeUrl: string): string {
-  return new URL(relativeUrl, location.origin).href
+export function getAbsoluteWorkerUrl(workerUrl: string): string {
+  return new URL(workerUrl, location.href).href
 }


### PR DESCRIPTION
- Originally fixed in #1394

## Change

Previously, the `getAbsoluteWorkerUrl` function didn't respect the current path when providing a worker script URL starting with a dot. Now it does. 