### PR TITLE
fix(SetupApi): validate given request handlers

### DIFF
--- a/src/SetupApi.ts
+++ b/src/SetupApi.ts
@@ -22,7 +22,7 @@ export abstract class SetupApi<EventsMap extends EventMapType> {
 
   public readonly events: LifeCycleEventEmitter<EventsMap>
 
-  constructor(initialHandlers: Array<RequestHandler>) {
+  constructor(...initialHandlers: Array<RequestHandler>) {
     this.validateHandlers(initialHandlers)
 
     this.initialHandlers = toReadonlyArray(initialHandlers)

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -12,5 +12,5 @@ export function setupServer(
 ): SetupServerApi {
   // Provision request interception via patching the `XMLHttpRequest` class only
   // in React Native. There is no `http`/`https` modules in that environment.
-  return new SetupServerApi([XMLHttpRequestInterceptor], handlers)
+  return new SetupServerApi([XMLHttpRequestInterceptor], ...handlers)
 }

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -39,9 +39,9 @@ export class SetupServerApi extends SetupApi<ServerLifecycleEventsMap> {
     interceptors: Array<{
       new (): Interceptor<HttpRequestEventMap>
     }>,
-    handlers: Array<RequestHandler>,
+    ...handlers: Array<RequestHandler>
   ) {
-    super(handlers)
+    super(...handlers)
 
     this.interceptor = new BatchInterceptor({
       name: 'setup-server',

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -13,6 +13,6 @@ export const setupServer = (
 ): SetupServerApi => {
   return new SetupServerApi(
     [ClientRequestInterceptor, XMLHttpRequestInterceptor],
-    handlers,
+    ...handlers,
   )
 }

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -32,8 +32,8 @@ export class SetupWorkerApi extends SetupApi<WorkerLifecycleEventsMap> {
   private stopHandler: StopHandler = null as any
   private listeners: Array<Listener>
 
-  constructor(handlers: Array<RequestHandler>) {
-    super(handlers)
+  constructor(...handlers: Array<RequestHandler>) {
+    super(...handlers)
 
     invariant(
       !isNodeProcess(),
@@ -224,5 +224,5 @@ export class SetupWorkerApi extends SetupApi<WorkerLifecycleEventsMap> {
 export function setupWorker(
   ...handlers: Array<RequestHandler>
 ): SetupWorkerApi {
-  return new SetupWorkerApi(handlers)
+  return new SetupWorkerApi(...handlers)
 }


### PR DESCRIPTION
Somehow, this issue made it to `main` without failing tests. Caching can be so cruel sometimes. 

- Follow-up to #1445 