### PR TITLE
fix(setupWorker): resolve the TS4094 error

### DIFF
--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -19,6 +19,7 @@ import { createFallbackStop } from './stop/createFallbackStop'
 import { devUtils } from '../utils/internal/devUtils'
 import { SetupApi } from '../SetupApi'
 import { mergeRight } from '../utils/internal/mergeRight'
+import { SetupWorkerApi as SetupWorker } from './glossary'
 
 interface Listener {
   target: EventTarget
@@ -26,7 +27,10 @@ interface Listener {
   callback: EventListener
 }
 
-export class SetupWorkerApi extends SetupApi<WorkerLifecycleEventsMap> {
+class SetupWorkerApi
+  extends SetupApi<WorkerLifecycleEventsMap>
+  implements SetupWorker
+{
   private context: SetupWorkerInternalContext
   private startHandler: StartHandler = null as any
   private stopHandler: StopHandler = null as any
@@ -221,8 +225,6 @@ export class SetupWorkerApi extends SetupApi<WorkerLifecycleEventsMap> {
  * @param {RequestHandler[]} handlers List of request handlers.
  * @see {@link https://mswjs.io/docs/api/setup-worker `setupWorker`}
  */
-export function setupWorker(
-  ...handlers: Array<RequestHandler>
-): SetupWorkerApi {
+export function setupWorker(...handlers: Array<RequestHandler>): SetupWorker {
   return new SetupWorkerApi(...handlers)
 }


### PR DESCRIPTION
Type the return of `setupWorker` with the interface instead of the class.

I also don't export the class `SetupWorkerApi` anymore because it was not used in other files in the project, and not exposd in the `index.ts` (only the interface is exposed)

I tested in local that it fixes https://github.com/mswjs/msw/issues/1454