### PR TITLE
feat: rename "SetupWorkerApi"/"SetupServerApi" types to "SetupWorker"/"SetupServer"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,8 @@ export { cleanUrl } from './utils/url/cleanUrl'
 /**
  * Type definitions.
  */
-export type { SetupWorkerApi, StartOptions } from './setupWorker/glossary'
+export type { SetupWorker, StartOptions } from './setupWorker/glossary'
+export { SetupWorkerApi } from './setupWorker/setupWorker'
 export type { SharedOptions } from './sharedOptions'
 
 export * from './utils/request/MockedRequest'

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -16,6 +16,7 @@ import { mergeRight } from '../utils/internal/mergeRight'
 import { MockedRequest } from '../utils/request/MockedRequest'
 import { handleRequest } from '../utils/handleRequest'
 import { devUtils } from '../utils/internal/devUtils'
+import { SetupServer } from './glossary'
 
 /**
  * @see https://github.com/mswjs/msw/pull/1399
@@ -28,7 +29,10 @@ const DEFAULT_LISTEN_OPTIONS: RequiredDeep<SharedOptions> = {
   onUnhandledRequest: 'warn',
 }
 
-export class SetupServerApi extends SetupApi<ServerLifecycleEventsMap> {
+export class SetupServerApi
+  extends SetupApi<ServerLifecycleEventsMap>
+  implements SetupServer
+{
   protected readonly interceptor: BatchInterceptor<
     Array<Interceptor<HttpRequestEventMap>>,
     HttpRequestEventMap

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -14,7 +14,7 @@ import { MockedRequest } from '../utils/request/MockedRequest'
 
 export type ServerLifecycleEventsMap = LifeCycleEventsMap<IsomorphicResponse>
 
-export interface SetupServerApi {
+export interface SetupServer {
   /**
    * Starts requests interception based on the previously provided request handlers.
    * @see {@link https://mswjs.io/docs/api/setup-server/listen `server.listen()`}

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,3 +1,4 @@
 export { ServerLifecycleEventsMap } from './SetupServerApi'
 export { setupServer } from './setupServer'
-export type { SetupServerApi } from './glossary'
+export type { SetupServer } from './glossary'
+export { SetupServerApi } from './SetupServerApi'

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -209,7 +209,7 @@ export type StartHandler = (
 ) => StartReturnType
 export type StopHandler = () => void
 
-export interface SetupWorkerApi {
+export interface SetupWorker {
   /**
    * Registers and activates the mock Service Worker.
    * @see {@link https://mswjs.io/docs/api/setup-worker/start `worker.start()`}

--- a/src/setupWorker/setupWorker.ts
+++ b/src/setupWorker/setupWorker.ts
@@ -19,7 +19,7 @@ import { createFallbackStop } from './stop/createFallbackStop'
 import { devUtils } from '../utils/internal/devUtils'
 import { SetupApi } from '../SetupApi'
 import { mergeRight } from '../utils/internal/mergeRight'
-import { SetupWorkerApi as SetupWorker } from './glossary'
+import { SetupWorker } from './glossary'
 
 interface Listener {
   target: EventTarget
@@ -27,7 +27,7 @@ interface Listener {
   callback: EventListener
 }
 
-class SetupWorkerApi
+export class SetupWorkerApi
   extends SetupApi<WorkerLifecycleEventsMap>
   implements SetupWorker
 {
@@ -225,6 +225,8 @@ class SetupWorkerApi
  * @param {RequestHandler[]} handlers List of request handlers.
  * @see {@link https://mswjs.io/docs/api/setup-worker `setupWorker`}
  */
-export function setupWorker(...handlers: Array<RequestHandler>): SetupWorker {
+export function setupWorker(
+  ...handlers: Array<RequestHandler>
+): SetupWorkerApi {
   return new SetupWorkerApi(...handlers)
 }

--- a/src/setupWorker/start/utils/prepareStartHandler.ts
+++ b/src/setupWorker/start/utils/prepareStartHandler.ts
@@ -1,7 +1,7 @@
 import { RequiredDeep } from '../../../typeUtils'
 import { mergeRight } from '../../../utils/internal/mergeRight'
 import {
-  SetupWorkerApi,
+  SetupWorker,
   SetupWorkerInternalContext,
   StartHandler,
   StartOptions,
@@ -36,7 +36,7 @@ export function resolveStartOptions(
 export function prepareStartHandler(
   handler: StartHandler,
   context: SetupWorkerInternalContext,
-): SetupWorkerApi['start'] {
+): SetupWorker['start'] {
   return (initialOptions) => {
     context.startOptions = resolveStartOptions(initialOptions)
     return handler(context.startOptions, initialOptions || {})


### PR DESCRIPTION
Follow-up to the [first PR](https://github.com/mswjs/msw/pull/1477#discussion_r1032575785), with breaking changes

Completes the fix to https://github.com/mswjs/msw/issues/1454