### PR TITLE
fix(HttpResponse): accept interfaces as json response-data type

### DIFF
--- a/src/HttpResponse.ts
+++ b/src/HttpResponse.ts
@@ -51,14 +51,10 @@ export const HttpResponse = {
    * HttpResponse.json({ firstName: 'John' })
    * HttpResponse.json({ error: 'Not Authorized' }, { status: 401 })
    */
-  json<
-    BodyType extends
-      | Record<string, unknown>
-      | Array<unknown>
-      | boolean
-      | number
-      | string,
-  >(body?: BodyType | null, init?: HttpResponseInit): StrictResponse<BodyType> {
+  json<BodyType extends DefaultBodyType>(
+    body?: BodyType | null,
+    init?: HttpResponseInit,
+  ): StrictResponse<BodyType> {
     const responseInit = decorateResponseInit(init)
     responseInit.headers.set('Content-Type', 'application/json')
     return createResponse(JSON.stringify(body), responseInit)

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -80,6 +80,22 @@ rest.get<never, never, { id: number }>('/user', () => {
   return HttpResponse.json({ id: 1 })
 })
 
+// Supports explicit response data declared via type.
+type ResponseBodyType = { id: number }
+rest.get<never, never, ResponseBodyType>('/user', () => {
+  const data: ResponseBodyType = { id: 1 }
+  return HttpResponse.json(data)
+})
+
+// Supports explicit response data declared via interface.
+interface ResponseBodyInterface {
+  id: number
+}
+rest.get<never, never, ResponseBodyInterface>('/user', () => {
+  const data: ResponseBodyInterface = { id: 1 }
+  return HttpResponse.json(data)
+})
+
 rest.get<never, never, { id: number }>(
   '/user',
   // @ts-expect-error String not assignable to number


### PR DESCRIPTION
This PR introduces a fix for an issue discussed with the upcoming standard-api. The relevant discussion can be found here: https://github.com/mswjs/msw/discussions/1464#discussioncomment-4242424
TLDR: Objects that are typed with an interface cannot be assigned to `HttpResponse.json`.

This PR changes the generic of `HttpResponse.json` to extend `DefaultBodyType` instead of the similar yet slightly different union. I think it makes more sense (and fixes the issue), because the response generic of resolver functions and generic of `StrictResponse` also extend `DefaultBodyType`.