### PR TITLE
docs(migrating): fix example for response composition

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -503,25 +503,27 @@ It is still possible to create custom handlers and resolvers, just make sure to 
 
 As this release removes the concept of response composition via `res()`, you can no longer compose context utilities or abstract their partial composed state to a helper function.
 
-Instead, you can abstract a common response logic into a plain function that always returns a `Response` instance.
+Instead, you can abstract a common response logic into a plain function that creates a new `Response` or  modifies a provided instance.
 
 ```js
 // utils.js
-import { Response } from 'msw'
+import { HttpResponse } from 'msw'
 
-export function augmentResponse<R extends Response>(response: R): R {
-  response.headers.set('X-Response-Source', 'mocks')
+export function augmentResponse(json) {
+  const response = HttpResponse.json(json, {
+    // Come up with some reusable defaults here. 
+  })
   return response
 }
 ```
 
 ```js
-import { rest, HttpResponse } from 'msw'
+import { rest } from 'msw'
 import { augmentResponse } from './utils'
 
 export const handlers = [
   rest.get('/user', () => {
-    return augmentResponse(HttpResponse.json({ id: 1 }))
+    return augmentResponse({ id: 1 })
   }),
 ]
 ```

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -503,14 +503,13 @@ It is still possible to create custom handlers and resolvers, just make sure to 
 
 As this release removes the concept of response composition via `res()`, you can no longer compose context utilities or abstract their partial composed state to a helper function.
 
-Instead, you can abstract a common response logic into a plain function and always returns a `Response` instance.
+Instead, you can abstract a common response logic into a plain function that always returns a `Response` instance.
 
 ```js
 // utils.js
 import { Response } from 'msw'
 
-export function augmentResponse() {
-  const response = new Response()
+export function augmentResponse<R extends Response>(response: R): R {
   response.headers.set('X-Response-Source', 'mocks')
   return response
 }


### PR DESCRIPTION
I noticed that the example for augmenting responses won't work as shown in the migration guide. Therefore, I fixed it to work with either `Response` or `StrictResponse` and augmenting an existing response, which is passed into the function in the next code snippet.

Using this approach in a project, I noticed that `augmentResponse<R extends Response>()` does not use the imported `Response` since it is a value and not a type. Is the important even necessary for some environments in this case? Otherwise, we might as well remove it from the example.