### PR TITLE
feat: warn on unsupported versions of Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "msw": "cli/index.js"
   },
   "engines": {
-    "node": ">=14 <17"
+    "node": ">=14"
   },
   "scripts": {
     "start": "tsup --watch",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "msw": "cli/index.js"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14 <17"
   },
   "scripts": {
     "start": "tsup --watch",

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -49,6 +49,14 @@ export class SetupServerApi extends SetupApi<ServerLifecycleEventsMap> {
     })
     this.resolvedOptions = {} as RequiredDeep<SharedOptions>
 
+    const nodeMajorVersion = parseFloat(process.version.replace('v', ''))
+    if (nodeMajorVersion > 16) {
+      devUtils.warn(
+        'Detected the version of Node.js (%s) that is not officially supported. Some features may not work as expected.',
+        process.version,
+      )
+    }
+
     this.init()
   }
 


### PR DESCRIPTION
msw does not support Node.js v18. Silently. Took me some time to realised that. Lets help to save time to others. There should be some warning until https://github.com/mswjs/msw/issues/1388 is done. I believe this is it. Thanks.