### PR TITLE
docs(migrating): fix description for "ctx.errors" migration

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -389,7 +389,7 @@ export const handlers = [
 
 ### `ctx.errors`
 
-The `ctx.data` utility has been removed in favor of constructing a mocked JSON response with the "data" property in it.
+The `ctx.errors` utility has been removed in favor of constructing a mocked JSON response with the "errors" property in it.
 
 ```js
 import { HttpResponse } from 'msw'


### PR DESCRIPTION
While giving the migration guide another read, I noticed that the `ctx.errors` description is the same as `ctx.data` above.

This PR replaces data with errors in the description, so it makes sense for the section.