### PR TITLE
fix: use `globalThis.fetch` in `ctx.fetch` utility

### DIFF
--- a/src/context/fetch.ts
+++ b/src/context/fetch.ts
@@ -8,7 +8,7 @@ const useFetch: (input: RequestInfo, init?: RequestInit) => Promise<Response> =
         import('node-fetch').then(({ default: nodeFetch }) =>
           (nodeFetch as unknown as typeof window.fetch)(input, init),
         )
-    : window.fetch
+    : globalThis.fetch
 
 export const augmentRequestInit = (requestInit: RequestInit): RequestInit => {
   const headers = new Headers(requestInit.headers)


### PR DESCRIPTION
This PR updates the `fetch` reference from `window.fetch` to `globalThis.fetch` in the useFetch function for broader environment support (Edge Runtime).

