### PR TITLE
feat: throw and suggest a URL polyfill for React Native

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as context from './context'
+import { checkGlobals } from './utils/internal/checkGlobals'
 export { context }
 
 export { setupWorker } from './setupWorker/setupWorker'
@@ -65,3 +66,9 @@ export type {
 export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
 export type { DelayMode } from './context/delay'
 export { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'
+
+// Validate environmental globals before executing any code.
+// This ensures that the library gives user-friendly errors
+// when ran in the environments that require additional polyfills
+// from the end user.
+checkGlobals()

--- a/src/utils/internal/checkGlobals.ts
+++ b/src/utils/internal/checkGlobals.ts
@@ -1,0 +1,17 @@
+import { invariant } from 'outvariant'
+import { devUtils } from './devUtils'
+
+export function checkGlobals() {
+  /**
+   * MSW expects the "URL" constructor to be defined.
+   * It's not present in React Native so suggest a polyfill
+   * instead of failing silently.
+   * @see https://github.com/mswjs/msw/issues/1408
+   */
+  invariant(
+    typeof URL !== 'undefined',
+    devUtils.formatMessage(
+      `Global "URL" class is not defined. This likely means that you're running MSW in an environment that doesn't support all Node.js standard API (e.g. React Native). If that's the case, please use an appropriate polyfill for the "URL" class, like "react-native-url-polyfill".`,
+    ),
+  )
+}


### PR DESCRIPTION
- Closes #1408
- Related to #203

## Changes

- Checks if the `URL` global class is not defined and throws a user-friendly error message in that case, suggesting to use a URL polyfill.