### PR TITLE
fix: use EventTarget-based event emitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "node-fetch": "^2.6.7",
     "outvariant": "^1.3.0",
     "path-to-regexp": "^6.2.0",
-    "strict-event-emitter": "^0.2.6",
+    "strict-event-emitter": "^0.4.3",
     "type-fest": "^2.19.0",
     "yargs": "^17.3.1"
   },

--- a/src/SetupApi.ts
+++ b/src/SetupApi.ts
@@ -1,5 +1,5 @@
 import { invariant } from 'outvariant'
-import { EventMapType, StrictEventEmitter } from 'strict-event-emitter'
+import { EventMap, Emitter } from 'strict-event-emitter'
 import {
   DefaultBodyType,
   RequestHandler,
@@ -14,11 +14,11 @@ import { MockedRequest } from './utils/request/MockedRequest'
 /**
  * Generic class for the mock API setup.
  */
-export abstract class SetupApi<EventsMap extends EventMapType> {
+export abstract class SetupApi<EventsMap extends EventMap> {
   protected initialHandlers: ReadonlyArray<RequestHandler>
   protected currentHandlers: Array<RequestHandler>
-  protected readonly emitter: StrictEventEmitter<EventsMap>
-  protected readonly publicEmitter: StrictEventEmitter<EventsMap>
+  protected readonly emitter: Emitter<EventsMap>
+  protected readonly publicEmitter: Emitter<EventsMap>
 
   public readonly events: LifeCycleEventEmitter<EventsMap>
 
@@ -28,8 +28,8 @@ export abstract class SetupApi<EventsMap extends EventMapType> {
     this.initialHandlers = toReadonlyArray(initialHandlers)
     this.currentHandlers = [...initialHandlers]
 
-    this.emitter = new StrictEventEmitter<EventsMap>()
-    this.publicEmitter = new StrictEventEmitter<EventsMap>()
+    this.emitter = new Emitter<EventsMap>()
+    this.publicEmitter = new Emitter<EventsMap>()
     pipeEvents(this.emitter, this.publicEmitter)
 
     this.events = this.createLifeCycleEvents()
@@ -81,13 +81,13 @@ export abstract class SetupApi<EventsMap extends EventMapType> {
 
   private createLifeCycleEvents(): LifeCycleEventEmitter<EventsMap> {
     return {
-      on: (...args) => {
-        return this.publicEmitter.on(...args)
+      on: (...args: any[]) => {
+        return (this.publicEmitter.on as any)(...args)
       },
-      removeListener: (...args) => {
-        return this.publicEmitter.removeListener(...args)
+      removeListener: (...args: any[]) => {
+        return (this.publicEmitter.removeListener as any)(...args)
       },
-      removeAllListeners: (...args: any) => {
+      removeAllListeners: (...args: any[]) => {
         return this.publicEmitter.removeAllListeners(...args)
       },
     }

--- a/src/setupWorker/glossary.ts
+++ b/src/setupWorker/glossary.ts
@@ -1,5 +1,5 @@
 import { FlatHeadersObject } from 'headers-polyfill'
-import { StrictEventEmitter } from 'strict-event-emitter'
+import { Emitter } from 'strict-event-emitter'
 import {
   LifeCycleEventEmitter,
   LifeCycleEventsMap,
@@ -103,7 +103,7 @@ export interface SetupWorkerInternalContext {
   worker: ServiceWorker | null
   registration: ServiceWorkerRegistration | null
   requestHandlers: RequestHandler[]
-  emitter: StrictEventEmitter<WorkerLifecycleEventsMap>
+  emitter: Emitter<WorkerLifecycleEventsMap>
   keepAliveInterval?: number
   workerChannel: {
     /**

--- a/src/sharedOptions.ts
+++ b/src/sharedOptions.ts
@@ -1,4 +1,4 @@
-import { StrictEventEmitter } from 'strict-event-emitter'
+import { Emitter } from 'strict-event-emitter'
 import { MockedRequest } from './utils/request/MockedRequest'
 import { UnhandledRequestStrategy } from './utils/request/onUnhandledRequest'
 
@@ -15,18 +15,16 @@ export interface SharedOptions {
 }
 
 export interface LifeCycleEventsMap<ResponseType> {
-  'request:start': (request: MockedRequest) => void
-  'request:match': (request: MockedRequest) => void
-  'request:unhandled': (request: MockedRequest) => void
-  'request:end': (request: MockedRequest) => void
-  'response:mocked': (response: ResponseType, requestId: string) => void
-  'response:bypass': (response: ResponseType, requestId: string) => void
-  unhandledException: (error: Error, request: MockedRequest) => void
+  'request:start': [MockedRequest]
+  'request:match': [MockedRequest]
+  'request:unhandled': [MockedRequest]
+  'request:end': [MockedRequest]
+  'response:mocked': [response: ResponseType, requestId: string]
+  'response:bypass': [response: ResponseType, requestId: string]
+  unhandledException: [error: Error, request: MockedRequest]
+  [key: string]: Array<unknown>
 }
 
 export type LifeCycleEventEmitter<
   ResponseType extends Record<string | symbol, any>,
-> = Pick<
-  StrictEventEmitter<ResponseType>,
-  'on' | 'removeListener' | 'removeAllListeners'
->
+> = Pick<Emitter<ResponseType>, 'on' | 'removeListener' | 'removeAllListeners'>

--- a/src/utils/handleRequest.test.ts
+++ b/src/utils/handleRequest.test.ts
@@ -1,5 +1,5 @@
 import { Headers } from 'headers-polyfill'
-import { StrictEventEmitter } from 'strict-event-emitter'
+import { Emitter } from 'strict-event-emitter'
 import { ServerLifecycleEventsMap } from '../node/glossary'
 import { SharedOptions } from '../sharedOptions'
 import { RequestHandler } from '../handlers/RequestHandler'
@@ -18,7 +18,7 @@ const callbacks: Partial<Record<keyof HandleRequestOptions<any>, any>> = {
 }
 
 function setup() {
-  const emitter = new StrictEventEmitter<ServerLifecycleEventsMap>()
+  const emitter = new Emitter<ServerLifecycleEventsMap>()
   const listener = jest.fn()
 
   const createMockListener = (name: string) => {

--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -1,5 +1,5 @@
 import { until } from '@open-draft/until'
-import { StrictEventEmitter } from 'strict-event-emitter'
+import { Emitter } from 'strict-event-emitter'
 import { RequestHandler } from '../handlers/RequestHandler'
 import { ServerLifecycleEventsMap } from '../node/glossary'
 import { MockedResponse } from '../response'
@@ -45,7 +45,7 @@ export async function handleRequest<
   request: MockedRequest,
   handlers: RequestHandler[],
   options: RequiredDeep<SharedOptions>,
-  emitter: StrictEventEmitter<ServerLifecycleEventsMap>,
+  emitter: Emitter<ServerLifecycleEventsMap>,
   handleRequestOptions?: HandleRequestOptions<ResponseType>,
 ): Promise<ResponseType | undefined> {
   emitter.emit('request:start', request)

--- a/src/utils/internal/pipeEvents.ts
+++ b/src/utils/internal/pipeEvents.ts
@@ -1,11 +1,11 @@
-import { EventEmitter } from 'stream'
+import { Emitter, EventMap } from 'strict-event-emitter'
 
 /**
  * Pipes all emitted events from one emitter to another.
  */
-export function pipeEvents(
-  source: EventEmitter,
-  destination: EventEmitter,
+export function pipeEvents<Events extends EventMap>(
+  source: Emitter<Events>,
+  destination: Emitter<Events>,
 ): void {
   const rawEmit = source.emit
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9230,12 +9230,10 @@ strict-event-emitter@^0.2.4:
   dependencies:
     events "^3.3.0"
 
-strict-event-emitter@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.6.tgz#7bb2022bdabcbf0058cec7118a7bbbfd64367366"
-  integrity sha512-qDZOqEBoNtKLPb/qAutkXUt7hs3zXgYA1xX4pVa+gZHCZZVLr2r81AzHsK5YrQQhRNphMtkOUyAyOr9e1IxJTw==
-  dependencies:
-    events "^3.3.0"
+strict-event-emitter@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.3.tgz#45d0f75e1dc071eeb7cfbdff864fd2b9172bc257"
+  integrity sha512-uD0y7Wp3+ifPyfzIS+JrMvSnxFExHytmD5gTkndF1fi8Vrk2uiOY/2At73AwzLHz+RwrchegD8tHdowsfG7raQ==
 
 string-argv@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
- Closes #1519 

This PR intended to update `strict event emitter` to the latest version.