### PR TITLE
fix: add "package.json" subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
       "require": "./lib/node/index.js",
       "default": "./lib/node/index.mjs"
     },
-    "./package.json": {
-      "default": "./package.json"
-    }
+    "./package.json": "./package.json"
   },
   "bin": {
     "msw": "cli/index.js"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
       "types": "./lib/node/index.d.ts",
       "require": "./lib/node/index.js",
       "default": "./lib/node/index.mjs"
+    },
+    "./package.json": {
+      "default": "./package.json"
     }
   },
   "bin": {


### PR DESCRIPTION
![Zrzut ekranu 2023-02-3 o 16 46 23](https://user-images.githubusercontent.com/53791881/216645993-83a6abfd-c1ae-4887-a3dc-bc8583dfc891.png)

Add a fix for the warning that occurred when starting React Native metro server.
