### PR TITLE
test(playwright configuration): use fullyParallel flag to isolate tests

### DIFF
--- a/test/browser/graphql-api/link.test.ts
+++ b/test/browser/graphql-api/link.test.ts
@@ -10,11 +10,11 @@ const server = new HttpServer((app) => {
   })
 })
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await server.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await server.close()
 })
 

--- a/test/browser/graphql-api/mutation.test.ts
+++ b/test/browser/graphql-api/mutation.test.ts
@@ -12,11 +12,11 @@ function endpoint(): string {
   return server.http.url('/graphql')
 }
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await server.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await server.close()
 })
 

--- a/test/browser/graphql-api/operation.test.ts
+++ b/test/browser/graphql-api/operation.test.ts
@@ -10,11 +10,11 @@ const server = new HttpServer((app) => {
   })
 })
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await server.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await server.close()
 })
 

--- a/test/browser/graphql-api/query.test.ts
+++ b/test/browser/graphql-api/query.test.ts
@@ -12,11 +12,11 @@ const endpoint = () => {
   return server.http.url('/graphql')
 }
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await server.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await server.close()
 })
 

--- a/test/browser/graphql-api/response-patching.test.ts
+++ b/test/browser/graphql-api/response-patching.test.ts
@@ -41,11 +41,11 @@ const httpServer = new HttpServer((app) => {
   })
 })
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await httpServer.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await httpServer.close()
 })
 

--- a/test/browser/playwright.config.ts
+++ b/test/browser/playwright.config.ts
@@ -21,6 +21,7 @@ const config: PlaywrightTestConfig = {
   workers: process.env.CI ? 2 : undefined,
   forbidOnly: !!process.env.CI,
   reporter: 'list',
+  fullyParallel: true,
 }
 
 export default config

--- a/test/browser/rest-api/204-response.test.ts
+++ b/test/browser/rest-api/204-response.test.ts
@@ -15,7 +15,7 @@ test.beforeAll(async () => {
   await httpServer.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await httpServer.close()
 })
 

--- a/test/browser/rest-api/cors.test.ts
+++ b/test/browser/rest-api/cors.test.ts
@@ -14,11 +14,11 @@ const server = new HttpServer((app) => {
   })
 })
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await server.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await server.close()
 })
 

--- a/test/browser/rest-api/request/matching/method.test.ts
+++ b/test/browser/rest-api/request/matching/method.test.ts
@@ -15,7 +15,7 @@ test.beforeEach(async () => {
   await server.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await server.close()
 })
 

--- a/test/browser/rest-api/request/matching/method.test.ts
+++ b/test/browser/rest-api/request/matching/method.test.ts
@@ -11,7 +11,7 @@ const server = new HttpServer((app) => {
   })
 })
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await server.listen()
 })
 

--- a/test/browser/rest-api/response-patching.test.ts
+++ b/test/browser/rest-api/response-patching.test.ts
@@ -35,11 +35,11 @@ const httpServer = new HttpServer((app) => {
   })
 })
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await httpServer.listen()
 })
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await httpServer.close()
 })
 


### PR DESCRIPTION
This flag makes playwright run each single test in a separate context in parallel, providing easier isolation, teardown and better performance when running in parallel in many workers.

Reference https://playwright.dev/docs/test-parallel