### PR TITLE
fix(worker): remove bypassing of server-sent events

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -88,11 +88,6 @@ self.addEventListener('fetch', function (event) {
   const { request } = event
   const accept = request.headers.get('accept') || ''
 
-  // Bypass server-sent events.
-  if (accept.includes('text/event-stream')) {
-    return
-  }
-
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
     return


### PR DESCRIPTION
Server-sent Events are now working fine and there is no need to bypass them.

Fixes workaround from https://github.com/mswjs/msw/issues/156#issuecomment-1189807742

Implementation examples
- Migration guide > [Support ReadableStream mocked responses](https://github.com/mswjs/msw/blob/feat/standard-api/MIGRATING.md#support-readablestream-mocked-responses)
- [test/rest-api/response/body/body-readable-stream.mocks.ts](https://github.com/mswjs/msw/pull/1436/files#diff-cc6c833284918f1602b3c897fb29381fd3803581ae18da15e795e8612360bef9)