### PR TITLE
chore: use NODE_AUTH_TOKEN with pnpm vs NPM_AUTH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
         run: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes the broken release pipeline after migrating to pnpm (#1542). 