### PR TITLE
feat: add `operationName` to GraphQL request

### DIFF
--- a/src/handlers/GraphQLHandler.test.ts
+++ b/src/handlers/GraphQLHandler.test.ts
@@ -548,3 +548,32 @@ describe('isDocumentNode', () => {
     expect(isDocumentNode(/value/)).toEqual(false)
   })
 })
+
+describe('request', () => {
+  it('has parsed operationName', async () => {
+    const matchAllResolver = jest.fn()
+    const handler = new GraphQLHandler(
+      OperationTypeNode.QUERY,
+      /.*/,
+      '*',
+      matchAllResolver,
+    )
+    const request = createPostGraphQLRequest({
+      query: `
+          query GetAllUsers {
+            user {
+              id
+            }
+          }
+        `,
+    })
+
+    await handler.run(request)
+
+    expect(matchAllResolver).toHaveBeenCalledTimes(1)
+    expect(matchAllResolver.mock.calls[0][0]).toHaveProperty(
+      'operationName',
+      'GetAllUsers',
+    )
+  })
+})

--- a/src/handlers/GraphQLHandler.ts
+++ b/src/handlers/GraphQLHandler.ts
@@ -84,7 +84,11 @@ export function isDocumentNode(
 export class GraphQLRequest<
   Variables extends GraphQLVariables,
 > extends MockedRequest<GraphQLRequestBody<Variables>> {
-  constructor(request: MockedRequest, public readonly variables: Variables) {
+  constructor(
+    request: MockedRequest,
+    public readonly variables: Variables,
+    public readonly operationName: string,
+  ) {
     super(request.url, {
       ...request,
       /**
@@ -160,7 +164,11 @@ export class GraphQLHandler<
     request: Request,
     parsedResult: ParsedGraphQLRequest,
   ): GraphQLRequest<any> {
-    return new GraphQLRequest(request, parsedResult?.variables || {})
+    return new GraphQLRequest(
+      request,
+      parsedResult?.variables ?? {},
+      parsedResult?.operationName ?? '',
+    )
   }
 
   predicate(request: MockedRequest, parsedResult: ParsedGraphQLRequest) {


### PR DESCRIPTION
Reasoning:

When a wildcard GraphQL query handler is registered (via regex) it is useful to have the parsed operationName in the request. Having the operationName allows the consumers to implement more complex/dynamic resolvers.