### PR TITLE
fix: update "headers-polyfill" to 3.1.2 to fix the ESM issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "chokidar": "^3.4.2",
     "cookie": "^0.4.2",
     "graphql": "^15.0.0 || ^16.0.0",
-    "headers-polyfill": "^3.1.0",
+    "headers-polyfill": "^3.1.2",
     "inquirer": "^8.2.0",
     "is-node-process": "^1.0.1",
     "js-levenshtein": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ specifiers:
   fs-extra: ^10.0.0
   fs-teardown: ^0.3.0
   graphql: ^15.0.0 || ^16.0.0
-  headers-polyfill: ^3.1.0
+  headers-polyfill: ^3.1.2
   inquirer: ^8.2.0
   is-node-process: ^1.0.1
   jest: ^29.4.3


### PR DESCRIPTION
This updates `headers-polyfill` to 3.1.2 which fixes the issue with ESM, described here: https://github.com/mswjs/headers-polyfill/issues/46