### PR TITLE
chore: trigger ci on any pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   # Builds the library and persists it as an artifact.


### PR DESCRIPTION
Right now, pull requests between feature branches do not trigger test runs. That's unfortunate, and needs to be fixed. 