### PR TITLE
fix: prevent "abort" listener memory leak in RequestHandler

### DIFF
--- a/src/browser/setupWorker/start/createFallbackRequestListener.ts
+++ b/src/browser/setupWorker/start/createFallbackRequestListener.ts
@@ -26,7 +26,7 @@ export function createFallbackRequestListener(
       options,
       context.emitter,
       {
-        onMockedResponse(_, { handler, request, parsedRequest }) {
+        onMockedResponse(_, { handler, parsedRequest }) {
           if (!options.quiet) {
             context.emitter.once('response:mocked', (response) => {
               handler.log(request, response, parsedRequest)

--- a/src/browser/setupWorker/start/createFallbackRequestListener.ts
+++ b/src/browser/setupWorker/start/createFallbackRequestListener.ts
@@ -19,6 +19,8 @@ export function createFallbackRequestListener(
   })
 
   interceptor.on('request', async (request, requestId) => {
+    const requestCloneForLogs = request.clone()
+
     const response = await handleRequest(
       request,
       requestId,
@@ -29,7 +31,7 @@ export function createFallbackRequestListener(
         onMockedResponse(_, { handler, parsedRequest }) {
           if (!options.quiet) {
             context.emitter.once('response:mocked', (response) => {
-              handler.log(request, response, parsedRequest)
+              handler.log(requestCloneForLogs, response, parsedRequest)
             })
           }
         },

--- a/src/browser/setupWorker/start/createRequestListener.ts
+++ b/src/browser/setupWorker/start/createRequestListener.ts
@@ -29,6 +29,7 @@ export const createRequestListener = (
 
     const requestId = message.payload.id
     const request = parseWorkerRequest(message.payload)
+    const requestCloneForLogs = request.clone()
 
     try {
       await handleRequest(
@@ -62,7 +63,7 @@ export const createRequestListener = (
 
             if (!options.quiet) {
               context.emitter.once('response:mocked', (response) => {
-                handler.log(request, response, parsedRequest)
+                handler.log(requestCloneForLogs, response, parsedRequest)
               })
             }
           },

--- a/src/browser/setupWorker/start/createRequestListener.ts
+++ b/src/browser/setupWorker/start/createRequestListener.ts
@@ -41,10 +41,7 @@ export const createRequestListener = (
           onPassthroughResponse() {
             messageChannel.postMessage('NOT_FOUND')
           },
-          async onMockedResponse(
-            response,
-            { request, handler, parsedRequest },
-          ) {
+          async onMockedResponse(response, { handler, parsedRequest }) {
             // Clone the mocked response so its body could be read
             // to buffer to be sent to the worker and also in the
             // ".log()" method of the request handler.

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -2,7 +2,7 @@ import { invariant } from 'outvariant'
 import { getCallFrame } from '../utils/internal/getCallFrame'
 import { isIterable } from '../utils/internal/isIterable'
 import type { ResponseResolutionContext } from '../utils/getResponse'
-import type { MaybePromise } from '..//typeUtils'
+import type { MaybePromise } from '../typeUtils'
 import { StrictRequest, StrictResponse } from '..//HttpResponse'
 
 export type DefaultRequestMultipartBody = Record<
@@ -177,16 +177,19 @@ export abstract class RequestHandler<
       return null
     }
 
+    const mainRequestRef = request.clone()
+
     // Immediately mark the handler as used.
     // Can't await the resolver to be resolved because it's potentially
     // asynchronous, and there may be multiple requests hitting this handler.
     this.isUsed = true
 
-    const requestClone = request.clone()
-
-    const parsedResult = await this.parse(request.clone(), resolutionContext)
+    const parsedResult = await this.parse(
+      mainRequestRef.clone(),
+      resolutionContext,
+    )
     const shouldInterceptRequest = this.predicate(
-      request.clone(),
+      mainRequestRef.clone(),
       parsedResult,
       resolutionContext,
     )
@@ -208,7 +211,7 @@ export abstract class RequestHandler<
     const executionResult = this.createExecutionResult(
       // Pass the cloned request to the result so that logging
       // and other consumers could read its body once more.
-      requestClone,
+      mainRequestRef,
       parsedResult,
       mockedResponse,
     )

--- a/src/core/utils/getResponse.ts
+++ b/src/core/utils/getResponse.ts
@@ -5,7 +5,7 @@ import {
 
 export interface ResponseLookupResult {
   handler: RequestHandler
-  parsedRequest: any
+  parsedRequest?: any
   response?: Response
 }
 

--- a/src/core/utils/handleRequest.test.ts
+++ b/src/core/utils/handleRequest.test.ts
@@ -137,7 +137,7 @@ test('reports request as unhandled when it has no matching request handlers', as
   expect(callbacks.onMockedResponse).not.toHaveBeenCalled()
 })
 
-test('returns undefined and warns on a request handler that returns no response', async () => {
+test('returns undefined on a request handler that returns no response', async () => {
   const { emitter, events } = setup()
 
   const requestId = uuidv4()
@@ -167,14 +167,10 @@ test('returns undefined and warns on a request handler that returns no response'
   expect(callbacks.onPassthroughResponse).toHaveBeenNthCalledWith(1, request)
   expect(callbacks.onMockedResponse).not.toHaveBeenCalled()
 
-  expect(console.warn).toHaveBeenCalledTimes(1)
-  const warning = (console.warn as unknown as jest.SpyInstance).mock.calls[0][0]
-
-  expect(warning).toContain(
-    '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
-  )
-  expect(warning).toContain('GET /user')
-  expect(warning).toMatch(/\d+:\d+/)
+  /**
+   * @note Returning undefined from a resolver no longer prints a warning.
+   */
+  expect(console.warn).toHaveBeenCalledTimes(0)
 })
 
 test('returns the mocked response for a request with a matching request handler', async () => {
@@ -229,10 +225,6 @@ test('returns the mocked response for a request with a matching request handler'
   expect(lookupResultParam).toEqual({
     handler: lookupResult.handler,
     parsedRequest: lookupResult.parsedRequest,
-    request: expect.objectContaining({
-      method: lookupResult.request.method,
-      url: lookupResult.request.url,
-    }),
     response: expect.objectContaining({
       status: lookupResult.response.status,
       statusText: lookupResult.response.statusText,
@@ -319,10 +311,6 @@ test('returns a transformed response if the "transformResponse" option is provid
   expect(lookupResultParam).toEqual({
     handler: lookupResult.handler,
     parsedRequest: lookupResult.parsedRequest,
-    request: expect.objectContaining({
-      method: lookupResult.request.method,
-      url: lookupResult.request.url,
-    }),
     response: expect.objectContaining({
       status: lookupResult.response.status,
       statusText: lookupResult.response.statusText,

--- a/src/core/utils/internal/Disposable.ts
+++ b/src/core/utils/internal/Disposable.ts
@@ -1,0 +1,9 @@
+export type DisposableSubscription = () => Promise<void> | void
+
+export class Disposable {
+  protected subscriptions: Array<DisposableSubscription> = []
+
+  public async dispose() {
+    await Promise.all(this.subscriptions.map((subscription) => subscription()))
+  }
+}

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -83,6 +83,10 @@ export class SetupServerApi
     // Apply the interceptor when starting the server.
     this.interceptor.apply()
 
+    this.subscriptions.push(() => {
+      this.interceptor.dispose()
+    })
+
     // Assert that the interceptor has been applied successfully.
     // Also guards us from forgetting to call "interceptor.apply()"
     // as a part of the "listen" method.
@@ -115,7 +119,6 @@ ${`${pragma} ${header}`}
   }
 
   public close(): void {
-    super.dispose()
-    this.interceptor.dispose()
+    this.dispose()
   }
 }

--- a/test/browser/msw-api/req/passthrough.test.ts
+++ b/test/browser/msw-api/req/passthrough.test.ts
@@ -1,4 +1,5 @@
-import { HttpResponse, passthrough, rest, SetupWorkerApi } from 'msw'
+import { HttpResponse, passthrough, rest } from 'msw'
+import { SetupWorkerApi } from 'msw/browser'
 import { test, expect } from '../../playwright.extend'
 
 const PASSTHROUGH_EXAMPLE = require.resolve('./passthrough.mocks.ts')
@@ -94,10 +95,9 @@ test('does not allow fall-through when returning "req.passthrough" call in the r
   expect(consoleSpy.get('warning')).toBeUndefined()
 })
 
-test('prints a warning and performs a request as-is if nothing was returned from the resolver', async ({
+test('performs a request as-is if nothing was returned from the resolver', async ({
   createServer,
   loadExample,
-  spyOnConsole,
   fetch,
   page,
 }) => {
@@ -107,7 +107,6 @@ test('prints a warning and performs a request as-is if nothing was returned from
     })
   })
 
-  const consoleSpy = spyOnConsole()
   await loadExample(PASSTHROUGH_EXAMPLE)
   const endpointUrl = server.http.url('/user')
 
@@ -128,12 +127,4 @@ test('prints a warning and performs a request as-is if nothing was returned from
   expect(json).toEqual({
     name: 'John',
   })
-
-  expect(consoleSpy.get('warning')).toEqual(
-    expect.arrayContaining([
-      expect.stringContaining(
-        '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
-      ),
-    ]),
-  )
 })

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.test.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.test.ts
@@ -79,9 +79,6 @@ test('emits events for a handled request with no response', async ({
 
   expect(consoleSpy.get('warning')).toEqual([
     `[request:start] POST ${url} ${requestId}`,
-    expect.stringContaining(
-      '[MSW] Expected response resolver to return a mocked response Object',
-    ),
     `[request:end] POST ${url} ${requestId}`,
     `[response:bypass] original-response ${requestId}`,
   ])

--- a/test/node/msw-api/req/passthrough.node.test.ts
+++ b/test/node/msw-api/req/passthrough.node.test.ts
@@ -74,7 +74,7 @@ it('does not allow fall-through when returning "req.passthrough" call in the res
   expect(console.warn).not.toHaveBeenCalled()
 })
 
-it('prints a warning and performs a request as-is if nothing was returned from the resolver', async () => {
+it('performs a request as-is if nothing was returned from the resolver', async () => {
   const endpointUrl = httpServer.http.url('/user')
   server.use(
     rest.post<ResponseBody>(endpointUrl, () => {
@@ -88,12 +88,4 @@ it('prints a warning and performs a request as-is if nothing was returned from t
   expect(json).toEqual<ResponseBody>({
     name: 'John',
   })
-
-  const warning = (console.warn as any as jest.SpyInstance).mock.calls[0][0]
-
-  expect(warning).toContain(
-    '[MSW] Expected response resolver to return a mocked response Object, but got undefined. The original response is going to be used instead.',
-  )
-  expect(warning).toContain(`POST ${endpointUrl}`)
-  expect(console.warn).toHaveBeenCalledTimes(1)
 })

--- a/test/node/msw-api/setup-server/scenarios/fall-through.node.test.ts
+++ b/test/node/msw-api/setup-server/scenarios/fall-through.node.test.ts
@@ -20,13 +20,14 @@ const server = setupServer(
 )
 
 beforeAll(() => {
-  // Supress the "Expeted mocking resolver function to return a mocked response" warnings.
-  jest.spyOn(global.console, 'warn').mockImplementation()
   server.listen()
 })
 
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
 afterAll(() => {
-  jest.restoreAllMocks()
   server.close()
 })
 
@@ -37,8 +38,8 @@ test('falls through all relevant request handlers until response is returned', a
   expect(body).toEqual({
     firstName: 'John',
   })
-  expect(log).toBeCalledWith('[get] first')
-  expect(log).toBeCalledWith('[get] second')
+  expect(log).toHaveBeenNthCalledWith(1, '[get] first')
+  expect(log).toHaveBeenNthCalledWith(2, '[get] second')
   expect(log).not.toBeCalledWith('[get] third')
 })
 
@@ -49,6 +50,6 @@ test('falls through all relevant handlers even if none return response', async (
   const { status } = res
 
   expect(status).toBe(404)
-  expect(log).toBeCalledWith('[post] first')
-  expect(log).toBeCalledWith('[post] second')
+  expect(log).toHaveBeenNthCalledWith(1, '[post] first')
+  expect(log).toHaveBeenNthCalledWith(2, '[post] second')
 })


### PR DESCRIPTION
- Closes #1207 
- Prevents the "abort" request listener leak in the `RequestHandler` class by cloning the incoming request _once_, and then doing subsequent clones from that main clone.

> Context: whenever a `Request` is cloned, it gets a new `abort` listener to propagate the original request abort event to the cloned instance. Since we were processing _the same_ request through multiple handlers, cloning it _multiple times_, every `request.clone()` invocation appended the `abort` listener, resulting in a memory leak. 

- Refactors the request handler lookup algorithm (finally). The main changes are:
  - Returning `undefined` from a response resolver _no longer prints a warning_. The devs must read the docks and understand that if they return nothing, nothing will happen.
  