### PR TITLE
fix(dependency): unpin the "chalk" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.1",
     "@types/js-levenshtein": "^1.1.1",
-    "chalk": "4.1.1",
+    "chalk": "^4.1.1",
     "chokidar": "^3.4.2",
     "cookie": "^0.4.2",
     "graphql": "^15.0.0 || ^16.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ specifiers:
   '@typescript-eslint/parser': ^5.11.0
   babel-loader: ^8.2.3
   babel-minify: ^0.5.1
-  chalk: 4.1.1
+  chalk: ^4.1.1
   chokidar: 3.4.1
   commitizen: ^4.2.4
   cookie: ^0.4.2


### PR DESCRIPTION
Open up the chalk dependency, which is currently pinned. This allows packages that use msw to choose the best, compatible chalk version without duplicating it in their module tree.

Note this PR does not update the lockfile. Running `pnpm install` using the `pnpm@8.6.2` changed the lockfile version, which seemed like too big a change for this PR. The maintainer should update the lockfile in the best method for the project.