### PR TITLE
fix: clone Response before logging

### DIFF
--- a/src/setupWorker/start/createRequestListener.ts
+++ b/src/setupWorker/start/createRequestListener.ts
@@ -54,6 +54,7 @@ export const createRequestListener = (
             }
 
             const responseInstance = new Response(response.body, response)
+            const responseForLogs = responseInstance.clone()
             const responseBodyBuffer = await responseInstance.arrayBuffer()
 
             // If the mocked response has no body, keep it that way.
@@ -73,10 +74,10 @@ export const createRequestListener = (
             )
 
             if (!options.quiet) {
-              context.emitter.once('response:mocked', async (response) => {
+              context.emitter.once('response:mocked', async () => {
                 handler.log(
                   publicRequest,
-                  await serializeResponse(response),
+                  await serializeResponse(responseForLogs),
                   parsedRequest,
                 )
               })

--- a/src/utils/logging/serializeResponse.ts
+++ b/src/utils/logging/serializeResponse.ts
@@ -11,6 +11,6 @@ export async function serializeResponse(
     // Serialize the response body to a string
     // so it's easier to process further down the chain in "prepareResponse" (browser-only)
     // and "parseBody" (ambiguous).
-    body: await response.text(),
+    body: await response.clone().text(),
   }
 }

--- a/src/utils/request/createResponseFromIsomorphicResponse.ts
+++ b/src/utils/request/createResponseFromIsomorphicResponse.ts
@@ -1,34 +1,11 @@
-import { encodeBuffer, IsomorphicResponse } from '@mswjs/interceptors'
-
-const noop = () => {
-  throw new Error('Not implemented')
-}
+import { IsomorphicResponse } from '@mswjs/interceptors'
 
 export function createResponseFromIsomorphicResponse(
   response: IsomorphicResponse,
 ): Response {
-  return {
-    ...response,
-    ok: response.status >= 200 && response.status < 300,
-    url: '',
-    type: 'default',
+  return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers: response.headers,
-    body: new ReadableStream(),
-    redirected: response.headers.get('Location') != null,
-    async text() {
-      return response.body || ''
-    },
-    async json() {
-      return JSON.parse(response.body || '')
-    },
-    async arrayBuffer() {
-      return encodeBuffer(response.body || '')
-    },
-    bodyUsed: false,
-    formData: noop,
-    blob: noop,
-    clone: noop,
-  }
+  })
 }


### PR DESCRIPTION
- Fixes #1640

## Changes

- The `IsomorphicResponse -> Response` construction for the fallback mode (in-browser only) now uses the standard `Response` class (every response can now be cloned).
- Clone the response in the `serializeResponse` before reading its body.
- Also clone the response _immediately_ on the regular worker response handling.