### PR TITLE
feat: remove `void` type from the ResponseResolverReturnType

### DIFF
--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -32,7 +32,6 @@ export type ResponseResolverReturnType<
 > =
   | (BodyType extends undefined ? Response : StrictResponse<BodyType>)
   | undefined
-  | void
 
 export type MaybeAsyncResponseResolverReturnType<
   BodyType extends DefaultBodyType,


### PR DESCRIPTION
- close #1671 

This change will enforce the return type of resolvers not to be `void`.

```ts
type RequestBody = {};
type Params = PathParams<"login">;
type Response = { login: string | readonly string[] };

const validHandler = rest.get<RequestBody, Params, Response>(
  "https://api.github.com/user/:login",
  (req, res, ctx) => {
    return res(ctx.json({ login: req.params.login }));
  }
);

// the following handler will be invalid by this PR.
const invalidHandler = rest.get<RequestBody, Params, Response>(
  "https://api.github.com/user/:login",
  (req, res, ctx) => {} // <- it does not return anything
);
```