### PR TITLE
chore: specify pnpm version in package json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ $ pnpm install
 $ pnpm start
 ```
 
-> Please use [PNPM][pnpm-url] version specified in the `package.json` file while working on this project. You can use [corepack][corepack-url] to manage multiple pnpm versions.
+> Please use [PNPM][pnpm-url] version 7.12 while working on this project.
+> Guide on how to install a specific PNPM version can be [found here][pnpm-install-guide-url].
 
 ## Git workflow
 
@@ -272,4 +273,4 @@ $ pnpm build
 [pnpm-url]: https://pnpm.io/
 [jest-url]: https://jestjs.io
 [page-with-url]: https://github.com/kettanaito/page-with
-[corepack-url]: https://github.com/nodejs/corepack
+[pnpm-install-guide-url]: https://pnpm.io/7.x/installation#installing-a-specific-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ $ pnpm install
 $ pnpm start
 ```
 
-> Please use [PNPM][pnpm-url] while working on this project.
+> Please use [PNPM][pnpm-url] version specified in the `package.json` file while working on this project. You can use [corepack][corepack-url] to manage multiple pnpm versions.
 
 ## Git workflow
 
@@ -272,3 +272,4 @@ $ pnpm build
 [pnpm-url]: https://pnpm.io/
 [jest-url]: https://jestjs.io
 [page-with-url]: https://github.com/kettanaito/page-with
+[corepack-url]: https://github.com/nodejs/corepack

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Seamless REST/GraphQL API mocking library for browser and Node.js.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "packageManager": "pnpm@7.12.2",
   "exports": {
     ".": {
       "default": "./lib/index.js"
@@ -23,7 +24,8 @@
     "msw": "cli/index.js"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14",
+    "pnpm": "~7.12"
   },
   "scripts": {
     "start": "tsup --watch",


### PR DESCRIPTION
specifies the pnpm version to use when contributing
enables contributors to easily switch to the correct version using `corepack`

update:
looks like the codesandbox demo runs of `pnpm@7.26.3`, do we want to lock the pnpm version to the major? `pnpm@^7.0.0` 