### PR TITLE
feat: support TypeScript 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ['4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0', '5.1']
+        ts: ['4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0', '5.1', '5.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "webpack-http-server": "^0.5.0"
   },
   "peerDependencies": {
-    "typescript": ">= 4.4.x <= 5.1.x"
+    "typescript": ">= 4.4.x <= 5.2.x"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "chokidar": "^3.4.2",
     "cookie": "^0.4.2",
     "graphql": "^15.0.0 || ^16.0.0",
-    "headers-polyfill": "^3.1.2",
+    "headers-polyfill": "^3.2.0",
     "inquirer": "^8.2.0",
     "is-node-process": "^1.2.0",
     "js-levenshtein": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ specifiers:
   fs-extra: ^10.0.0
   fs-teardown: ^0.3.0
   graphql: ^15.0.0 || ^16.0.0
-  headers-polyfill: ^3.1.2
+  headers-polyfill: ^3.2.0
   inquirer: ^8.2.0
   is-node-process: ^1.2.0
   jest: ^29.4.3
@@ -82,7 +82,7 @@ dependencies:
   chokidar: 3.4.1
   cookie: 0.4.2
   graphql: 16.6.0
-  headers-polyfill: 3.1.2
+  headers-polyfill: 3.2.0
   inquirer: 8.2.5
   is-node-process: 1.2.0
   js-levenshtein: 1.1.6
@@ -2127,7 +2127,7 @@ packages:
       '@types/debug': 4.1.7
       '@xmldom/xmldom': 0.8.6
       debug: 4.3.4
-      headers-polyfill: 3.1.2
+      headers-polyfill: 3.2.0
       outvariant: 1.4.0
       strict-event-emitter: 0.2.8
       web-encoding: 1.1.5
@@ -5990,8 +5990,8 @@ packages:
     dependencies:
       function-bind: 1.1.1
 
-  /headers-polyfill/3.1.2:
-    resolution: {integrity: sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==}
+  /headers-polyfill/3.2.0:
+    resolution: {integrity: sha512-NsYkbrWFQyoPBrbX5riycJ3D4aaB/3fpx1nYgDi3JTTnoeFET3BN0rq2nOB3VUmvpQrYpbKL8zRJo1Jsmmt7nA==}
 
   /homedir-polyfill/1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -8099,7 +8099,7 @@ packages:
       '@types/uuid': 8.3.4
       debug: 4.3.4
       express: 4.18.2
-      headers-polyfill: 3.1.2
+      headers-polyfill: 3.2.0
       memfs: 3.4.13
       mustache: 4.2.0
       playwright: 1.30.0

--- a/test/typings/tsconfig.5.2.json
+++ b/test/typings/tsconfig.5.2.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.4.7.json"
+}

--- a/test/typings/tsconfig.5.2.json
+++ b/test/typings/tsconfig.5.2.json
@@ -1,3 +1,7 @@
 {
-  "extends": "./tsconfig.4.7.json"
+  "extends": "./tsconfig.4.7.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  }
 }


### PR DESCRIPTION
Loosen peer dependency constraint to unblock projects that use msw from upgrading to TypeScript 5.2.x.

