### PR TITLE
fix: allow installs with any version of pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "msw": "cli/index.js"
   },
   "engines": {
-    "node": ">=14",
-    "pnpm": "~7.12"
+    "node": ">=14"
   },
   "scripts": {
     "start": "tsup --watch",


### PR DESCRIPTION
- Fixes #1712 
- Introduced by #1676 

Listing `engines.pnpm` also affects consumers. The version of PNPM is only relevant for contributors so the correct lockfile gets generated. The consumers can use whichever PNPM, or other package manager's version they wish. I am not aware of the way to enforce certain engines for contributors only by `package.json` so I'm simply removing that restriction altogether. 