### PR TITLE
fix: pin "headers-polyfill" to 3.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "chokidar": "^3.4.2",
     "cookie": "^0.4.2",
     "graphql": "^15.0.0 || ^16.0.0",
-    "headers-polyfill": "^3.2.0",
+    "headers-polyfill": "3.2.5",
     "inquirer": "^8.2.0",
     "is-node-process": "^1.2.0",
     "js-levenshtein": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "sideEffects": false,
   "dependencies": {
     "@mswjs/cookies": "^0.2.2",
-    "@mswjs/interceptors": "^0.17.5",
+    "@mswjs/interceptors": "^0.17.10",
     "@open-draft/until": "^1.0.3",
     "@types/cookie": "^0.4.1",
     "@types/js-levenshtein": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@commitlint/cli': ^16.1.0
   '@commitlint/config-conventional': ^16.0.0
   '@mswjs/cookies': ^0.2.2
-  '@mswjs/interceptors': ^0.17.5
+  '@mswjs/interceptors': ^0.17.10
   '@open-draft/test-server': ^0.4.2
   '@open-draft/until': ^1.0.3
   '@ossjs/release': ^0.7.2
@@ -74,7 +74,7 @@ specifiers:
 
 dependencies:
   '@mswjs/cookies': 0.2.2
-  '@mswjs/interceptors': 0.17.7
+  '@mswjs/interceptors': 0.17.10
   '@open-draft/until': 1.0.3
   '@types/cookie': 0.4.1
   '@types/js-levenshtein': 1.1.1
@@ -2119,8 +2119,8 @@ packages:
       set-cookie-parser: 2.5.1
     dev: false
 
-  /@mswjs/interceptors/0.17.7:
-    resolution: {integrity: sha512-dPInyLEF6ybLxfKGY99euI+mbT6ls4PVO9qPgGIsRk3+2VZVfT7fo9Sq6Q8eKT9W38QtUyhG74hN7xMtKWioGw==}
+  /@mswjs/interceptors/0.17.10:
+    resolution: {integrity: sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==}
     engines: {node: '>=14'}
     dependencies:
       '@open-draft/until': 1.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ specifiers:
   fs-extra: ^10.0.0
   fs-teardown: ^0.3.0
   graphql: ^15.0.0 || ^16.0.0
-  headers-polyfill: ^3.2.0
+  headers-polyfill: 3.2.5
   inquirer: ^8.2.0
   is-node-process: ^1.2.0
   jest: ^29.4.3
@@ -82,7 +82,7 @@ dependencies:
   chokidar: 3.4.1
   cookie: 0.4.2
   graphql: 16.6.0
-  headers-polyfill: 3.2.0
+  headers-polyfill: 3.2.5
   inquirer: 8.2.5
   is-node-process: 1.2.0
   js-levenshtein: 1.1.6
@@ -2127,7 +2127,7 @@ packages:
       '@types/debug': 4.1.7
       '@xmldom/xmldom': 0.8.6
       debug: 4.3.4
-      headers-polyfill: 3.2.0
+      headers-polyfill: 3.2.5
       outvariant: 1.4.0
       strict-event-emitter: 0.2.8
       web-encoding: 1.1.5
@@ -5994,8 +5994,8 @@ packages:
     dependencies:
       function-bind: 1.1.1
 
-  /headers-polyfill/3.2.0:
-    resolution: {integrity: sha512-NsYkbrWFQyoPBrbX5riycJ3D4aaB/3fpx1nYgDi3JTTnoeFET3BN0rq2nOB3VUmvpQrYpbKL8zRJo1Jsmmt7nA==}
+  /headers-polyfill/3.2.5:
+    resolution: {integrity: sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==}
 
   /homedir-polyfill/1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -8103,7 +8103,7 @@ packages:
       '@types/uuid': 8.3.4
       debug: 4.3.4
       express: 4.18.2
-      headers-polyfill: 3.2.0
+      headers-polyfill: 3.2.5
       memfs: 3.4.13
       mustache: 4.2.0
       playwright: 1.30.0


### PR DESCRIPTION
- Fixes an issue introduced by https://github.com/mswjs/headers-polyfill/releases/tag/v3.3.0 
- This also needs a backport for `@mswjs/interceptors@0.17`