### PR TITLE
chore: update to @ossjs/release@0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
     "@open-draft/test-server": "^0.4.2",
-    "@ossjs/release": "^0.7.2",
+    "@ossjs/release": "^0.8.0",
     "@playwright/test": "^1.30.0",
     "@swc/core": "^1.3.35",
     "@swc/jest": "^0.2.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ specifiers:
   '@mswjs/interceptors': ^0.17.10
   '@open-draft/test-server': ^0.4.2
   '@open-draft/until': ^1.0.3
-  '@ossjs/release': ^0.7.2
+  '@ossjs/release': ^0.8.0
   '@playwright/test': ^1.30.0
   '@swc/core': ^1.3.35
   '@swc/jest': ^0.2.24
@@ -99,7 +99,7 @@ devDependencies:
   '@commitlint/cli': 16.3.0_@swc+core@1.3.35
   '@commitlint/config-conventional': 16.2.4
   '@open-draft/test-server': 0.4.2
-  '@ossjs/release': 0.7.2
+  '@ossjs/release': 0.8.0
   '@playwright/test': 1.30.0
   '@swc/core': 1.3.35
   '@swc/jest': 0.2.24_@swc+core@1.3.35
@@ -2183,8 +2183,8 @@ packages:
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
     dev: true
 
-  /@ossjs/release/0.7.2:
-    resolution: {integrity: sha512-s8w7VRC6Xf1vfpIsDG2CflWinSg9O7H/6nckxaBCiMWClkeaZ3JuXzZEIcybc6jeAFc1Rz7UilCvgZflb06Y5g==}
+  /@ossjs/release/0.8.0:
+    resolution: {integrity: sha512-vzxhYvad/Ub3j8bWWCRfdwTvFzK3HtKjm8IM5J+7njnQcZZie5iouUXX+G65OI3F1YgQSWvsozrWqHyN1x7fjQ==}
     hasBin: true
     dependencies:
       '@open-draft/deferred-promise': 2.1.0
@@ -2197,7 +2197,7 @@ packages:
       '@types/registry-auth-token': 4.2.1
       '@types/semver': 7.5.1
       '@types/yargs': 17.0.22
-      conventional-commits-parser: 3.2.4
+      conventional-commits-parser: 5.0.0
       get-stream: 6.0.1
       git-log-parser: 1.2.0
       issue-parser: 6.0.0
@@ -4120,6 +4120,17 @@ packages:
       meow: 8.1.2
       split2: 3.2.2
       through2: 4.0.2
+    dev: true
+
+  /conventional-commits-parser/5.0.0:
+    resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      JSONStream: 1.3.5
+      is-text-path: 2.0.0
+      meow: 12.1.1
+      split2: 4.1.0
     dev: true
 
   /convert-source-map/1.9.0:
@@ -6534,6 +6545,13 @@ packages:
       text-extensions: 1.9.0
     dev: true
 
+  /is-text-path/2.0.0:
+    resolution: {integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==}
+    engines: {node: '>=8'}
+    dependencies:
+      text-extensions: 2.4.0
+    dev: true
+
   /is-typed-array/1.1.10:
     resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
     engines: {node: '>= 0.4'}
@@ -7554,6 +7572,11 @@ packages:
     dependencies:
       errno: 0.1.8
       readable-stream: 2.3.7
+    dev: true
+
+  /meow/12.1.1:
+    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
+    engines: {node: '>=16.10'}
     dev: true
 
   /meow/8.1.2:
@@ -9613,6 +9636,11 @@ packages:
   /text-extensions/1.9.0:
     resolution: {integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==}
     engines: {node: '>=0.10'}
+    dev: true
+
+  /text-extensions/2.4.0:
+    resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
+    engines: {node: '>=8'}
     dev: true
 
   /text-table/0.2.0:


### PR DESCRIPTION
- Adds support for releases via the `!` commit type appendix, like `feat!:` or `feat(scope)!:`