### PR TITLE
feat: set minimal supported typescript version to 4.7

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ['4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0', '5.1', '5.2']
+        ts: ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "webpack-http-server": "^0.5.0"
   },
   "peerDependencies": {
-    "typescript": ">= 4.4.x <= 5.2.x"
+    "typescript": ">= 4.7.x <= 5.2.x"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
TypeScript 4.7 [was announced](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/) almost 1.5 years ago. Drop everything older than 4.7. 