### PR TITLE
Ignore type check in generated file

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 
 /**
  * Mock Service Worker (<PACKAGE_VERSION>).


### PR DESCRIPTION
A type check error occurred in the file generated when running msw init, so it was corrected to be ignored.