### PR TITLE
feat(RequestHandler): make class method arguments an object

### DIFF
--- a/src/browser/setupWorker/start/createFallbackRequestListener.ts
+++ b/src/browser/setupWorker/start/createFallbackRequestListener.ts
@@ -28,10 +28,14 @@ export function createFallbackRequestListener(
       options,
       context.emitter,
       {
-        onMockedResponse(_, { handler, parsedRequest }) {
+        onMockedResponse(_, { handler, parsedResult }) {
           if (!options.quiet) {
             context.emitter.once('response:mocked', ({ response }) => {
-              handler.log(requestCloneForLogs, response, parsedRequest)
+              handler.log({
+                request: requestCloneForLogs,
+                response,
+                parsedResult,
+              })
             })
           }
         },

--- a/src/browser/setupWorker/start/createRequestListener.ts
+++ b/src/browser/setupWorker/start/createRequestListener.ts
@@ -41,7 +41,7 @@ export const createRequestListener = (
           onPassthroughResponse() {
             messageChannel.postMessage('NOT_FOUND')
           },
-          async onMockedResponse(response, { handler, parsedRequest }) {
+          async onMockedResponse(response, { handler, parsedResult }) {
             // Clone the mocked response so its body could be read
             // to buffer to be sent to the worker and also in the
             // ".log()" method of the request handler.
@@ -62,7 +62,11 @@ export const createRequestListener = (
 
             if (!options.quiet) {
               context.emitter.once('response:mocked', ({ response }) => {
-                handler.log(requestCloneForLogs, response, parsedRequest)
+                handler.log({
+                  request: requestCloneForLogs,
+                  response,
+                  parsedResult,
+                })
               })
             }
           },

--- a/src/core/handlers/GraphQLHandler.test.ts
+++ b/src/core/handlers/GraphQLHandler.test.ts
@@ -159,7 +159,7 @@ describe('parse', () => {
         query: GET_USER,
       })
 
-      expect(await handler.parse(request)).toEqual({
+      expect(await handler.parse({ request })).toEqual({
         operationType: 'query',
         operationName: 'GetUser',
         query: GET_USER,
@@ -181,7 +181,7 @@ describe('parse', () => {
         },
       })
 
-      expect(await handler.parse(request)).toEqual({
+      expect(await handler.parse({ request })).toEqual({
         operationType: 'query',
         operationName: 'GetUser',
         query: GET_USER,
@@ -202,7 +202,7 @@ describe('parse', () => {
         query: GET_USER,
       })
 
-      expect(await handler.parse(request)).toEqual({
+      expect(await handler.parse({ request })).toEqual({
         operationType: 'query',
         operationName: 'GetUser',
         query: GET_USER,
@@ -224,7 +224,7 @@ describe('parse', () => {
         },
       })
 
-      expect(await handler.parse(request)).toEqual({
+      expect(await handler.parse({ request })).toEqual({
         operationType: 'query',
         operationName: 'GetUser',
         query: GET_USER,
@@ -247,7 +247,7 @@ describe('parse', () => {
         query: LOGIN,
       })
 
-      expect(await handler.parse(request)).toEqual({
+      expect(await handler.parse({ request })).toEqual({
         operationType: 'mutation',
         operationName: 'Login',
         query: LOGIN,
@@ -269,7 +269,7 @@ describe('parse', () => {
         },
       })
 
-      expect(await handler.parse(request)).toEqual({
+      expect(await handler.parse({ request })).toEqual({
         operationType: 'mutation',
         operationName: 'Login',
         query: LOGIN,
@@ -290,7 +290,7 @@ describe('parse', () => {
         query: LOGIN,
       })
 
-      expect(await handler.parse(request)).toEqual({
+      expect(await handler.parse({ request })).toEqual({
         operationType: 'mutation',
         operationName: 'Login',
         query: LOGIN,
@@ -312,7 +312,7 @@ describe('parse', () => {
         },
       })
 
-      expect(await handler.parse(request)).toEqual({
+      expect(await handler.parse({ request })).toEqual({
         operationType: 'mutation',
         operationName: 'Login',
         query: LOGIN,
@@ -339,9 +339,17 @@ describe('predicate', () => {
       query: LOGIN,
     })
 
-    expect(handler.predicate(request, await handler.parse(request))).toBe(true)
     expect(
-      handler.predicate(alienRequest, await handler.parse(alienRequest)),
+      handler.predicate({
+        request,
+        parsedResult: await handler.parse({ request }),
+      }),
+    ).toBe(true)
+    expect(
+      handler.predicate({
+        request: alienRequest,
+        parsedResult: await handler.parse({ request: alienRequest }),
+      }),
     ).toBe(false)
   })
 
@@ -365,9 +373,17 @@ describe('predicate', () => {
         `,
     })
 
-    expect(handler.predicate(request, await handler.parse(request))).toBe(true)
     expect(
-      handler.predicate(alienRequest, await handler.parse(alienRequest)),
+      handler.predicate({
+        request,
+        parsedResult: await handler.parse({ request }),
+      }),
+    ).toBe(true)
+    expect(
+      handler.predicate({
+        request: alienRequest,
+        parsedResult: await handler.parse({ request: alienRequest }),
+      }),
     ).toBe(false)
   })
 
@@ -384,7 +400,12 @@ describe('predicate', () => {
       `,
     })
 
-    expect(handler.predicate(request, await handler.parse(request))).toBe(true)
+    expect(
+      handler.predicate({
+        request,
+        parsedResult: await handler.parse({ request }),
+      }),
+    ).toBe(true)
   })
 
   test('respects custom endpoint', async () => {
@@ -404,9 +425,17 @@ describe('predicate', () => {
       query: GET_USER,
     })
 
-    expect(handler.predicate(request, await handler.parse(request))).toBe(true)
     expect(
-      handler.predicate(alienRequest, await handler.parse(alienRequest)),
+      handler.predicate({
+        request,
+        parsedResult: await handler.parse({ request }),
+      }),
+    ).toBe(true)
+    expect(
+      handler.predicate({
+        request: alienRequest,
+        parsedResult: await handler.parse({ request: alienRequest }),
+      }),
     ).toBe(false)
   })
 })
@@ -426,8 +455,8 @@ describe('test', () => {
       query: LOGIN,
     })
 
-    expect(await handler.test(request)).toBe(true)
-    expect(await handler.test(alienRequest)).toBe(false)
+    expect(await handler.test({ request })).toBe(true)
+    expect(await handler.test({ request: alienRequest })).toBe(false)
   })
 
   test('respects operation name', async () => {
@@ -450,8 +479,8 @@ describe('test', () => {
         `,
     })
 
-    expect(await handler.test(request)).toBe(true)
-    expect(await handler.test(alienRequest)).toBe(false)
+    expect(await handler.test({ request })).toBe(true)
+    expect(await handler.test({ request: alienRequest })).toBe(false)
   })
 
   test('respects custom endpoint', async () => {
@@ -471,8 +500,8 @@ describe('test', () => {
       query: GET_USER,
     })
 
-    expect(await handler.test(request)).toBe(true)
-    expect(await handler.test(alienRequest)).toBe(false)
+    expect(await handler.test({ request })).toBe(true)
+    expect(await handler.test({ request: alienRequest })).toBe(false)
   })
 })
 
@@ -490,7 +519,7 @@ describe('run', () => {
         userId: 'abc-123',
       },
     })
-    const result = await handler.run(request)
+    const result = await handler.run({ request })
 
     expect(result!.handler).toEqual(handler)
     expect(result!.parsedResult).toEqual({
@@ -524,7 +553,7 @@ describe('run', () => {
     const request = createPostGraphQLRequest({
       query: LOGIN,
     })
-    const result = await handler.run(request)
+    const result = await handler.run({ request })
 
     expect(result).toBeNull()
   })
@@ -571,7 +600,7 @@ describe('request', () => {
         `,
     })
 
-    await handler.run(request)
+    await handler.run({ request })
 
     expect(matchAllResolver).toHaveBeenCalledTimes(1)
     expect(matchAllResolver.mock.calls[0][0]).toHaveProperty(

--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -156,7 +156,7 @@ Consider naming this operation or using "graphql.operation()" request handler to
     )
   }
 
-  protected extendInfo(args: {
+  protected extendResolverArgs(args: {
     request: Request
     parsedResult: ParsedGraphQLRequest<GraphQLVariables>
   }) {

--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -114,37 +114,40 @@ export class GraphQLHandler extends RequestHandler<
     this.endpoint = endpoint
   }
 
-  async parse(request: Request) {
-    return parseGraphQLRequest(request).catch((error) => {
+  async parse(args: { request: Request }) {
+    return parseGraphQLRequest(args.request).catch((error) => {
       console.error(error)
       return undefined
     })
   }
 
-  predicate(request: Request, parsedResult: ParsedGraphQLRequest) {
-    if (!parsedResult) {
+  predicate(args: { request: Request; parsedResult: ParsedGraphQLRequest }) {
+    if (!args.parsedResult) {
       return false
     }
 
-    if (!parsedResult.operationName && this.info.operationType !== 'all') {
-      const publicUrl = getPublicUrlFromRequest(request)
+    if (!args.parsedResult.operationName && this.info.operationType !== 'all') {
+      const publicUrl = getPublicUrlFromRequest(args.request)
 
       devUtils.warn(`\
-Failed to intercept a GraphQL request at "${request.method} ${publicUrl}": anonymous GraphQL operations are not supported.
+Failed to intercept a GraphQL request at "${args.request.method} ${publicUrl}": anonymous GraphQL operations are not supported.
 
 Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation`)
       return false
     }
 
-    const hasMatchingUrl = matchRequestUrl(new URL(request.url), this.endpoint)
+    const hasMatchingUrl = matchRequestUrl(
+      new URL(args.request.url),
+      this.endpoint,
+    )
     const hasMatchingOperationType =
       this.info.operationType === 'all' ||
-      parsedResult.operationType === this.info.operationType
+      args.parsedResult.operationType === this.info.operationType
 
     const hasMatchingOperationName =
       this.info.operationName instanceof RegExp
-        ? this.info.operationName.test(parsedResult.operationName || '')
-        : parsedResult.operationName === this.info.operationName
+        ? this.info.operationName.test(args.parsedResult.operationName || '')
+        : args.parsedResult.operationName === this.info.operationName
 
     return (
       hasMatchingUrl.matches &&
@@ -153,28 +156,28 @@ Consider naming this operation or using "graphql.operation()" request handler to
     )
   }
 
-  protected extendInfo(
-    _request: Request,
-    parsedResult: ParsedGraphQLRequest<GraphQLVariables>,
-  ) {
+  protected extendInfo(args: {
+    request: Request
+    parsedResult: ParsedGraphQLRequest<GraphQLVariables>
+  }) {
     return {
-      query: parsedResult?.query || '',
-      operationName: parsedResult?.operationName || '',
-      variables: parsedResult?.variables || {},
+      query: args.parsedResult?.query || '',
+      operationName: args.parsedResult?.operationName || '',
+      variables: args.parsedResult?.variables || {},
     }
   }
 
-  async log(
-    request: Request,
-    response: Response,
-    parsedRequest: ParsedGraphQLRequest,
-  ) {
-    const loggedRequest = await serializeRequest(request)
-    const loggedResponse = await serializeResponse(response)
+  async log(args: {
+    request: Request
+    response: Response
+    parsedResult: ParsedGraphQLRequest
+  }) {
+    const loggedRequest = await serializeRequest(args.request)
+    const loggedResponse = await serializeResponse(args.response)
     const statusColor = getStatusCodeColor(loggedResponse.status)
-    const requestInfo = parsedRequest?.operationName
-      ? `${parsedRequest?.operationType} ${parsedRequest?.operationName}`
-      : `anonymous ${parsedRequest?.operationType}`
+    const requestInfo = args.parsedResult?.operationName
+      ? `${args.parsedResult?.operationType} ${args.parsedResult?.operationName}`
+      : `anonymous ${args.parsedResult?.operationType}`
 
     console.groupCollapsed(
       devUtils.formatMessage('%s %s (%c%s%c)'),

--- a/src/core/handlers/HttpHandler.ts
+++ b/src/core/handlers/HttpHandler.ts
@@ -106,14 +106,17 @@ export class HttpHandler extends RequestHandler<
     )
   }
 
-  async parse(request: Request, resolutionContext?: ResponseResolutionContext) {
-    const url = new URL(request.url)
+  async parse(args: {
+    request: Request
+    resolutionContext?: ResponseResolutionContext
+  }) {
+    const url = new URL(args.request.url)
     const match = matchRequestUrl(
       url,
       this.info.path,
-      resolutionContext?.baseUrl,
+      args.resolutionContext?.baseUrl,
     )
-    const cookies = getAllRequestCookies(request)
+    const cookies = getAllRequestCookies(args.request)
 
     return {
       match,
@@ -121,9 +124,9 @@ export class HttpHandler extends RequestHandler<
     }
   }
 
-  predicate(request: Request, parsedResult: HttpRequestParsedResult) {
-    const hasMatchingMethod = this.matchMethod(request.method)
-    const hasMatchingUrl = parsedResult.match.matches
+  predicate(args: { request: Request; parsedResult: HttpRequestParsedResult }) {
+    const hasMatchingMethod = this.matchMethod(args.request.method)
+    const hasMatchingUrl = args.parsedResult.match.matches
     return hasMatchingMethod && hasMatchingUrl
   }
 
@@ -133,26 +136,26 @@ export class HttpHandler extends RequestHandler<
       : isStringEqual(this.info.method, actualMethod)
   }
 
-  protected extendInfo(
-    _request: Request,
-    parsedResult: HttpRequestParsedResult,
-  ) {
+  protected extendInfo(args: {
+    request: Request
+    parsedResult: HttpRequestParsedResult
+  }) {
     return {
-      params: parsedResult.match?.params || {},
-      cookies: parsedResult.cookies,
+      params: args.parsedResult.match?.params || {},
+      cookies: args.parsedResult.cookies,
     }
   }
 
-  async log(request: Request, response: Response) {
-    const publicUrl = getPublicUrlFromRequest(request)
-    const loggedRequest = await serializeRequest(request)
-    const loggedResponse = await serializeResponse(response)
+  async log(args: { request: Request; response: Response }) {
+    const publicUrl = getPublicUrlFromRequest(args.request)
+    const loggedRequest = await serializeRequest(args.request)
+    const loggedResponse = await serializeResponse(args.response)
     const statusColor = getStatusCodeColor(loggedResponse.status)
 
     console.groupCollapsed(
       devUtils.formatMessage('%s %s %s (%c%s%c)'),
       getTimestamp(),
-      request.method,
+      args.request.method,
       publicUrl,
       `color:${statusColor}`,
       `${loggedResponse.status} ${loggedResponse.statusText}`,

--- a/src/core/handlers/HttpHandler.ts
+++ b/src/core/handlers/HttpHandler.ts
@@ -136,7 +136,7 @@ export class HttpHandler extends RequestHandler<
       : isStringEqual(this.info.method, actualMethod)
   }
 
-  protected extendInfo(args: {
+  protected extendResolverArgs(args: {
     request: Request
     parsedResult: HttpRequestParsedResult
   }) {

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -122,50 +122,55 @@ export abstract class RequestHandler<
   /**
    * Determine if the intercepted request should be mocked.
    */
-  abstract predicate(
-    request: Request,
-    parsedResult: ParsedResult,
-    resolutionContext?: ResponseResolutionContext,
-  ): boolean
+  abstract predicate(args: {
+    request: Request
+    parsedResult: ParsedResult
+    resolutionContext?: ResponseResolutionContext
+  }): boolean
 
   /**
    * Print out the successfully handled request.
    */
-  abstract log(
-    request: Request,
-    response: Response,
-    parsedResult: ParsedResult,
-  ): void
+  abstract log(args: {
+    request: Request
+    response: Response
+    parsedResult: ParsedResult
+  }): void
 
   /**
    * Parse the intercepted request to extract additional information from it.
    * Parsed result is then exposed to other methods of this request handler.
    */
-  async parse(
-    _request: Request,
-    _resolutionContext?: ResponseResolutionContext,
-  ): Promise<ParsedResult> {
+  async parse(_args: {
+    request: Request
+    resolutionContext?: ResponseResolutionContext
+  }): Promise<ParsedResult> {
     return {} as ParsedResult
   }
 
   /**
    * Test if this handler matches the given request.
    */
-  public async test(
-    request: Request,
-    resolutionContext?: ResponseResolutionContext,
-  ): Promise<boolean> {
-    return this.predicate(
-      request,
-      await this.parse(request.clone(), resolutionContext),
-      resolutionContext,
-    )
+  public async test(args: {
+    request: Request
+    resolutionContext?: ResponseResolutionContext
+  }): Promise<boolean> {
+    const parsedResult = await this.parse({
+      request: args.request.clone(),
+      resolutionContext: args.resolutionContext,
+    })
+
+    return this.predicate({
+      request: args.request,
+      parsedResult,
+      resolutionContext: args.resolutionContext,
+    })
   }
 
-  protected extendInfo(
-    _request: Request,
-    _parsedResult: ParsedResult,
-  ): ResolverExtras {
+  protected extendInfo(_args: {
+    request: Request
+    parsedResult: ParsedResult
+  }): ResolverExtras {
     return {} as ResolverExtras
   }
 
@@ -173,30 +178,30 @@ export abstract class RequestHandler<
    * Execute this request handler and produce a mocked response
    * using the given resolver function.
    */
-  public async run(
-    request: StrictRequest<any>,
-    resolutionContext?: ResponseResolutionContext,
-  ): Promise<RequestHandlerExecutionResult<ParsedResult> | null> {
+  public async run(args: {
+    request: StrictRequest<any>
+    resolutionContext?: ResponseResolutionContext
+  }): Promise<RequestHandlerExecutionResult<ParsedResult> | null> {
     if (this.isUsed && this.options?.once) {
       return null
     }
 
-    const mainRequestRef = request.clone()
+    const mainRequestRef = args.request.clone()
 
     // Immediately mark the handler as used.
     // Can't await the resolver to be resolved because it's potentially
     // asynchronous, and there may be multiple requests hitting this handler.
     this.isUsed = true
 
-    const parsedResult = await this.parse(
-      mainRequestRef.clone(),
-      resolutionContext,
-    )
-    const shouldInterceptRequest = this.predicate(
-      mainRequestRef.clone(),
+    const parsedResult = await this.parse({
+      request: mainRequestRef.clone(),
+      resolutionContext: args.resolutionContext,
+    })
+    const shouldInterceptRequest = this.predicate({
+      request: mainRequestRef.clone(),
       parsedResult,
-      resolutionContext,
-    )
+      resolutionContext: args.resolutionContext,
+    })
 
     if (!shouldInterceptRequest) {
       return null
@@ -206,19 +211,22 @@ export abstract class RequestHandler<
     // since it can be both an async function and a generator.
     const executeResolver = this.wrapResolver(this.resolver)
 
-    const resolverExtras = this.extendInfo(request, parsedResult)
+    const resolverExtras = this.extendInfo({
+      request: args.request,
+      parsedResult,
+    })
     const mockedResponse = (await executeResolver({
       ...resolverExtras,
-      request,
+      request: args.request,
     })) as Response
 
-    const executionResult = this.createExecutionResult(
+    const executionResult = this.createExecutionResult({
       // Pass the cloned request to the result so that logging
       // and other consumers could read its body once more.
-      mainRequestRef,
+      request: mainRequestRef,
+      response: mockedResponse,
       parsedResult,
-      mockedResponse,
-    )
+    })
 
     return executionResult
   }
@@ -272,16 +280,16 @@ export abstract class RequestHandler<
     }
   }
 
-  private createExecutionResult(
-    request: Request,
-    parsedResult: ParsedResult,
-    response?: Response,
-  ): RequestHandlerExecutionResult<ParsedResult> {
+  private createExecutionResult(args: {
+    request: Request
+    parsedResult: ParsedResult
+    response?: Response
+  }): RequestHandlerExecutionResult<ParsedResult> {
     return {
       handler: this,
-      parsedResult,
-      request,
-      response,
+      request: args.request,
+      response: args.response,
+      parsedResult: args.parsedResult,
     }
   }
 }

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -167,7 +167,7 @@ export abstract class RequestHandler<
     })
   }
 
-  protected extendInfo(_args: {
+  protected extendResolverArgs(_args: {
     request: Request
     parsedResult: ParsedResult
   }): ResolverExtras {
@@ -211,7 +211,7 @@ export abstract class RequestHandler<
     // since it can be both an async function and a generator.
     const executeResolver = this.wrapResolver(this.resolver)
 
-    const resolverExtras = this.extendInfo({
+    const resolverExtras = this.extendResolverArgs({
       request: args.request,
       parsedResult,
     })

--- a/src/core/utils/getResponse.ts
+++ b/src/core/utils/getResponse.ts
@@ -25,7 +25,7 @@ export const getResponse = async <Handler extends Array<RequestHandler>>(
   let result: RequestHandlerExecutionResult<any> | null = null
 
   for (const handler of handlers) {
-    result = await handler.run(request, resolutionContext)
+    result = await handler.run({ request, resolutionContext })
 
     // If the handler produces some result for this request,
     // it automatically becomes matching.

--- a/src/core/utils/getResponse.ts
+++ b/src/core/utils/getResponse.ts
@@ -5,7 +5,7 @@ import {
 
 export interface ResponseLookupResult {
   handler: RequestHandler
-  parsedRequest?: any
+  parsedResult?: any
   response?: Response
 }
 
@@ -46,7 +46,7 @@ export const getResponse = async <Handler extends Array<RequestHandler>>(
   if (matchingHandler) {
     return {
       handler: matchingHandler,
-      parsedRequest: result?.parsedResult,
+      parsedResult: result?.parsedResult,
       response: result?.response,
     }
   }

--- a/src/core/utils/handleRequest.test.ts
+++ b/src/core/utils/handleRequest.test.ts
@@ -187,7 +187,7 @@ test('returns the mocked response for a request with a matching request handler'
     handler: handlers[0],
     response: mockedResponse,
     request,
-    parsedRequest: {
+    parsedResult: {
       match: { matches: true, params: {} },
       cookies: {},
     },
@@ -222,7 +222,7 @@ test('returns the mocked response for a request with a matching request handler'
 
   expect(lookupResultParam).toEqual({
     handler: lookupResult.handler,
-    parsedRequest: lookupResult.parsedRequest,
+    parsedResult: lookupResult.parsedResult,
     response: expect.objectContaining({
       status: lookupResult.response.status,
       statusText: lookupResult.response.statusText,
@@ -252,7 +252,7 @@ test('returns a transformed response if the "transformResponse" option is provid
     handler: handlers[0],
     response: mockedResponse,
     request,
-    parsedRequest: {
+    parsedResult: {
       match: { matches: true, params: {} },
       cookies: {},
     },
@@ -305,7 +305,7 @@ test('returns a transformed response if the "transformResponse" option is provid
 
   expect(lookupResultParam).toEqual({
     handler: lookupResult.handler,
-    parsedRequest: lookupResult.parsedRequest,
+    parsedResult: lookupResult.parsedResult,
     response: expect.objectContaining({
       status: lookupResult.response.status,
       statusText: lookupResult.response.statusText,


### PR DESCRIPTION
## Motivation

I'd like for the `RequestHandler` to become a public API in v2.0. For that, I'm adjusting the class' method arguments to accept a single object. They become more scalable this way. 