### PR TITLE
fix(worker): replace `Math.random()` with `crypto.randomUUID()`

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -107,7 +107,7 @@ self.addEventListener('fetch', function (event) {
   }
 
   // Generate unique request ID.
-  const requestId = Math.random().toString(16).slice(2)
+  const requestId = crypto.randomUUID()
   event.respondWith(handleRequest(event, requestId))
 })
 


### PR DESCRIPTION
Replace  `Math.random()` with `with crypto.randomUUID()` in `mockServiceWorker.js` file.

It's known that Math.Random isn't secure (see https://v8.dev/blog/math-random). Even if this file isn't supposed to be deployed in production, some static code analysis tools may flag this as a critical issue, breaking CI pipelines.