### PR TITLE
fix(setupServer): set max listeners on the "request.signal"

### DIFF
--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -156,7 +156,7 @@ export abstract class RequestHandler<
     resolutionContext?: ResponseResolutionContext
   }): Promise<boolean> {
     const parsedResult = await this.parse({
-      request: args.request.clone(),
+      request: args.request,
       resolutionContext: args.resolutionContext,
     })
 
@@ -186,6 +186,8 @@ export abstract class RequestHandler<
       return null
     }
 
+    // Clone the request instance before it's passed to the handler phases
+    // and the response resolver so we can always read it for logging.
     const mainRequestRef = args.request.clone()
 
     // Immediately mark the handler as used.
@@ -194,11 +196,11 @@ export abstract class RequestHandler<
     this.isUsed = true
 
     const parsedResult = await this.parse({
-      request: mainRequestRef.clone(),
+      request: args.request,
       resolutionContext: args.resolutionContext,
     })
     const shouldInterceptRequest = this.predicate({
-      request: mainRequestRef.clone(),
+      request: args.request,
       parsedResult,
       resolutionContext: args.resolutionContext,
     })

--- a/test/node/msw-api/many-request-handlers.test.ts
+++ b/test/node/msw-api/many-request-handlers.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+import { graphql, http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+// Create a large number of request handlers.
+const restHandlers = new Array(100).fill(null).map((_, index) => {
+  return http.post(
+    `https://example.com/resource/${index}`,
+    async ({ request }) => {
+      const text = await request.text()
+      return HttpResponse.text(text + index.toString())
+    },
+  )
+})
+
+const graphqlHanlers = new Array(100).fill(null).map((_, index) => {
+  return graphql.query(`Get${index}`, () => {
+    return HttpResponse.json({ data: { index } })
+  })
+})
+
+const server = setupServer(...restHandlers, ...graphqlHanlers)
+
+beforeAll(() => {
+  server.listen()
+  jest.spyOn(process.stderr, 'write')
+})
+
+afterAll(() => {
+  server.close()
+  jest.restoreAllMocks()
+})
+
+it('does not print a memory leak warning when having many request handlers', async () => {
+  const httpResponse = await fetch('https://example.com/resource/42', {
+    method: 'POST',
+    body: 'request-body-',
+  }).then((response) => response.text())
+
+  const graphqlResponse = await fetch('https://example.com', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: `query Get42 { index }`,
+    }),
+  }).then((response) => response.json())
+
+  // Must not print any memory leak warnings.
+  expect(process.stderr.write).not.toHaveBeenCalled()
+
+  // Must return the mocked response.
+  expect(httpResponse).toBe('request-body-42')
+  expect(graphqlResponse).toEqual({ data: { index: 42 } })
+})


### PR DESCRIPTION
- Fixes #1760

Fixes the issue when having a large number of request handlers would result in the following error from Node when processing an intercepting request:

```
(node:3158) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal].
```

## Why was this error printed?

When a large number of event listeners is added to any target, Node preemptively prints an error letting you know that something may be off (a potential memory leak). However, in the case of the request handlers, we are expecting at least a N `abort` event listener to be added to the original `request.signal` because every request handler clones the intercepted request at least once (so it could read its body when logging it).

## How is this fixed?

By using `require('events').setMaxListeners()` on the `request.signal`. 