### PR TITLE
fix: transfer response buffer on safari

### DIFF
--- a/src/browser/setupWorker/glossary.ts
+++ b/src/browser/setupWorker/glossary.ts
@@ -72,7 +72,7 @@ export type ServiceWorkerOutgoingEventTypes =
   | 'CLIENT_CLOSED'
 
 export interface StringifiedResponse extends ResponseInit {
-  body: string | ReadableStream<Uint8Array> | null
+  body: string | ArrayBuffer | ReadableStream<Uint8Array> | null
 }
 
 /**

--- a/src/browser/setupWorker/glossary.ts
+++ b/src/browser/setupWorker/glossary.ts
@@ -147,6 +147,9 @@ export interface SetupWorkerInternalContext {
     >
   }
   useFallbackMode: boolean
+  supports: {
+    readableStreamTransfer: boolean
+  }
   fallbackInterceptor?: Interceptor<HttpRequestEventMap>
 }
 

--- a/src/browser/setupWorker/glossary.ts
+++ b/src/browser/setupWorker/glossary.ts
@@ -146,8 +146,8 @@ export interface SetupWorkerInternalContext {
       ServiceWorkerMessage<EventType, ServiceWorkerIncomingEventsMap[EventType]>
     >
   }
-  useFallbackMode: boolean
   supports: {
+    serviceWorkerApi: boolean
     readableStreamTransfer: boolean
   }
   fallbackInterceptor?: Interceptor<HttpRequestEventMap>

--- a/src/browser/setupWorker/setupWorker.ts
+++ b/src/browser/setupWorker/setupWorker.ts
@@ -20,6 +20,7 @@ import { SetupApi } from '~/core/SetupApi'
 import { mergeRight } from '~/core/utils/internal/mergeRight'
 import { LifeCycleEventsMap } from '~/core/sharedOptions'
 import { SetupWorker } from './glossary'
+import { supportsReadableStreamTransfer } from '../utils/supportsReadableStreamTransfer'
 
 interface Listener {
   target: EventTarget
@@ -144,6 +145,9 @@ export class SetupWorkerApi
       },
       useFallbackMode:
         !('serviceWorker' in navigator) || location.protocol === 'file:',
+      supports: {
+        readableStreamTransfer: supportsReadableStreamTransfer(),
+      },
     }
 
     /**

--- a/src/browser/setupWorker/setupWorker.ts
+++ b/src/browser/setupWorker/setupWorker.ts
@@ -143,9 +143,9 @@ export class SetupWorkerApi
           })
         },
       },
-      useFallbackMode:
-        !('serviceWorker' in navigator) || location.protocol === 'file:',
       supports: {
+        serviceWorkerApi:
+          !('serviceWorker' in navigator) || location.protocol === 'file:',
         readableStreamTransfer: supportsReadableStreamTransfer(),
       },
     }
@@ -160,11 +160,11 @@ export class SetupWorkerApi
       },
     })
 
-    this.startHandler = context.useFallbackMode
+    this.startHandler = context.supports.serviceWorkerApi
       ? createFallbackStart(context)
       : createStartHandler(context)
 
-    this.stopHandler = context.useFallbackMode
+    this.stopHandler = context.supports.serviceWorkerApi
       ? createFallbackStop(context)
       : createStop(context)
 

--- a/src/browser/setupWorker/start/createRequestListener.ts
+++ b/src/browser/setupWorker/start/createRequestListener.ts
@@ -12,7 +12,6 @@ import { handleRequest } from '~/core/utils/handleRequest'
 import { RequiredDeep } from '~/core/typeUtils'
 import { devUtils } from '~/core/utils/internal/devUtils'
 import { toResponseInit } from '~/core/utils/toResponseInit'
-import { supportsReadableStreamTransfer } from '../../utils/supportsReadableStreamTransfer'
 
 export const createRequestListener = (
   context: SetupWorkerInternalContext,
@@ -53,7 +52,7 @@ export const createRequestListener = (
              * @note Safari doesn't support transferring a "ReadableStream".
              * Check that the browser supports that before sending it to the worker.
              */
-            if (supportsReadableStreamTransfer()) {
+            if (context.supports.readableStreamTransfer) {
               const responseStream = response.body
               messageChannel.postMessage(
                 'MOCK_RESPONSE',

--- a/src/browser/utils/supportsReadableStreamTransfer.ts
+++ b/src/browser/utils/supportsReadableStreamTransfer.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns a boolean indicating whether the current browser
+ * supports `ReadableStream` as a `Transferable` when posting
+ * messages.
+ */
+export function supportsReadableStreamTransfer() {
+  try {
+    const stream = new ReadableStream({
+      start: (controller) => controller.close(),
+    })
+    const message = new MessageChannel()
+    message.port1.postMessage(stream, [stream])
+    return true
+  } catch (error) {
+    return false
+  }
+}


### PR DESCRIPTION
- Fixes #1757
- Related to #1436 
- Originally reported [here](https://github.com/mswjs/msw/pull/1436#issuecomment-1762701825)

## Motivation

Fixes an issue where sending a `ReadableStream` via `messageChannel.port1.postMessage()` throws the following error on Safari:

```
DataCloneError: The object can not be cloned.
```

## Solution

MSW will run a quick supports check for `ReadableStream` as transferable. If it fails, MSW will read the mocked response's `ArrayBuffer` body and send it _at once_ to the worker. This still means that mocking streams won't work in Safari as reading the response body will exhaust its stream so it loses the chunks/timings information when the client will receive it. 

That's acceptable since it's an issue in Safari and must be addressed there. 

