### PR TITLE
fix(core): export the "RequestHandlerOptions" type

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -32,7 +32,6 @@ export type {
 export type {
   RequestQuery,
   HttpRequestParsedResult,
-  HttpRequestResolverExtras,
 } from './handlers/HttpHandler'
 
 export type {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,6 +24,7 @@ export type {
   ResponseResolver,
   ResponseResolverReturnType,
   AsyncResponseResolverReturnType,
+  RequestHandlerOptions,
   DefaultBodyType,
   DefaultRequestMultipartBody,
 } from './handlers/RequestHandler'
@@ -31,6 +32,7 @@ export type {
 export type {
   RequestQuery,
   HttpRequestParsedResult,
+  HttpRequestResolverExtras,
 } from './handlers/HttpHandler'
 
 export type {


### PR DESCRIPTION
## What has changed`

This PR adds additional exports for the `HttpRequestResolverExtras` and `RequestHandlerOptions` to the main package export.

## Why has this changed?

I am currently in the process of writing a small wrapper around MSW's `http` methods that is supposed to use type definitions generated from an OpenAPI spec with [openapi-ts](https://openapi-ts.pages.dev/). The goal is to be able to have conflicts in http-handler definitions when they are no longer compatible with the OpenAPI spec. Here is some pseudocode that hopefully provides an idea about my intention with "wrapping msw":

```ts 
import {
  http as http,
  type HttpHandler,
  type ResponseResolver,
  type DefaultBodyType,
} from "msw"; 

function createOpenApiHttp<ApiDef>() {
  return {
    get: <Path extends PathsFromApiDef>(
      path: Path,
      resolver: ResponseResolver<
        PathParamsFromApiDefForPath<Path>,
        RequestBodyFromApiDefForPath<Path>,
        ResponseFromApiDefForPath<Path>
      >,
      options: RequestHandlerOptions
      //        ^ Interface cannot be imported because it is not exported
    ): HttpHandler => http.get(path as string, resolver, options),
     //                                            ^ resolver cannot be
     // passed to http.get(...) because the params generic
     // is not wrapped with `HttpRequestResolverExtras`, which not exported


    // ... other methods that exist on http
  }
}
```

I am open for other ideas that make it possible to wrap the http methods without exporting the two additional interfaces. However, this is the only solutions that I found, unless it is somehow possible nowadays to provide generic arguments to `typeof http["get"]"`, i.e. `<never, never, never>(typeof http["get"])`.

Should we rather export some new type helpers than these additional two interfaces? I open for your suggestions.