### PR TITLE
feat(HttpResponse): add empty response helper for strict empty responses

### DIFF
--- a/src/core/HttpResponse.test.ts
+++ b/src/core/HttpResponse.test.ts
@@ -30,6 +30,22 @@ it('creates a json response', async () => {
   expect(await response.json()).toEqual({ firstName: 'John' })
 })
 
+it('creates an empty response with no-content status', async () => {
+  const response = HttpResponse.empty()
+
+  expect(response.status).toBe(204)
+  expect(response.statusText).toBe('No Content')
+  expect(response.body).toBeNull()
+})
+
+it('creates an empty response with overwritten status', async () => {
+  const response = HttpResponse.empty({ status: 201 })
+
+  expect(response.status).toBe(201)
+  expect(response.statusText).toBe('Created')
+  expect(response.body).toBeNull()
+})
+
 it('creates an xml response', async () => {
   const response = HttpResponse.xml('<user name="John" />')
 

--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -75,6 +75,20 @@ export class HttpResponse extends Response {
   }
 
   /**
+   * Create a `Response` with an empty body and status code 204 by default.
+   * @example
+   * HttpResponse.empty()
+   * HttpResponse.empty({ status: 201 })
+   */
+  static empty(init?: HttpResponseInit): StrictResponse<null> {
+    const noContentInit: HttpResponseInit = init
+      ? { ...init, status: init.status ?? 204 }
+      : { status: 204 }
+    const responseInit = normalizeResponseInit(noContentInit)
+    return new HttpResponse(null, responseInit) as StrictResponse<null>
+  }
+
+  /**
    * Create a `Response` with a `Content-Type: "application/xml"` body.
    * @example
    * HttpResponse.xml(`<user name="John" />`)

--- a/test/browser/rest-api/response/body/body-empty.mocks.ts
+++ b/test/browser/rest-api/response/body/body-empty.mocks.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from 'msw'
+import { setupWorker } from 'msw/browser'
+
+const worker = setupWorker(
+  http.get('/empty', () => {
+    return HttpResponse.empty()
+  }),
+)
+
+worker.start()

--- a/test/browser/rest-api/response/body/body-empty.test.ts
+++ b/test/browser/rest-api/response/body/body-empty.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '../../../playwright.extend'
+
+test('responds with a empty response body', async ({ loadExample, fetch }) => {
+  await loadExample(require.resolve('./body-empty.mocks.ts'))
+
+  const res = await fetch('/empty')
+  const headers = await res.allHeaders()
+
+  expect(res.status()).toBe(204)
+  expect(headers).not.toHaveProperty('content-type')
+  await expect(res.json()).rejects.toThrowError(
+    'No data found for resource with given identifier',
+  )
+})

--- a/test/node/rest-api/response/body-empty.node.test.ts
+++ b/test/node/rest-api/response/body-empty.node.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+import fetch from 'node-fetch'
+import { HttpResponse, http } from 'msw'
+import { setupServer } from 'msw/node'
+
+const server = setupServer(
+  http.get('http://localhost/empty', () => {
+    return HttpResponse.empty()
+  }),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+test('responds with an empty response body', async () => {
+  const res = await fetch('http://localhost/empty')
+  const body = await res.buffer()
+
+  expect(res.status).toBe(204)
+  expect(res.headers.get('content-type')).toBeNull()
+  expect(body.byteLength).toBe(0)
+})

--- a/test/typings/rest.test-d.ts
+++ b/test/typings/rest.test-d.ts
@@ -119,3 +119,13 @@ http.get<never, never, string | string[]>('/user', () =>
 http.get<never, never, { label: boolean }>('/user', () =>
   HttpResponse.json({ label: true }),
 )
+
+// Empty response body requires a strict response
+http.get<never, never, null>(
+  '/user',
+  // @ts-expect-error HttpResponse is not StrictResponse<null>
+  () => new HttpResponse(),
+)
+
+// Empty response can be used for en empty response body
+http.get<never, never, null>('/user', () => HttpResponse.empty())


### PR DESCRIPTION
This PR adds a helper that makes it possible to create a `StrictResponse<null>` response without a content header or type casting.

### Motivation

We have some scenarios where handlers return responses without a body. This appears to be best enforced by typing the response body for resolver functions with `null`.

```typescript
// Typing the body with "never" does not allow any response...
http.delete<never, never, never>('/resource', () => {
  return new HttpResponse(); // Errors
});

// Typing the body with "undefined" (or providing nothing) does allow responses with any body...
http.delete<never, never>('/resource', () => {
  return HttpResponse.json({id: 42}); // Should not be allowed since not empty
});

// Typing the body with "null" achieves what we are looking for
http.delete<never, never, null>('/resource', () => {
  return HttpResponse.json(null, { status: 204 }); // Works but also sets the content-type
  return new HttpResponse(null, {status: 204}) as StrictResponse<null>; // Works but needs casting
});
```

However, as you can see in the example, creating a response that satisfies the resolver either also sets a content-type or requires casting. Neither of these downsides should be required to create an empty response. Therefore, this PR adds `HttpResponse.empty` to work around this downsides, which also sets the default status to 204 as a little bonus.

```typescript
http.delete<never, never, null>('/resource', () => {
  return HttpResponse.empty(); // Returns StrictsReponse<null> with 204
});

http.post<never, never, null>('/resource', () => {
  return HttpResponse.empty({ status: 201 }); // Returns StrictResponse<null> with 201
});
```

If you agree on adding this to MSW, I can create the relevant PR for updating the documentation for `HttpResponse.empty`.