### PR TITLE
fix: correctly check "undefined" as response body type

### DIFF
--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -30,7 +30,7 @@ export interface RequestHandlerInternalInfo {
 export type ResponseResolverReturnType<
   BodyType extends DefaultBodyType = undefined,
 > =
-  | (BodyType extends undefined ? Response : StrictResponse<BodyType>)
+  | ([BodyType] extends [undefined] ? Response : StrictResponse<BodyType>)
   | undefined
   | void
 
@@ -265,7 +265,7 @@ export abstract class RequestHandler<
 
           // Clone the previously stored response from the generator
           // so that it could be read again.
-          return this.resolverGeneratorResult.clone()
+          return this.resolverGeneratorResult.clone() as StrictResponse<any>
         }
 
         if (!this.resolverGenerator) {

--- a/test/typings/regressions/response-body-type.test-d.ts
+++ b/test/typings/regressions/response-body-type.test-d.ts
@@ -1,0 +1,10 @@
+/**
+ * @see https://github.com/mswjs/msw/issues/1823
+ */
+import { http, Path, HttpResponse, DefaultBodyType } from 'msw'
+
+function myHandler<CustomResponseBodyType extends DefaultBodyType>(path: Path) {
+  return (response: CustomResponseBodyType) => {
+    http.get(path, () => HttpResponse.json(response))
+  }
+}


### PR DESCRIPTION
- Fixes #1823

## Why still check if `[undefined`] and not `[never]`?

Because `never` is an explicit "this response must _not_ have any body". This is a narrower response body type and it must use the `StrictResponse<never>` internal type if it's provided. 

`undefined` is the _default_ (fallback) response body type. This means that by default, we don't know what type the response body will be, so `undefined` is equivalent to a plain `Response`. 