### PR TITLE
fix: export missing "GraphQLResolverExtras" and "GraphQLResponseBody" types

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -38,6 +38,8 @@ export type {
   GraphQLVariables,
   GraphQLRequestBody,
   GraphQLJsonRequestBody,
+  GraphQLResolverExtras,
+  GraphQLResponseBody,
 } from './handlers/GraphQLHandler'
 
 export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'


### PR DESCRIPTION
### Problem
The resolver function for GraphQL is typed as
```ts
type resolver = ResponseResolver<
    GraphQLResolverExtras<Variables>,
    null,
    GraphQLResponseBody<Query>
  >
```
I want to be able to have a wrapper that takes in a resolver function, but I can't properly type it without being able to import the `GraphQLResolverExtras` and `GraphQLResponseBody` types.

### Solution
Export the needed types.