### PR TITLE
fix: allow overriding "Content-Type" in HttpResponse static methods

### DIFF
--- a/src/core/HttpResponse.test.ts
+++ b/src/core/HttpResponse.test.ts
@@ -13,15 +13,33 @@ it('creates a plain response', async () => {
   expect(Object.fromEntries(response.headers.entries())).toEqual({})
 })
 
-it('creates a text response', async () => {
-  const response = HttpResponse.text('hello world', { status: 201 })
+describe('HttpResponse.text()', () => {
+  it('creates a text response', async () => {
+    const response = HttpResponse.text('hello world', { status: 201 })
 
-  expect(response.status).toBe(201)
-  expect(response.statusText).toBe('Created')
-  expect(response.body).toBeInstanceOf(ReadableStream)
-  expect(await response.text()).toBe('hello world')
-  expect(Object.fromEntries(response.headers.entries())).toEqual({
-    'content-type': 'text/plain',
+    expect(response.status).toBe(201)
+    expect(response.statusText).toBe('Created')
+    expect(response.body).toBeInstanceOf(ReadableStream)
+    expect(await response.text()).toBe('hello world')
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-type': 'text/plain',
+    })
+  })
+
+  it('allows overriding the "Content-Type" response header', async () => {
+    const response = HttpResponse.text('hello world', {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.statusText).toBe('OK')
+    expect(response.body).toBeInstanceOf(ReadableStream)
+    expect(await response.text()).toBe('hello world')
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-type': 'text/plain; charset=utf-8',
+    })
   })
 })
 
@@ -97,17 +115,54 @@ describe('HttpResponse.json()', () => {
       'content-type': 'application/json',
     })
   })
+
+  it('allows overriding the "Content-Type" response header', async () => {
+    const response = HttpResponse.json(
+      { a: 1 },
+      {
+        headers: {
+          'Content-Type': 'application/hal+json',
+        },
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.statusText).toBe('OK')
+    expect(response.body).toBeInstanceOf(ReadableStream)
+    expect(await response.json()).toEqual({ a: 1 })
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-type': 'application/hal+json',
+    })
+  })
 })
 
-it('creates an xml response', async () => {
-  const response = HttpResponse.xml('<user name="John" />')
+describe('HttpResponse.xml()', () => {
+  it('creates an xml response', async () => {
+    const response = HttpResponse.xml('<user name="John" />')
 
-  expect(response.status).toBe(200)
-  expect(response.statusText).toBe('OK')
-  expect(response.body).toBeInstanceOf(ReadableStream)
-  expect(await response.text()).toBe('<user name="John" />')
-  expect(Object.fromEntries(response.headers.entries())).toEqual({
-    'content-type': 'text/xml',
+    expect(response.status).toBe(200)
+    expect(response.statusText).toBe('OK')
+    expect(response.body).toBeInstanceOf(ReadableStream)
+    expect(await response.text()).toBe('<user name="John" />')
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-type': 'text/xml',
+    })
+  })
+
+  it('allows overriding the "Content-Type" response header', async () => {
+    const response = HttpResponse.xml('<user name="John" />', {
+      headers: {
+        'Content-Type': 'text/xml; charset=utf-8',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.statusText).toBe('OK')
+    expect(response.body).toBeInstanceOf(ReadableStream)
+    expect(await response.text()).toBe('<user name="John" />')
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-type': 'text/xml; charset=utf-8',
+    })
   })
 })
 

--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -52,7 +52,11 @@ export class HttpResponse extends Response {
     init?: HttpResponseInit,
   ): StrictResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
-    responseInit.headers.set('Content-Type', 'text/plain')
+
+    if (!responseInit.headers.has('Content-Type')) {
+      responseInit.headers.set('Content-Type', 'text/plain')
+    }
+
     return new HttpResponse(body, responseInit) as StrictResponse<BodyType>
   }
 
@@ -67,7 +71,11 @@ export class HttpResponse extends Response {
     init?: HttpResponseInit,
   ): StrictResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
-    responseInit.headers.set('Content-Type', 'application/json')
+
+    if (!responseInit.headers.has('Content-Type')) {
+      responseInit.headers.set('Content-Type', 'application/json')
+    }
+
     return new HttpResponse(
       JSON.stringify(body),
       responseInit,
@@ -85,7 +93,11 @@ export class HttpResponse extends Response {
     init?: HttpResponseInit,
   ): Response {
     const responseInit = normalizeResponseInit(init)
-    responseInit.headers.set('Content-Type', 'text/xml')
+
+    if (!responseInit.headers.has('Content-Type')) {
+      responseInit.headers.set('Content-Type', 'text/xml')
+    }
+
     return new HttpResponse(body, responseInit)
   }
 


### PR DESCRIPTION
## Changes

- It's now possible to override the `Content-Type` response header when using `HttpResponse` static methods `.text()`, `.json()`, and `.xml()` (previously, overrides were ignored). 