### PR TITLE
fix: correct docs link for anonymous GraphQL operations

### DIFF
--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -132,7 +132,7 @@ export class GraphQLHandler extends RequestHandler<
       devUtils.warn(`\
 Failed to intercept a GraphQL request at "${args.request.method} ${publicUrl}": anonymous GraphQL operations are not supported.
 
-Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation`)
+Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/#graphqloperationresolver`)
       return false
     }
 

--- a/test/browser/graphql-api/anonymous-operation.test.ts
+++ b/test/browser/graphql-api/anonymous-operation.test.ts
@@ -83,7 +83,7 @@ Read more: https://mswjs.io/docs/getting-started/mocks`,
   //       expect.arrayContaining([
   //         `[MSW] Failed to intercept a GraphQL request at "POST ${endpointUrl}": anonymous GraphQL operations are not supported.
 
-  // Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation`,
+  // Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/#graphqloperationresolver`,
   //       ]),
   //     )
   //   })
@@ -146,7 +146,7 @@ test('warns on handled anonymous GraphQL operation', async ({
       expect.arrayContaining([
         `[MSW] Failed to intercept a GraphQL request at "POST ${endpointUrl}": anonymous GraphQL operations are not supported.
 
-Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation`,
+Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/#graphqloperationresolver`,
       ]),
     )
   })

--- a/test/browser/graphql-api/mutation.test.ts
+++ b/test/browser/graphql-api/mutation.test.ts
@@ -73,7 +73,7 @@ test('prints a warning when intercepted an anonymous GraphQL mutation', async ({
         `\
 [MSW] Failed to intercept a GraphQL request at "POST ${endpoint()}": anonymous GraphQL operations are not supported.
 
-Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation\
+Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/#graphqloperationresolver\
 `,
       ),
     ]),

--- a/test/browser/graphql-api/query.test.ts
+++ b/test/browser/graphql-api/query.test.ts
@@ -109,7 +109,7 @@ test('prints a warning when intercepted an anonymous GraphQL query', async ({
         `\
 [MSW] Failed to intercept a GraphQL request at "POST ${endpoint()}": anonymous GraphQL operations are not supported.
 
-Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation`,
+Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/#graphqloperationresolver`,
       ),
     ]),
   )

--- a/test/node/graphql-api/anonymous-operations.test.ts
+++ b/test/node/graphql-api/anonymous-operations.test.ts
@@ -63,7 +63,7 @@ test('warns on unhandled anonymous GraphQL operations', async () => {
   expect(console.warn).toHaveBeenCalledWith(`\
 [MSW] Failed to intercept a GraphQL request at "POST ${endpointUrl}": anonymous GraphQL operations are not supported.
 
-Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/operation`)
+Consider naming this operation or using "graphql.operation()" request handler to intercept GraphQL requests regardless of their operation name/type. Read more: https://mswjs.io/docs/api/graphql/#graphqloperationresolver`)
 })
 
 test('does not print a warning when using anonymous operation with "graphql.operation()"', async () => {


### PR DESCRIPTION
Closes https://github.com/mswjs/mswjs.io/issues/280.

## Changes

Updated dead link to documentation when warning is logged from GraphQLHandler. Tests updated accordingly.