### PR TITLE
test: add axios upload test

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
     "@web/dev-server": "^0.1.38",
+    "axios": "^1.6.1",
     "babel-loader": "^8.2.3",
     "babel-minify": "^0.5.1",
     "commitizen": "^4.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ specifiers:
   '@typescript-eslint/eslint-plugin': ^5.11.0
   '@typescript-eslint/parser': ^5.11.0
   '@web/dev-server': ^0.1.38
+  axios: ^1.6.1
   babel-loader: ^8.2.3
   babel-minify: ^0.5.1
   chalk: ^4.1.2
@@ -121,6 +122,7 @@ devDependencies:
   '@typescript-eslint/eslint-plugin': 5.52.0_aaw67h7nkydj3qj4plp2jqjmxe
   '@typescript-eslint/parser': 5.52.0_jeuwjvsopuo23ctsjsevxmvjsi
   '@web/dev-server': 0.1.38
+  axios: 1.6.1
   babel-loader: 8.3.0_la66t7xldg4uecmyawueag5wkm
   babel-minify: 0.5.2
   commitizen: 4.3.0_@swc+core@1.3.35
@@ -3692,6 +3694,16 @@ packages:
   /available-typed-arrays/1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /axios/1.6.1:
+    resolution: {integrity: sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==}
+    dependencies:
+      follow-redirects: 1.15.2_debug@4.3.4
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
     dev: true
 
   /babel-helper-evaluate-path/0.5.0:
@@ -8452,6 +8464,10 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+    dev: true
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: true
 
   /prr/1.0.1:

--- a/test/browser/third-party/axios-upload.runtime.js
+++ b/test/browser/third-party/axios-upload.runtime.js
@@ -1,0 +1,43 @@
+import axios from 'axios'
+import { http, HttpResponse } from 'msw'
+import { setupWorker } from 'msw/browser'
+
+const worker = setupWorker(
+  http.post('/upload', async ({ request }) => {
+    const data = await request.formData()
+    const file = data.get('file')
+
+    if (!file) {
+      return new HttpResponse('Missing document upload', { status: 400 })
+    }
+
+    if (!(file instanceof File)) {
+      return new HttpResponse('Uploaded document is not a File', {
+        status: 400,
+      })
+    }
+
+    return HttpResponse.json({
+      message: `Successfully uploaded "${file.name}"!`,
+      content: await file.text(),
+    })
+  }),
+)
+worker.start()
+
+const progressEvents = []
+const request = axios.create({
+  baseURL: '/',
+  onDownloadProgress(event) {
+    progressEvents.push(event)
+  },
+})
+
+window.progressEvents = progressEvents
+window.upload = async function () {
+  const formData = new FormData()
+  const file = new Blob(['Hello', 'world'], { type: 'text/plain' })
+  formData.set('file', file, 'doc.txt')
+
+  return request.post('/upload', formData)
+}

--- a/test/node/third-party/axios-upload.node.test.ts
+++ b/test/node/third-party/axios-upload.node.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { File } from 'node:buffer'
+import axios from 'axios'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const server = setupServer(
+  http.post('https://example.com/upload', async ({ request }) => {
+    const data = await request.formData()
+    const file = data.get('file')
+
+    if (!file) {
+      return new HttpResponse('Missing document upload', { status: 400 })
+    }
+
+    if (!(file instanceof File)) {
+      return new HttpResponse('Uploaded document is not a File', {
+        status: 400,
+      })
+    }
+
+    return HttpResponse.json({
+      message: `Successfully uploaded "${file.name}"!`,
+      content: await file.text(),
+    })
+  }),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it('responds with a mocked response to an upload request', async () => {
+  const onUploadProgress = vi.fn()
+  const request = axios.create({
+    baseURL: 'https://example.com',
+    onUploadProgress,
+  })
+
+  const formData = new FormData()
+  const file = new Blob(['Hello', 'world'], { type: 'text/plain' })
+  formData.set('file', file, 'doc.txt')
+
+  const response = await request.post('/upload', formData)
+
+  expect(response.data).toEqual({
+    message: 'Successfully uploaded "doc.txt"!',
+    content: 'Helloworld',
+  })
+  expect(onUploadProgress).toHaveBeenCalledTimes(2)
+  expect(onUploadProgress).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      loaded: 50,
+      total: 209,
+      bytes: 50,
+    }),
+  )
+  expect(onUploadProgress).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      loaded: 209,
+      total: 209,
+      bytes: 159,
+    }),
+  )
+})

--- a/test/node/third-party/axios-upload.node.test.ts
+++ b/test/node/third-party/axios-upload.node.test.ts
@@ -51,21 +51,13 @@ it('responds with a mocked response to an upload request', async () => {
     message: 'Successfully uploaded "doc.txt"!',
     content: 'Helloworld',
   })
-  expect(onUploadProgress).toHaveBeenCalledTimes(2)
+  expect(onUploadProgress.mock.calls.length).toBeGreaterThan(0)
   expect(onUploadProgress).toHaveBeenNthCalledWith(
     1,
     expect.objectContaining({
-      loaded: 50,
-      total: 209,
-      bytes: 50,
-    }),
-  )
-  expect(onUploadProgress).toHaveBeenNthCalledWith(
-    2,
-    expect.objectContaining({
-      loaded: 209,
-      total: 209,
-      bytes: 159,
+      loaded: expect.any(Number),
+      total: expect.any(Number),
+      bytes: expect.any(Number),
     }),
   )
 })


### PR DESCRIPTION
- Adds node/browser integration tests featuring Axios upload request with `onUploadProgress` option set. 
- Closes #1613
- [File upload](https://mswjs.io/docs/recipes/file-uploads) recipe added to the docs.