### PR TITLE
fix: change request cookie type to be Record<string, string>

### DIFF
--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -35,7 +35,7 @@ export type GraphQLResolverExtras<Variables extends GraphQLVariables> = {
   query: string
   operationName: string
   variables: Variables
-  cookies: Record<string, string | Array<string>>
+  cookies: Record<string, string>
 }
 
 export type GraphQLRequestBody<VariablesType extends GraphQLVariables> =

--- a/src/core/handlers/HttpHandler.ts
+++ b/src/core/handlers/HttpHandler.ts
@@ -49,7 +49,7 @@ export type HttpRequestParsedResult = {
 
 export type HttpRequestResolverExtras<Params extends PathParams> = {
   params: Params
-  cookies: Record<string, string | Array<string>>
+  cookies: Record<string, string>
 }
 
 /**


### PR DESCRIPTION
Request cookie value types are currently incorrectly typed as `string | Array<string>`. This PR changes the request cookie value type to a simple `string`.

fix #1854