### PR TITLE
fix(graphql): allow null for "data" and "errors" response property types

### DIFF
--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -50,8 +50,8 @@ export interface GraphQLJsonRequestBody<Variables extends GraphQLVariables> {
 }
 
 export interface GraphQLResponseBody<BodyType extends DefaultBodyType> {
-  data?: BodyType
-  errors?: readonly Partial<GraphQLError>[]
+  data?: BodyType | null
+  errors?: readonly Partial<GraphQLError>[] | null
 }
 
 export function isDocumentNode(

--- a/test/typings/graphql.test-d.ts
+++ b/test/typings/graphql.test-d.ts
@@ -53,6 +53,13 @@ graphql.query<{ id: string }>('GetUser', () => {
   })
 })
 
+graphql.query<{ id: string }>('GetUser', () => {
+  return HttpResponse.json({
+    // Explicit null must be allowed.
+    data: null,
+  })
+})
+
 graphql.query<{ id: string }>(
   'GetUser',
   // @ts-expect-error "id" type is incorrect
@@ -87,6 +94,13 @@ graphql.query<{ key: string }>(
   },
 )
 
+graphql.mutation<{ key: string }>('MutateData', () => {
+  return HttpResponse.json({
+    // Explicit null in mutations must also be allowed.
+    data: null,
+  })
+})
+
 graphql.mutation<{ key: string }>(
   'MutateData',
   // @ts-expect-error Response data doesn't match the query type.
@@ -101,6 +115,10 @@ graphql.operation<{ key: string }>(
     return HttpResponse.json({ data: {} })
   },
 )
+
+graphql.operation<{ key: string }>(() => {
+  return HttpResponse.json({ data: null })
+})
 
 /**
  * Variables type.


### PR DESCRIPTION
Currently, providing `null` as the value of `data` or `errors` properties on the mocked GraphQL response causes a TypeScript error. That's because the types for those properties don't have the union with `null`:

https://github.com/mswjs/msw/blob/28efd320549ea1dd1b2afacfdbdf62a05977e03c/src/core/handlers/GraphQLHandler.ts#L52-L55

This also makes them incompatible with the `ExecutionResult` from the `graphql` package. 