### PR TITLE
fix: node:events segfault

### DIFF
--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -61,6 +61,11 @@ export interface SetupServer {
   events: LifeCycleEventEmitter<LifeCycleEventsMap>
 }
 
-export type SetupServerInternalContext = {
-  get nodeEvents(): Promise<typeof import('node:events') | undefined>
-}
+export type SetupServerContext = Readonly<{
+  nodeEvents:
+    | Pick<
+        typeof import('node:events'),
+        'setMaxListeners' | 'defaultMaxListeners'
+      >
+    | undefined
+}>

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,10 +1,10 @@
 import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
 import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
 import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+import { defaultMaxListeners, setMaxListeners } from 'node:events'
 import { RequestHandler } from '~/core/handlers/RequestHandler'
-import { SetupServer } from './glossary'
 import { SetupServerApi } from './SetupServerApi'
-
+import { SetupServer } from './glossary'
 /**
  * Sets up a requests interception in Node.js with the given request handlers.
  * @param {RequestHandler[]} handlers List of request handlers.
@@ -17,5 +17,10 @@ export const setupServer = (
   return new SetupServerApi(
     [ClientRequestInterceptor, XMLHttpRequestInterceptor, FetchInterceptor],
     ...handlers,
-  )
+  ).withContext({
+    nodeEvents: {
+      setMaxListeners,
+      defaultMaxListeners,
+    },
+  })
 }

--- a/test/node/native/native.node.test.ts
+++ b/test/node/native/native.node.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { http } from 'msw'
+import { setupServer } from 'msw/native'
+import { stringToHeaders } from 'headers-polyfill'
+
+const server = setupServer(
+  http.get('http://localhost:3001/resource', ({ request }) => {
+    return new Response(
+      JSON.stringify({
+        firstName: 'John',
+        age: 32,
+      }),
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Header': 'yes',
+        },
+      },
+    )
+  }),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('given I perform an XMLHttpRequest', () => {
+  let statusCode: number
+  let headers: Headers
+  let body: string
+
+  beforeAll(async () => {
+    const req = new XMLHttpRequest()
+    req.open('GET', 'http://localhost:3001/resource')
+
+    const requestFinishPromise = new Promise<void>((resolve, reject) => {
+      req.onload = function () {
+        statusCode = this.status
+        body = JSON.parse(this.response)
+        headers = stringToHeaders(this.getAllResponseHeaders())
+        resolve()
+      }
+      req.onerror = reject.bind(req)
+    })
+    req.send()
+
+    await requestFinishPromise
+  })
+
+  test('returns mocked status code', () => {
+    expect(statusCode).toEqual(401)
+  })
+
+  test('returns mocked headers', () => {
+    expect(headers.get('content-type')).toEqual('application/json')
+    expect(headers.get('x-header')).toEqual('yes')
+  })
+
+  test('returns mocked body', () => {
+    expect(body).toEqual({
+      firstName: 'John',
+      age: 32,
+    })
+  })
+})


### PR DESCRIPTION
fixes https://github.com/mswjs/msw/issues/1868

In https://github.com/mswjs/msw/pull/1858 we tried to work around the fact that `node:events` is not defined in `react-native` by default, leading to that environment throwing on setup. 

The fix applied previously was to dynamically import and test for those properties before accessing.  This is entirely functional, and should work, but from what I can gather from discussion and separate research, some node/jest combinations (and I wasn't really sure where this comes into play directly) cause tests to segfault on dynamic imports of builtin modules.   

While this is not something wrong with `msw` I think if we can find an alternative, we should try that out.  We also don't have much of a test suite for the `native` export, and maybe need to figure out how to support that - not sure if vite has a good path setup for that yet, but I think we need something to do it. 

I've suggested an alternative strategy here. I don't love it, but It's a non-breaking change and should hopefully help in this case. 

Ideally, an additional constructor argument to `SetupServerApi` would probably be the way to go, but since we expose `SetupServerApi` that would be a breaking change.  I think this provides enough value to ship now, and we can make those changes at the next major, if we decide to do this now.  Maybe we could do this purely additively as well, and i'll open a [second PR](https://github.com/mswjs/msw/pull/1880) to this one that tries that approach also.


There may be other alternatives here to explore, however this seemed like one of the simpler options overall

I also added a simple test for `msw/native`'s call to setupServer, just to have one.  it's in the wrong place (in the `test/node` folder) and isn't a native-like environment, but this seemed like the most straightforward place for adding this simple test case, for now