### PR TITLE
fix: inject node:event dependencies through `SetupServerApi` first argument in constructor

### DIFF
--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -61,6 +61,11 @@ export interface SetupServer {
   events: LifeCycleEventEmitter<LifeCycleEventsMap>
 }
 
-export type SetupServerInternalContext = {
-  get nodeEvents(): Promise<typeof import('node:events') | undefined>
-}
+export type SetupServerContext = Readonly<{
+  nodeEvents:
+    | Pick<
+        typeof import('node:events'),
+        'setMaxListeners' | 'defaultMaxListeners'
+      >
+    | undefined
+}>

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,10 +1,10 @@
 import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
 import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
 import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+import { defaultMaxListeners, setMaxListeners } from 'node:events'
 import { RequestHandler } from '~/core/handlers/RequestHandler'
-import { SetupServer } from './glossary'
 import { SetupServerApi } from './SetupServerApi'
-
+import { SetupServer } from './glossary'
 /**
  * Sets up a requests interception in Node.js with the given request handlers.
  * @param {RequestHandler[]} handlers List of request handlers.
@@ -17,5 +17,10 @@ export const setupServer = (
   return new SetupServerApi(
     [ClientRequestInterceptor, XMLHttpRequestInterceptor, FetchInterceptor],
     ...handlers,
-  )
+  ).withContext({
+    nodeEvents: {
+      setMaxListeners,
+      defaultMaxListeners,
+    },
+  })
 }

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -15,12 +15,19 @@ export const setupServer = (
   ...handlers: Array<RequestHandler>
 ): SetupServer => {
   return new SetupServerApi(
-    [ClientRequestInterceptor, XMLHttpRequestInterceptor, FetchInterceptor],
-    ...handlers,
-  ).withContext({
-    nodeEvents: {
-      setMaxListeners,
-      defaultMaxListeners,
+    {
+      interceptors: [
+        ClientRequestInterceptor,
+        XMLHttpRequestInterceptor,
+        FetchInterceptor,
+      ],
+      context: {
+        nodeEvents: {
+          setMaxListeners,
+          defaultMaxListeners,
+        },
+      },
     },
-  })
+    ...handlers,
+  )
 }

--- a/test/node/native/native.node.test.ts
+++ b/test/node/native/native.node.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { http } from 'msw'
+import { setupServer } from 'msw/native'
+import { stringToHeaders } from 'headers-polyfill'
+
+const server = setupServer(
+  http.get('http://localhost:3001/resource', ({ request }) => {
+    return new Response(
+      JSON.stringify({
+        firstName: 'John',
+        age: 32,
+      }),
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Header': 'yes',
+        },
+      },
+    )
+  }),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('given I perform an XMLHttpRequest', () => {
+  let statusCode: number
+  let headers: Headers
+  let body: string
+
+  beforeAll(async () => {
+    const req = new XMLHttpRequest()
+    req.open('GET', 'http://localhost:3001/resource')
+
+    const requestFinishPromise = new Promise<void>((resolve, reject) => {
+      req.onload = function () {
+        statusCode = this.status
+        body = JSON.parse(this.response)
+        headers = stringToHeaders(this.getAllResponseHeaders())
+        resolve()
+      }
+      req.onerror = reject.bind(req)
+    })
+    req.send()
+
+    await requestFinishPromise
+  })
+
+  test('returns mocked status code', () => {
+    expect(statusCode).toEqual(401)
+  })
+
+  test('returns mocked headers', () => {
+    expect(headers.get('content-type')).toEqual('application/json')
+    expect(headers.get('x-header')).toEqual('yes')
+  })
+
+  test('returns mocked body', () => {
+    expect(body).toEqual({
+      firstName: 'John',
+      age: 32,
+    })
+  })
+})


### PR DESCRIPTION
An alternative take on https://github.com/mswjs/msw/pull/1879

This uses a modified first argument to SetupServerApi that optionally uses a config object instead of a straight array of interceptors. 

Ideally, i think an api like

`SetupServerApi(interceptors, config, ...handlers)` might be clearer, but that would be a breaking change I'm trying to avoid, and the pure additive approach here seems reasonable as an iterative step 

I don't have a strong preference between this version and the one in the other referenced pr, which provides a context setter