### PR TITLE
chore: remove ts-ignores. force ts-expect-error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
   rules: {
+    '@typescript-eslint/prefer-ts-expect-error': 2,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,
     '@typescript-eslint/ban-ts-comment': 0,

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -66,11 +66,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install TypeScript ${{ matrix.ts }}
-        run: pnpm add typescript@${{ matrix.ts }}
-
       - name: Build
         run: pnpm build
+
+      - name: Install TypeScript ${{ matrix.ts }}
+        run: pnpm add typescript@${{ matrix.ts }}
 
       - name: Typings tests
         run: |

--- a/config/plugins/esbuild/copyWorkerPlugin.ts
+++ b/config/plugins/esbuild/copyWorkerPlugin.ts
@@ -17,14 +17,7 @@ const SERVICE_WORKER_OUTPUT_PATH = path.resolve(
 )
 
 function getChecksum(contents: string): string {
-  const { code } = minify(
-    contents,
-    {},
-    {
-      // @ts-ignore "babel-minify" has no type definitions.
-      comments: false,
-    },
-  )
+  const { code } = minify(contents, {}, { comments: false })
 
   return crypto.createHash('md5').update(code, 'utf8').digest('hex')
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -6,3 +6,16 @@ declare module '@bundled-es-modules/statuses' {
   import * as statuses from 'statuses'
   export default statuses
 }
+
+declare module 'babel-minify' {
+  export default function babelMinify(
+    code: string,
+    opts: Record<string, any>,
+    babelOpts: Record<string, any>,
+  ): { code: string }
+}
+
+declare module '@bundled-es-modules/js-levenshtein' {
+  import levenshtein from 'js-levenshtein'
+  export default levenshtein
+}

--- a/src/browser/setupWorker/start/utils/createMessageChannel.ts
+++ b/src/browser/setupWorker/start/utils/createMessageChannel.ts
@@ -27,6 +27,14 @@ export class WorkerChannel {
     ...rest: WorkerChannelEventsMap[Event]
   ): void {
     const [data, transfer] = rest
-    this.port.postMessage({ type: event, data }, { transfer })
+    this.port.postMessage(
+      { type: event, data },
+      {
+        // but TypeScript doesn't acknowledge that.
+        // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+        // @ts-ignore ReadableStream can be transferred, but only in versions 4.8 and lower
+        transfer,
+      },
+    )
   }
 }

--- a/src/browser/setupWorker/start/utils/createMessageChannel.ts
+++ b/src/browser/setupWorker/start/utils/createMessageChannel.ts
@@ -27,13 +27,6 @@ export class WorkerChannel {
     ...rest: WorkerChannelEventsMap[Event]
   ): void {
     const [data, transfer] = rest
-    this.port.postMessage(
-      { type: event, data },
-      {
-        // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore ReadableStream can be transferred, but this isn't handled in typescript versions 4.8 and below
-        transfer,
-      },
-    )
+    this.port.postMessage({ type: event, data }, { transfer })
   }
 }

--- a/src/browser/setupWorker/start/utils/createMessageChannel.ts
+++ b/src/browser/setupWorker/start/utils/createMessageChannel.ts
@@ -27,13 +27,6 @@ export class WorkerChannel {
     ...rest: WorkerChannelEventsMap[Event]
   ): void {
     const [data, transfer] = rest
-    this.port.postMessage(
-      { type: event, data },
-      {
-        // @ts-ignore ReadableStream can be transferred
-        // but TypeScript doesn't acknowledge that.
-        transfer,
-      },
-    )
+    this.port.postMessage({ type: event, data }, { transfer })
   }
 }

--- a/src/browser/setupWorker/start/utils/createMessageChannel.ts
+++ b/src/browser/setupWorker/start/utils/createMessageChannel.ts
@@ -30,9 +30,8 @@ export class WorkerChannel {
     this.port.postMessage(
       { type: event, data },
       {
-        // but TypeScript doesn't acknowledge that.
         // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-        // @ts-ignore ReadableStream can be transferred, but only in versions 4.8 and lower
+        // @ts-ignore ReadableStream can be transferred, but this isn't handled in typescript versions 4.8 and below
         transfer,
       },
     )

--- a/src/core/utils/internal/pipeEvents.ts
+++ b/src/core/utils/internal/pipeEvents.ts
@@ -7,18 +7,19 @@ export function pipeEvents<Events extends EventMap>(
   source: Emitter<Events>,
   destination: Emitter<Events>,
 ): void {
-  const rawEmit = source.emit
+  const rawEmit: typeof source.emit & { _isPiped?: boolean } = source.emit
 
-  // @ts-ignore
   if (rawEmit._isPiped) {
     return
   }
 
-  source.emit = function (event, ...data) {
-    destination.emit(event, ...data)
-    return rawEmit.call(this, event, ...data)
-  }
+  const sourceEmit: typeof source.emit & { _isPiped?: boolean } =
+    function sourceEmit(this: typeof source, event, ...data) {
+      destination.emit(event, ...data)
+      return rawEmit.call(this, event, ...data)
+    }
 
-  // @ts-ignore
-  source.emit._isPiped = true
+  sourceEmit._isPiped = true
+
+  source.emit = sourceEmit
 }

--- a/src/core/utils/request/onUnhandledRequest.ts
+++ b/src/core/utils/request/onUnhandledRequest.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import jsLevenshtein from '@bundled-es-modules/js-levenshtein'
 import { RequestHandler, HttpHandler, GraphQLHandler } from '../..'
 import {

--- a/test/browser/graphql-api/anonymous-operation.mocks.ts
+++ b/test/browser/graphql-api/anonymous-operation.mocks.ts
@@ -4,9 +4,10 @@ import { setupWorker } from 'msw/browser'
 const worker = setupWorker()
 worker.start()
 
-// @ts-ignore
-window.msw = {
-  worker,
-  graphql,
-  HttpResponse,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+    graphql,
+    HttpResponse,
+  },
+})

--- a/test/browser/graphql-api/response-patching.mocks.ts
+++ b/test/browser/graphql-api/response-patching.mocks.ts
@@ -26,23 +26,22 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.msw = {
-  registration: worker.start(),
-}
+Object.assign(window, {
+  msw: {
+    registration: worker.start(),
+  },
+  dispatchGraphQLQuery: (uri: string) => {
+    const client = createGraphQLClient({ uri })
 
-// @ts-ignore
-window.dispatchGraphQLQuery = (uri: string) => {
-  const client = createGraphQLClient({ uri })
-
-  return client({
-    query: gql`
-      query GetUser {
-        user {
-          firstName
-          lastName
+    return client({
+      query: gql`
+        query GetUser {
+          user {
+            firstName
+            lastName
+          }
         }
-      }
-    `,
-  })
-}
+      `,
+    })
+  },
+})

--- a/test/browser/msw-api/exception-handling.mocks.ts
+++ b/test/browser/msw-api/exception-handling.mocks.ts
@@ -3,7 +3,7 @@ import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker(
   http.get('https://api.github.com/users/:username', () => {
-    // @ts-ignore
+    // @ts-expect-error nonExisting should not be defined
     nonExisting()
     return
   }),

--- a/test/browser/msw-api/req/passthrough.mocks.ts
+++ b/test/browser/msw-api/req/passthrough.mocks.ts
@@ -9,10 +9,11 @@ const worker = setupWorker(
 
 worker.start()
 
-// @ts-ignore
-window.msw = {
-  worker,
-  http,
-  passthrough,
-  HttpResponse,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+    http,
+    passthrough,
+    HttpResponse,
+  },
+})

--- a/test/browser/msw-api/setup-worker/fallback-mode/fallback-mode.mocks.ts
+++ b/test/browser/msw-api/setup-worker/fallback-mode/fallback-mode.mocks.ts
@@ -9,5 +9,4 @@ const worker = setupWorker(
 
 worker.start()
 
-// @ts-ignore
-window.worker = worker
+Object.assign(window, { worker })

--- a/test/browser/msw-api/setup-worker/input-validation.mocks.ts
+++ b/test/browser/msw-api/setup-worker/input-validation.mocks.ts
@@ -1,9 +1,7 @@
 import { http, HttpResponse } from 'msw'
 import { setupWorker } from 'msw/browser'
 
-// The next line will be ignored because we want to test that an Error
-// should be trown when `setupWorker` parameters are not valid
-//@ts-ignore
+//@ts-expect-error invalid parameter provided to setupWorker so we can validate it throws
 const worker = setupWorker([
   http.get('/book/:bookId', function originalResolver() {
     return HttpResponse.json({ title: 'Original title' })

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
@@ -27,13 +27,13 @@ worker.events.on('request:unhandled', ({ request, requestId }) => {
   )
 })
 
-const requestEndListner: (
+const requestEndListener: (
   ...args: LifeCycleEventsMap['request:end']
 ) => void = ({ request, requestId }) => {
   console.warn(`[request:end] ${request.method} ${request.url} ${requestId}`)
 }
 
-worker.events.on('request:end', requestEndListner)
+worker.events.on('request:end', requestEndListener)
 
 worker.events.on('response:mocked', async ({ response, requestId }) => {
   const body = await response.clone().text()
@@ -55,8 +55,9 @@ worker.start({
   onUnhandledRequest: 'bypass',
 })
 
-// @ts-ignore
-window.msw = {
-  worker,
-  requestEndListner,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+    requestEndListener,
+  },
+})

--- a/test/browser/msw-api/setup-worker/life-cycle-events/removeListener.test.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/removeListener.test.ts
@@ -4,7 +4,7 @@ import { test, expect } from '../../../playwright.extend'
 declare namespace window {
   export const msw: {
     worker: SetupWorkerApi
-    requestEndListner: any
+    requestEndListener: any
   }
 }
 
@@ -21,7 +21,7 @@ test('removes a listener by the event name', async ({
 
   await page.evaluate(() => {
     const { msw } = window
-    msw.worker.events.removeListener('request:end', msw.requestEndListner)
+    msw.worker.events.removeListener('request:end', msw.requestEndListener)
   })
 
   const url = makeUrl('/user')

--- a/test/browser/msw-api/setup-worker/listHandlers.mocks.ts
+++ b/test/browser/msw-api/setup-worker/listHandlers.mocks.ts
@@ -16,9 +16,10 @@ const worker = setupWorker(
 
 worker.start()
 
-// @ts-ignore
-window.msw = {
-  worker,
-  http,
-  graphql,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+    http,
+    graphql,
+  },
+})

--- a/test/browser/msw-api/setup-worker/start/error.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/error.mocks.ts
@@ -7,7 +7,8 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.msw = {
-  worker,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+  },
+})

--- a/test/browser/msw-api/setup-worker/start/find-worker.error.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/find-worker.error.mocks.ts
@@ -7,22 +7,23 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.msw = {
-  registration: worker
-    .start({
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      findWorker: (scriptURL, _mockServiceWorkerUrl) => {
-        return scriptURL.includes('some-bad-filename-that-does-not-exist.js')
-      },
-    })
-    .then((registration) => {
-      console.log('Registration Promise resolved')
-      // This will throw as as there is no instance returned with a non-matching worker name.
-      return registration?.constructor.name
-    })
-    .catch((error) => {
-      console.error('Error - no worker instance after starting', error)
-      throw error
-    }),
-}
+Object.assign(window, {
+  msw: {
+    registration: worker
+      .start({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        findWorker: (scriptURL, _mockServiceWorkerUrl) => {
+          return scriptURL.includes('some-bad-filename-that-does-not-exist.js')
+        },
+      })
+      .then((registration) => {
+        console.log('Registration Promise resolved')
+        // This will throw as as there is no instance returned with a non-matching worker name.
+        return registration?.constructor.name
+      })
+      .catch((error) => {
+        console.error('Error - no worker instance after starting', error)
+        throw error
+      }),
+  },
+})

--- a/test/browser/msw-api/setup-worker/start/find-worker.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/find-worker.mocks.ts
@@ -7,17 +7,18 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.msw = {
-  registration: worker
-    .start({
-      // This is the default matching behavior if left unspecified.
-      findWorker(scriptURL, mockServiceWorkerUrl) {
-        return scriptURL === mockServiceWorkerUrl
-      },
-    })
-    .then((registration) => {
-      console.log('Registration Promise resolved', registration)
-      return registration?.constructor.name
-    }),
-}
+Object.assign(window, {
+  msw: {
+    registration: worker
+      .start({
+        // This is the default matching behavior if left unspecified.
+        findWorker(scriptURL, mockServiceWorkerUrl) {
+          return scriptURL === mockServiceWorkerUrl
+        },
+      })
+      .then((registration) => {
+        console.log('Registration Promise resolved', registration)
+        return registration?.constructor.name
+      }),
+  },
+})

--- a/test/browser/msw-api/setup-worker/start/on-unhandled-request/suggestions.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/on-unhandled-request/suggestions.mocks.ts
@@ -9,9 +9,10 @@ worker.start({
   onUnhandledRequest: 'warn',
 })
 
-// @ts-ignore
-window.msw = {
-  worker,
-  http,
-  graphql,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+    http,
+    graphql,
+  },
+})

--- a/test/browser/msw-api/setup-worker/start/quiet.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/quiet.mocks.ts
@@ -10,10 +10,11 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.msw = {
-  registration: worker.start({
-    // Disable logging of matched requests into browser's console
-    quiet: true,
-  }),
-}
+Object.assign(window, {
+  msw: {
+    registration: worker.start({
+      // Disable logging of matched requests into browser's console
+      quiet: true,
+    }),
+  },
+})

--- a/test/browser/msw-api/setup-worker/start/start.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/start.mocks.ts
@@ -7,17 +7,18 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.msw = {
-  async startWorker() {
-    await worker.start({
-      serviceWorker: {
-        // Use a custom Service Worker for this test that intentionally
-        // delays the worker installation time. This allows us to test
-        // that the "worker.start()" Promise indeed resolves only after
-        // the worker has been activated and not just registered.
-        url: './worker.js',
-      },
-    })
+Object.assign(window, {
+  msw: {
+    async startWorker() {
+      await worker.start({
+        serviceWorker: {
+          // Use a custom Service Worker for this test that intentionally
+          // delays the worker installation time. This allows us to test
+          // that the "worker.start()" Promise indeed resolves only after
+          // the worker has been activated and not just registered.
+          url: './worker.js',
+        },
+      })
+    },
   },
-}
+})

--- a/test/browser/msw-api/setup-worker/start/wait-until-ready.error.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/wait-until-ready.error.mocks.ts
@@ -10,17 +10,18 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.init = () => {
-  worker.start({
-    // Force an exception during Service Worker registration.
-    // @ts-expect-error Providing invalid option value.
-    serviceWorker: 'invalid-value',
-  })
+Object.assign(window, {
+  init: () => {
+    worker.start({
+      // Force an exception during Service Worker registration.
+      // @ts-expect-error Providing invalid option value.
+      serviceWorker: 'invalid-value',
+    })
 
-  fetch('./numbers')
+    fetch('./numbers')
 
-  const req = new XMLHttpRequest()
-  req.open('GET', './letters')
-  req.send()
-}
+    const req = new XMLHttpRequest()
+    req.open('GET', './letters')
+    req.send()
+  },
+})

--- a/test/browser/msw-api/setup-worker/start/wait-until-ready.false.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/wait-until-ready.false.mocks.ts
@@ -10,21 +10,22 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.init = () => {
-  worker.start({
-    serviceWorker: {
-      url: './worker.js',
-    },
-    waitUntilReady: false,
-  })
+Object.assign(window, {
+  init: () => {
+    worker.start({
+      serviceWorker: {
+        url: './worker.js',
+      },
+      waitUntilReady: false,
+    })
 
-  // Without deferring the network requests until the worker is ready,
-  // there is a race condition between the worker's registration and
-  // any runtime requests that may happen meanwhile.
-  fetch('./numbers')
+    // Without deferring the network requests until the worker is ready,
+    // there is a race condition between the worker's registration and
+    // any runtime requests that may happen meanwhile.
+    fetch('./numbers')
 
-  const req = new XMLHttpRequest()
-  req.open('GET', './letters')
-  req.send()
-}
+    const req = new XMLHttpRequest()
+    req.open('GET', './letters')
+    req.send()
+  },
+})

--- a/test/browser/msw-api/setup-worker/start/wait-until-ready.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/wait-until-ready.mocks.ts
@@ -10,22 +10,23 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.init = () => {
-  // By default, starting the worker defers the network requests
-  // until the worker is ready to intercept them.
-  worker.start({
-    serviceWorker: {
-      url: './worker.js',
-    },
-  })
+Object.assign(window, {
+  init: () => {
+    // By default, starting the worker defers the network requests
+    // until the worker is ready to intercept them.
+    worker.start({
+      serviceWorker: {
+        url: './worker.js',
+      },
+    })
 
-  // Although this request is performed alongside an asynchronous
-  // worker registration, it's being deferred by `worker.start`,
-  // so it will happen only when the worker is ready.
-  fetch('./numbers')
+    // Although this request is performed alongside an asynchronous
+    // worker registration, it's being deferred by `worker.start`,
+    // so it will happen only when the worker is ready.
+    fetch('./numbers')
 
-  const req = new XMLHttpRequest()
-  req.open('GET', './letters')
-  req.send()
-}
+    const req = new XMLHttpRequest()
+    req.open('GET', './letters')
+    req.send()
+  },
+})

--- a/test/browser/msw-api/setup-worker/stop.mocks.ts
+++ b/test/browser/msw-api/setup-worker/stop.mocks.ts
@@ -9,7 +9,8 @@ const worker = setupWorker(
 
 worker.start()
 
-// @ts-ignore
-window.msw = {
-  worker,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+  },
+})

--- a/test/browser/msw-api/setup-worker/stop/quiet.mocks.ts
+++ b/test/browser/msw-api/setup-worker/stop/quiet.mocks.ts
@@ -2,7 +2,8 @@ import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker()
 
-// @ts-ignore
-window.msw = {
-  worker,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+  },
+})

--- a/test/browser/msw-api/setup-worker/stop/removes-all-listeners.mocks.ts
+++ b/test/browser/msw-api/setup-worker/stop/removes-all-listeners.mocks.ts
@@ -9,7 +9,8 @@ const createWorker = () => {
   )
 }
 
-// @ts-ignore
-window.msw = {
-  createWorker,
-}
+Object.assign(window, {
+  msw: {
+    createWorker,
+  },
+})

--- a/test/browser/msw-api/setup-worker/use.mocks.ts
+++ b/test/browser/msw-api/setup-worker/use.mocks.ts
@@ -11,11 +11,10 @@ const worker = setupWorker(
 
 worker.start()
 
-// @ts-ignore
-// Propagate the worker and `http` references to be globally available.
-// This would allow to modify request handlers on runtime.
-window.msw = {
-  worker,
-  http,
-  HttpResponse,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+    http,
+    HttpResponse,
+  },
+})

--- a/test/browser/msw-api/unregister.mocks.ts
+++ b/test/browser/msw-api/unregister.mocks.ts
@@ -7,7 +7,8 @@ const worker = setupWorker(
   }),
 )
 
-// @ts-ignore
-window.msw = {
-  worker,
-}
+Object.assign(window, {
+  msw: {
+    worker,
+  },
+})

--- a/test/browser/rest-api/basic.mocks.ts
+++ b/test/browser/rest-api/basic.mocks.ts
@@ -14,5 +14,4 @@ const worker = setupWorker(
 
 worker.start()
 
-// @ts-ignore
-window.worker = worker
+Object.assign(window, { worker })

--- a/test/node/msw-api/setup-server/input-validation.node.test.ts
+++ b/test/node/msw-api/setup-server/input-validation.node.test.ts
@@ -3,9 +3,7 @@ import { setupServer } from 'msw/node'
 
 test('throws an error given an Array of request handlers to setupServer', () => {
   const createServer = () => {
-    // The next line will be ignored because we want to test that an Error
-    // should be thrown when `setupServer` parameters are not valid
-    // @ts-ignore
+    // @ts-expect-error intentionally invalid parameters for setupServer to force it to throw
     return setupServer([
       http.get('https://test.mswjs.io/book/:bookId', () => {
         return HttpResponse.json({ title: 'Original title' })


### PR DESCRIPTION
This is very much stylistic/preference, and feel free to close

I noticed `transfer` was ts-ignored, even though the types are no longer incorrect in the version of typescript we develop with, so I thought we should move to using `ts-expect-error` generally instead of ignores to avoid scenarios where errors _stop happening_ still being ignored

I added small ambient declarations for some third party modules we use internally to avoid needing to ignore them.  I was not complete in those typings, but that seems fair