### PR TITLE
fix: force response bodies for 304s to be null

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -122,10 +122,13 @@ async function handleRequest(event, requestId) {
     ;(async function () {
       const responseClone = response.clone()
       // When performing original requests, response body will
-      // always be a ReadableStream, even for 204 responses.
+      // always be a ReadableStream, even for 204 / 304 responses.
       // But when creating a new Response instance on the client,
-      // the body for a 204 response must be null.
-      const responseBody = response.status === 204 ? null : responseClone.body
+      // the body for a 204 / 304 response must be null.
+      const responseBody =
+        response.status === 204 || response.status === 304
+          ? null
+          : responseClone.body
 
       sendToClient(
         client,

--- a/test/browser/msw-api/regression/null-body.mocks.ts
+++ b/test/browser/msw-api/regression/null-body.mocks.ts
@@ -5,6 +5,9 @@ const worker = setupWorker(
   http.get('/api/books', () => {
     return new HttpResponse(null, { status: 204 })
   }),
+  http.get('/api/authors', () => {
+    return new HttpResponse(null, { status: 304 })
+  }),
 )
 
 worker.start()

--- a/test/browser/msw-api/regression/null-body.test.ts
+++ b/test/browser/msw-api/regression/null-body.test.ts
@@ -18,3 +18,21 @@ test('gracefully handles a 204 response null body during life-cycle events', asy
 
   expect(errors).toEqual([])
 })
+
+test('gracefully handles a 304 response null body during life-cycle events', async ({
+  loadExample,
+  fetch,
+  page,
+}) => {
+  await loadExample(require.resolve('./null-body.mocks.ts'))
+
+  const errors: Array<Error> = []
+  page.on('pageerror', (pageError) => {
+    errors.push(pageError)
+  })
+
+  await fetch('/api/authors')
+  await sleep(500)
+
+  expect(errors).toEqual([])
+})

--- a/test/browser/rest-api/null-body-responses.test.ts
+++ b/test/browser/rest-api/null-body-responses.test.ts
@@ -9,6 +9,10 @@ const httpServer = new HttpServer((app) => {
   app.get('/posts', (req, res) => {
     return res.status(204).end()
   })
+
+  app.get('/comments', (req, res) => {
+    return res.status(304).end()
+  })
 })
 
 test.beforeAll(async () => {
@@ -38,4 +42,25 @@ test('handles a 204 status response without Response instance exceptions', async
   // Failed to construct 'Response': Response with null body status cannot have body
   expect(pageError).toBeUndefined()
   expect(res.status()).toBe(204)
+})
+
+test('handles a 304 status response without Response instance exceptions', async ({
+  loadExample,
+  fetch,
+  page,
+}) => {
+  await loadExample(require.resolve('./basic.mocks.ts'))
+
+  let pageError: Error
+
+  page.on('pageerror', (error) => {
+    pageError = error
+  })
+
+  const res = await fetch(httpServer.http.url('/comments'))
+
+  // There must be no such exception:
+  // Failed to construct 'Response': Response with null body status cannot have body
+  expect(pageError).toBeUndefined()
+  expect(res.status()).toBe(304)
 })


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/1893

## Changes

- Forces the response body to be null for responses with `304` status codes.