### PR TITLE
fix: null-body responses enforced in createResponseListener instead o…

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@bundled-es-modules/js-levenshtein": "^2.0.1",
     "@bundled-es-modules/statuses": "^1.0.1",
     "@mswjs/cookies": "^1.1.0",
-    "@mswjs/interceptors": "^0.25.11",
+    "@mswjs/interceptors": "^0.25.13",
     "@open-draft/until": "^2.1.0",
     "@types/cookie": "^0.4.1",
     "@types/js-levenshtein": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ specifiers:
   '@commitlint/cli': ^16.1.0
   '@commitlint/config-conventional': ^16.0.0
   '@mswjs/cookies': ^1.1.0
-  '@mswjs/interceptors': ^0.25.11
+  '@mswjs/interceptors': ^0.25.13
   '@open-draft/test-server': ^0.4.2
   '@open-draft/until': ^2.1.0
   '@ossjs/release': ^0.8.0
@@ -82,7 +82,7 @@ dependencies:
   '@bundled-es-modules/js-levenshtein': 2.0.1
   '@bundled-es-modules/statuses': 1.0.1
   '@mswjs/cookies': 1.1.0
-  '@mswjs/interceptors': 0.25.11
+  '@mswjs/interceptors': 0.25.13
   '@open-draft/until': 2.1.0
   '@types/cookie': 0.4.1
   '@types/js-levenshtein': 1.1.1
@@ -2429,8 +2429,8 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /@mswjs/interceptors/0.25.11:
-    resolution: {integrity: sha512-27aonWAjdeoZN4j4j6QvePOSOacQUucFRUESAU8FUXsmmagDjmyOi4/NHizxzY/NHSk/HAyqF/IMhl+9puhqNw==}
+  /@mswjs/interceptors/0.25.13:
+    resolution: {integrity: sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==}
     engines: {node: '>=18'}
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -3695,7 +3695,7 @@ packages:
   /axios/1.6.1:
     resolution: {integrity: sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -5906,6 +5906,16 @@ packages:
 
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+    dev: true
+
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
     dev: true
 
   /follow-redirects/1.15.2_debug@4.3.4:

--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -4,6 +4,7 @@ import {
 } from '../glossary'
 import { ServiceWorkerMessage } from './utils/createMessageChannel'
 import { isResponseWithoutBody } from '@mswjs/interceptors'
+
 export function createResponseListener(context: SetupWorkerInternalContext) {
   return (
     _: MessageEvent,

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -121,11 +121,6 @@ async function handleRequest(event, requestId) {
   if (client && activeClientIds.has(client.id)) {
     ;(async function () {
       const responseClone = response.clone()
-      // When performing original requests, response body will
-      // always be a ReadableStream, even for 204 responses.
-      // But when creating a new Response instance on the client,
-      // the body for a 204 response must be null.
-      const responseBody = response.status === 204 ? null : responseClone.body
 
       sendToClient(
         client,
@@ -137,11 +132,11 @@ async function handleRequest(event, requestId) {
             type: responseClone.type,
             status: responseClone.status,
             statusText: responseClone.statusText,
-            body: responseBody,
+            body: responseClone.body,
             headers: Object.fromEntries(responseClone.headers.entries()),
           },
         },
-        [responseBody],
+        [responseClone.body],
       )
     })()
   }

--- a/test/browser/msw-api/regression/null-body.mocks.ts
+++ b/test/browser/msw-api/regression/null-body.mocks.ts
@@ -2,14 +2,9 @@ import { http, HttpResponse } from 'msw'
 import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker(
-  http.get('/api/204', () => {
-    return new HttpResponse(null, { status: 204 })
-  }),
-  http.get('/api/205', () => {
-    return new HttpResponse(null, { status: 205 })
-  }),
-  http.get('/api/304', () => {
-    return new HttpResponse(null, { status: 304 })
+  http.get<{ code: string }>('/api/:code', ({ params }) => {
+    const status = parseInt(params.code)
+    return new HttpResponse(null, { status })
   }),
 )
 

--- a/test/browser/msw-api/regression/null-body.mocks.ts
+++ b/test/browser/msw-api/regression/null-body.mocks.ts
@@ -3,8 +3,7 @@ import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker(
   http.get<{ code: string }>('/api/:code', ({ params }) => {
-    const status = parseInt(params.code)
-    return new HttpResponse(null, { status })
+    return new HttpResponse(null, { status: parseInt(params.code) })
   }),
 )
 

--- a/test/browser/msw-api/regression/null-body.mocks.ts
+++ b/test/browser/msw-api/regression/null-body.mocks.ts
@@ -2,8 +2,14 @@ import { http, HttpResponse } from 'msw'
 import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker(
-  http.get('/api/books', () => {
+  http.get('/api/204', () => {
     return new HttpResponse(null, { status: 204 })
+  }),
+  http.get('/api/205', () => {
+    return new HttpResponse(null, { status: 205 })
+  }),
+  http.get('/api/304', () => {
+    return new HttpResponse(null, { status: 304 })
   }),
 )
 

--- a/test/browser/msw-api/regression/null-body.test.ts
+++ b/test/browser/msw-api/regression/null-body.test.ts
@@ -1,20 +1,22 @@
 import { sleep } from '../../../support/utils'
 import { test, expect } from '../../playwright.extend'
 
-test('gracefully handles a 204 response null body during life-cycle events', async ({
-  loadExample,
-  fetch,
-  page,
-}) => {
-  await loadExample(require.resolve('./null-body.mocks.ts'))
+for (const code of [204, 205, 304]) {
+  test(`gracefully handles a ${code} response null body during life-cycle events`, async ({
+    loadExample,
+    fetch,
+    page,
+  }) => {
+    await loadExample(require.resolve('./null-body.mocks.ts'))
 
-  const errors: Array<Error> = []
-  page.on('pageerror', (pageError) => {
-    errors.push(pageError)
+    const errors: Array<Error> = []
+    page.on('pageerror', (pageError) => {
+      errors.push(pageError)
+    })
+
+    await fetch(`/api/${code}`)
+    await sleep(500)
+
+    expect(errors).toEqual([])
   })
-
-  await fetch('/api/books')
-  await sleep(500)
-
-  expect(errors).toEqual([])
-})
+}

--- a/test/browser/msw-api/regression/null-body.test.ts
+++ b/test/browser/msw-api/regression/null-body.test.ts
@@ -1,5 +1,4 @@
-import { sleep } from '../../../support/utils'
-import { test, expect } from '../../playwright.extend'
+import { expect, test } from '../../playwright.extend'
 
 for (const code of [204, 205, 304]) {
   test(`gracefully handles a ${code} response null body during life-cycle events`, async ({
@@ -15,8 +14,6 @@ for (const code of [204, 205, 304]) {
     })
 
     await fetch(`/api/${code}`)
-    await sleep(500)
-
     expect(errors).toEqual([])
   })
 }

--- a/test/browser/msw-api/req/passthrough.test.ts
+++ b/test/browser/msw-api/req/passthrough.test.ts
@@ -131,6 +131,43 @@ test('performs a request as-is if nothing was returned from the resolver', async
 })
 
 for (const code of [204, 205, 304]) {
+  test(`performs a ${code} request as-is if passthrough was returned from the resolver`, async ({
+    createServer,
+    loadExample,
+    fetch,
+    page,
+  }) => {
+    const server = await createServer((app) => {
+      app.post('/user', (_, res) => {
+        res.status(code).send()
+      })
+    })
+
+    await loadExample(PASSTHROUGH_EXAMPLE)
+    const endpointUrl = server.http.url('/user')
+
+    const errors: Array<Error> = []
+    page.on('pageerror', (pageError) => {
+      errors.push(pageError)
+    })
+
+    await page.evaluate((endpointUrl) => {
+      const { worker, http, passthrough } = window.msw
+      worker.use(
+        http.post<never, ResponseBody>(endpointUrl, () => {
+          return passthrough()
+        }),
+      )
+    }, endpointUrl)
+
+    const res = await fetch(endpointUrl, { method: 'POST' })
+    expect(res.status()).toBe(code)
+    await sleep(500)
+    expect(errors).toEqual([])
+  })
+}
+
+for (const code of [204, 205, 304]) {
   test(`performs a ${code} request as-is if nothing was returned from the resolver`, async ({
     createServer,
     loadExample,
@@ -151,7 +188,7 @@ for (const code of [204, 205, 304]) {
       errors.push(pageError)
     })
 
-    await page.evaluate(async (endpointUrl) => {
+    await page.evaluate((endpointUrl) => {
       const { worker, http } = window.msw
       worker.use(
         http.post<never, ResponseBody>(endpointUrl, () => {

--- a/test/browser/msw-api/req/passthrough.test.ts
+++ b/test/browser/msw-api/req/passthrough.test.ts
@@ -1,6 +1,7 @@
-import { HttpResponse, passthrough, http } from 'msw'
+import { HttpResponse, http, passthrough } from 'msw'
 import { SetupWorkerApi } from 'msw/browser'
-import { test, expect } from '../../playwright.extend'
+import { sleep } from '../../../support/utils'
+import { expect, test } from '../../playwright.extend'
 
 const PASSTHROUGH_EXAMPLE = require.resolve('./passthrough.mocks.ts')
 
@@ -145,6 +146,11 @@ for (const code of [204, 205, 304]) {
     await loadExample(PASSTHROUGH_EXAMPLE)
     const endpointUrl = server.http.url('/user')
 
+    const errors: Array<Error> = []
+    page.on('pageerror', (pageError) => {
+      errors.push(pageError)
+    })
+
     await page.evaluate(async (endpointUrl) => {
       const { worker, http } = window.msw
       worker.use(
@@ -156,5 +162,7 @@ for (const code of [204, 205, 304]) {
 
     const res = await fetch(endpointUrl, { method: 'POST' })
     expect(res.status()).toBe(code)
+    await sleep(500)
+    expect(errors).toEqual([])
   })
 }

--- a/test/browser/msw-api/req/passthrough.test.ts
+++ b/test/browser/msw-api/req/passthrough.test.ts
@@ -1,6 +1,5 @@
 import { HttpResponse, http, passthrough } from 'msw'
 import { SetupWorkerApi } from 'msw/browser'
-import { sleep } from '../../../support/utils'
 import { expect, test } from '../../playwright.extend'
 
 const PASSTHROUGH_EXAMPLE = require.resolve('./passthrough.mocks.ts')
@@ -162,7 +161,6 @@ for (const code of [204, 205, 304]) {
 
     const res = await fetch(endpointUrl, { method: 'POST' })
     expect(res.status()).toBe(code)
-    await sleep(500)
     expect(errors).toEqual([])
   })
 
@@ -197,7 +195,6 @@ for (const code of [204, 205, 304]) {
 
     const res = await fetch(endpointUrl, { method: 'POST' })
     expect(res.status()).toBe(code)
-    await sleep(500)
     expect(errors).toEqual([])
   })
 }

--- a/test/browser/msw-api/req/passthrough.test.ts
+++ b/test/browser/msw-api/req/passthrough.test.ts
@@ -165,9 +165,7 @@ for (const code of [204, 205, 304]) {
     await sleep(500)
     expect(errors).toEqual([])
   })
-}
 
-for (const code of [204, 205, 304]) {
   test(`performs a ${code} request as-is if nothing was returned from the resolver`, async ({
     createServer,
     loadExample,

--- a/test/node/msw-api/req/passthrough.node.test.ts
+++ b/test/node/msw-api/req/passthrough.node.test.ts
@@ -9,17 +9,14 @@ const httpServer = new HttpServer((app) => {
   app.post<never, ResponseBody>('/user', (req, res) => {
     res.json({ name: 'John' })
   })
-  app.post('/code/:code', (req, res) => {
-    const code = req.params.code
-    if (code === '204') {
-      res.status(204).send()
-    } else if (code === '205') {
-      res.status(205).send()
-    } else if (code === '304') {
-      res.status(304).send()
-    } else {
-      res.status(500).send()
-    }
+  app.post('/code/204', (req, res) => {
+    res.status(204).send()
+  })
+  app.post('/code/205', (req, res) => {
+    res.status(205).send()
+  })
+  app.post('/code/304', (req, res) => {
+    res.status(304).send()
   })
 })
 

--- a/test/node/msw-api/req/passthrough.node.test.ts
+++ b/test/node/msw-api/req/passthrough.node.test.ts
@@ -98,9 +98,8 @@ it('performs a request as-is if nothing was returned from the resolver', async (
   })
 })
 
-it.each([{ code: 204 }, { code: 205 }, { code: 304 }])(
-  'performs a $code request as-is if nothing was returned from the resolver',
-  async ({ code }) => {
+for (const code of [204, 205, 304]) {
+  it(`performs a ${code} request as-is if nothing was returned from the resolver`, async () => {
     const endpointUrl = httpServer.http.url(`/code/${code}`)
     server.use(
       http.post<ResponseBody>(endpointUrl, () => {
@@ -111,12 +110,9 @@ it.each([{ code: 204 }, { code: 205 }, { code: 304 }])(
     const res = await fetch(endpointUrl, { method: 'POST' })
 
     expect(res.status).toEqual(code)
-  },
-)
+  })
 
-it.each([{ code: 204 }, { code: 205 }, { code: 304 }])(
-  'performs a $code request as-is if passthrough was returned from the resolver',
-  async ({ code }) => {
+  it(`performs a ${code} request as-is if passthrough was returned from the resolver`, async () => {
     const endpointUrl = httpServer.http.url(`/code/${code}`)
     server.use(
       http.post<ResponseBody>(endpointUrl, () => {
@@ -127,5 +123,5 @@ it.each([{ code: 204 }, { code: 205 }, { code: 304 }])(
     const res = await fetch(endpointUrl, { method: 'POST' })
 
     expect(res.status).toEqual(code)
-  },
-)
+  })
+}

--- a/test/node/msw-api/req/passthrough.node.test.ts
+++ b/test/node/msw-api/req/passthrough.node.test.ts
@@ -9,14 +9,8 @@ const httpServer = new HttpServer((app) => {
   app.post<never, ResponseBody>('/user', (req, res) => {
     res.json({ name: 'John' })
   })
-  app.post('/code/204', (req, res) => {
-    res.status(204).send()
-  })
-  app.post('/code/205', (req, res) => {
-    res.status(205).send()
-  })
-  app.post('/code/304', (req, res) => {
-    res.status(304).send()
+  app.post('/code/:code', (req, res) => {
+    res.status(parseInt(req.params.code)).send()
   })
 })
 


### PR DESCRIPTION
closes https://github.com/mswjs/msw/pull/1894
fixes #1893 

This should fix passthrough errors specifically, where the body was a stream and the status code cannot support a body.
