### PR TITLE
[experiment] chore: performance updates

### DIFF
--- a/src/core/SetupApi.ts
+++ b/src/core/SetupApi.ts
@@ -59,7 +59,9 @@ export abstract class SetupApi<EventsMap extends EventMap> extends Disposable {
       ),
     )
 
-    this.currentHandlers.unshift(...runtimeHandlers)
+    for (let i = runtimeHandlers.length - 1; i >= 0; i--) {
+      this.currentHandlers.unshift(runtimeHandlers[i])
+    }
   }
 
   public restoreHandlers(): void {

--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -20,6 +20,7 @@ import {
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
 import { devUtils } from '../utils/internal/devUtils'
 import { getAllRequestCookies } from '../utils/request/getRequestCookies'
+import { memoizedUrl } from '../utils/memoizedUrl'
 
 export type ExpectedOperationTypeNode = OperationTypeNode | 'all'
 export type GraphQLHandlerNameSelector = DocumentNode | RegExp | string
@@ -138,7 +139,7 @@ export class GraphQLHandler extends RequestHandler<
      * If the request doesn't match a specified endpoint, there's no
      * need to parse it since there's no case where we would handle this
      */
-    const match = matchRequestUrl(new URL(args.request.url), this.endpoint)
+    const match = matchRequestUrl(memoizedUrl(args.request.url), this.endpoint)
     if (!match.matches) return { match }
 
     const parsedResult = await parseGraphQLRequest(args.request).catch(

--- a/src/core/handlers/HttpHandler.ts
+++ b/src/core/handlers/HttpHandler.ts
@@ -11,6 +11,7 @@ import {
   Path,
   PathParams,
 } from '../utils/matching/matchRequestUrl'
+import { memoizedUrl } from '../utils/memoizedUrl'
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
 import { getAllRequestCookies } from '../utils/request/getRequestCookies'
 import { cleanUrl, getSearchParams } from '../utils/url/cleanUrl'
@@ -110,7 +111,7 @@ export class HttpHandler extends RequestHandler<
     request: Request
     resolutionContext?: ResponseResolutionContext
   }) {
-    const url = new URL(args.request.url)
+    const url = memoizedUrl(args.request.url)
     const match = matchRequestUrl(
       url,
       this.info.path,

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -202,6 +202,15 @@ export abstract class RequestHandler<
       return null
     }
 
+    /**
+     * @deprecated do we need this request?
+     * Or, can we pass it into run instead,
+     * since it's _only_ used in the execution result,
+     * but then never read or utilized.
+     *
+     * We don't want to copy this for _every_ handler, as it
+     * is expensive to do so.
+     */
     const mainRequestRef = (() => {
       if (RequestHandler.mainRefCache.has(args.request)) {
         return RequestHandler.mainRefCache.get(

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -87,7 +87,6 @@ export interface RequestHandlerExecutionResult<
 > {
   handler: RequestHandler
   parsedResult?: ParsedResult
-  request: Request
   response?: Response
 }
 
@@ -198,10 +197,6 @@ export abstract class RequestHandler<
       return null
     }
 
-    // Clone the request instance before it's passed to the handler phases
-    // and the response resolver so we can always read it for logging.
-    const mainRequestRef = args.request.clone()
-
     const parsedResult = await this.parse({
       request: args.request,
       resolutionContext: args.resolutionContext,
@@ -238,9 +233,6 @@ export abstract class RequestHandler<
     })) as Response
 
     const executionResult = this.createExecutionResult({
-      // Pass the cloned request to the result so that logging
-      // and other consumers could read its body once more.
-      request: mainRequestRef,
       response: mockedResponse,
       parsedResult,
     })
@@ -298,13 +290,11 @@ export abstract class RequestHandler<
   }
 
   private createExecutionResult(args: {
-    request: Request
     parsedResult: ParsedResult
     response?: Response
   }): RequestHandlerExecutionResult<ParsedResult> {
     return {
       handler: this,
-      request: args.request,
       response: args.response,
       parsedResult: args.parsedResult,
     }

--- a/src/core/utils/internal/requestHandlerUtils.ts
+++ b/src/core/utils/internal/requestHandlerUtils.ts
@@ -4,7 +4,9 @@ export function use(
   currentHandlers: Array<RequestHandler>,
   ...handlers: Array<RequestHandler>
 ): void {
-  currentHandlers.unshift(...handlers)
+  for (let i = handlers.length - 1; i >= 0; i--) {
+    currentHandlers.unshift(handlers[i])
+  }
 }
 
 export function restoreHandlers(handlers: Array<RequestHandler>): void {

--- a/src/core/utils/logging/serializeRequest.ts
+++ b/src/core/utils/logging/serializeRequest.ts
@@ -1,3 +1,5 @@
+import { memoizedUrl } from '../memoizedUrl'
+
 export interface LoggedRequest {
   url: URL
   method: string
@@ -15,7 +17,7 @@ export async function serializeRequest(
   const requestText = await requestClone.text()
 
   return {
-    url: new URL(request.url),
+    url: memoizedUrl(request.url),
     method: request.method,
     headers: Object.fromEntries(request.headers.entries()),
     body: requestText,

--- a/src/core/utils/matching/matchRequestUrl.ts
+++ b/src/core/utils/matching/matchRequestUrl.ts
@@ -52,10 +52,13 @@ export function coercePath(path: string): string {
   )
 }
 
+const cache = new Map<string, Match>()
 /**
  * Returns the result of matching given request URL against a mask.
  */
 export function matchRequestUrl(url: URL, path: Path, baseUrl?: string): Match {
+  const key = `${url}|${path}|${baseUrl}`
+  if (cache.has(key)) return cache.get(key) as Match
   const normalizedPath = normalizePath(path, baseUrl)
   const cleanPath =
     typeof normalizedPath === 'string'
@@ -66,8 +69,10 @@ export function matchRequestUrl(url: URL, path: Path, baseUrl?: string): Match {
   const result = match(cleanPath, { decode: decodeURIComponent })(cleanUrl)
   const params = (result && (result.params as PathParams)) || {}
 
-  return {
+  const matchObject = {
     matches: result !== false,
     params,
   }
+  cache.set(key, matchObject)
+  return matchObject
 }

--- a/src/core/utils/memoizedUrl.ts
+++ b/src/core/utils/memoizedUrl.ts
@@ -1,0 +1,9 @@
+const cache = new Map<string, URL>()
+
+export function memoizedUrl(url: string, base?: string): URL {
+  const key = `${url}|${base}`
+  if (!cache.has(key)) {
+    cache.set(key, new URL(url, base))
+  }
+  return cache.get(key) as URL
+}

--- a/src/core/utils/request/getPublicUrlFromRequest.ts
+++ b/src/core/utils/request/getPublicUrlFromRequest.ts
@@ -1,3 +1,5 @@
+import { memoizedUrl } from '../memoizedUrl'
+
 /**
  * Returns a relative URL if the given request URL is relative to the current origin.
  * Otherwise returns an absolute URL.
@@ -7,7 +9,7 @@ export function getPublicUrlFromRequest(request: Request): string {
     return request.url
   }
 
-  const url = new URL(request.url)
+  const url = memoizedUrl(request.url)
 
   return url.origin === location.origin
     ? url.pathname

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es6",
+    "target": "es2020",
     "module": "esnext",
     "moduleResolution": "node",
     "strictNullChecks": true,


### PR DESCRIPTION
Expanding from: https://github.com/mswjs/msw/pull/1900

I was interested in trying to optimize the `handleRequest` pipeline without making substantial changes.  I hope this can help inform some future updates suggested in https://github.com/mswjs/msw/discussions/1901 and other related areas. 

I don't expect this branch to land directly at all, but solely to be used as discovery

## Takeaways

We can make significant improvements to performance and scalability with a few relatively small code changes. 

- Prior to executing handlers create a `requestUrl = new URL(request.url) and `mainRequestRef = request.clone()` passing them directly to each handler. We may not even need a `mainRequestRef` at all, as it doesn't seem used anywhere directly. We might not need to memoize `new URL` if we extract that outside of the handlers, but we'd still have this cost where we might not need it as frequently
- Cache `matchRequestUrl` lazily. Every request has to hit all paths, but once that occurs we'll be able to precompute the matches later, so we should be ok to re-use those after initial matching, giving a good cache key
- Cache `parseGraphQLRequest` results across handlers for a given request. Should we also cache the actual query parse here, which may be the same for multiple variables, where that input might currently not be identical - we should verify this (I did not try that yet)
- Cache `getAllRequestCookies` - this is actually cheap compared to everything else discussed above

## Test structure

Before: MSW v2.0.9 (with the `unshift` fix from this branch)
After: this branch

Results are described as a single run, and not a many run average, but they are very stable results so they're indicative of larger test windows

Using my m1 macbook pro, latest chrome. 2 tabs open (this issue and a vite sample project - code below)
100,000 handlers configured.

Fresh page load:

- Perform a single `http` request to the first handler.
- Perform a single `http` request to the last handler.
- Perform a second `http` request to the last handler

Fresh page load: 

- Perform a single `graphql` request to the first handler.
- Perform a single `graphql` request to the last handler.
- Perform a second `graphql` request to the last handler

## Before

### Http

1st handler: 5ms
Last handler (1x): 10.42s
Last handler (2x): 10.97s

<img width="550" alt="Screen Shot 2023-12-03 at 8 46 18 AM" src="https://github.com/mswjs/msw/assets/8616962/4bf805fd-d2a0-4980-803c-9bc2bfa2fc17">


### Graphql

1st handler: 6ms
Last handler (1x): 13.20s
Last handler (2x): 13.15s

<img width="548" alt="Screen Shot 2023-12-03 at 8 45 16 AM" src="https://github.com/mswjs/msw/assets/8616962/bc123d7a-b1b9-4911-a32a-eb09293be078">


## After 

### Http

1st handler: 5ms
Last handler (1x): 2.41s
Last handler (2x): 818ms

<img width="550" alt="Screen Shot 2023-12-03 at 8 56 26 AM" src="https://github.com/mswjs/msw/assets/8616962/1497e32d-717e-4c1a-9ba3-6f91c8a45136">

### Graphql

1st handler: 6ms
Last handler (1x): 1.83s
Last handler (2x): 1.81s

<img width="546" alt="Screen Shot 2023-12-03 at 8 56 45 AM" src="https://github.com/mswjs/msw/assets/8616962/c6f7d815-d5bc-4faa-ac2c-2c284f813677">

## Findings

1st handler results stay about identical.
Last handler results improve drastically
- HTTP 
    - last handler first request - 76.3%
    - last handler last request - 92.5%
    - average last handler improvement - 84.98%
- GraphQL
    - last handler first request - 86.1%
    - last handler last request - 86.2%
    - average last handler improvement - 86.15%

Obviously these results are extreme because of the number of handlers, but even for more moderate handler numbers these results are very promising

When a smaller, 50 handler set is used (raw numbers only)

Before:
- Http
    - first handler - 4ms
    - last handler (1x) - 13ms
    - last handler (2x) - 13ms
- GrapQL
    - first handler - 5ms
    - last handler (1x) - 15ms
    - last handler (2x) - 16ms

After:

- Http
    - first handler - 4ms
    - last handler (1x) - 6ms
    - last handler (2x) - 6ms
- GrapQL
    - first handler - 4ms
    - last handler (1x) - 6ms
    - last handler (2x) - 6ms

## Description of changes

Setup changes, equal across tests

* <a href="diffhunk://#diff-c9e56be02b046c738d10384a7b8490e0ea21fc397f6904d2b88dcc58fc745b34R62-R64">`src/core/SetupApi.ts`</a> and <a href="diffhunk://#diff-ea77d8a9f875c81840eb3b697aa5bcbda54cb96619c7a20a915313877626663bR7-R9">`src/core/utils/internal/requestHandlerUtils.ts`</a>: Instead if calling unshift with a spread, loop through the handlers in reverse and unshift them individually. This avoids maximum stack issues when a large number of handlers are 'use'd. Spreading forces the arguments all onto the stack, which is why it overflows. <a href="diffhunk://#diff-c9e56be02b046c738d10384a7b8490e0ea21fc397f6904d2b88dcc58fc745b34L62-R64">[1]</a> <a href="diffhunk://#diff-ea77d8a9f875c81840eb3b697aa5bcbda54cb96619c7a20a915313877626663bL7-R9">[2]</a>
* <a href="diffhunk://#diff-0b280a445be167f54cd916c0718c952b8e0d4ca9621903d05eec25efd4c6ed6dL4-R4">`tsconfig.base.json`</a>: Updated the TypeScript target version from ES6 to ES2020. These made debugging/testing simpler, since we don't create generators for promise resolution

Performance improvements:

* <a href="diffhunk://#diff-b6e49d193f2bfa26b1cbca804c9bc9636e72f980f5264116d49f0d3a43cc4a5fR1-R9">`src/core/utils/memoizedUrl.ts`</a>: Introduced a `memoizedUrl` function to create and cache URL objects, reducing the overhead of repeatedly creating new URL objects.
* <a href="diffhunk://#diff-b2f9353d793b757713c58e3398de4e1f6975c46c5279c9595e1f80a8a6eefca6R192">`src/core/handlers/RequestHandler.ts`</a>: Reduced unnecessary request cloning by introducing a `mainRefCache` to store a reference to the original request. We probably don't need to clone this at all, but minimizing changes to call signatures meant we needed to provide a clone to the execution result for the one handler that matches. We don't seem to read this, so maybe we don't need it.  If we _do_ can we do this prior to starting the resolution pipeline?  <a href="diffhunk://#diff-b2f9353d793b757713c58e3398de4e1f6975c46c5279c9595e1f80a8a6eefca6R192">[1]</a> <a href="diffhunk://#diff-b2f9353d793b757713c58e3398de4e1f6975c46c5279c9595e1f80a8a6eefca6L201-R223">[2]</a> <a href="diffhunk://#diff-b2f9353d793b757713c58e3398de4e1f6975c46c5279c9595e1f80a8a6eefca6L241-L242">[3]</a>
* <a href="diffhunk://#diff-c604d2555e89b3bedcb745c2e268a3f04e2b45f300061e31a7e1782a2000a6baR170-R182">`src/core/utils/internal/parseGraphQLRequest.ts`</a>: Added a caching mechanism to the `parseGraphQLRequest` function to store and reuse the parsed result of a GraphQL request. <a href="diffhunk://#diff-c604d2555e89b3bedcb745c2e268a3f04e2b45f300061e31a7e1782a2000a6baR170-R182">[1]</a> <a href="diffhunk://#diff-c604d2555e89b3bedcb745c2e268a3f04e2b45f300061e31a7e1782a2000a6baL188-R191">[2]</a> <a href="diffhunk://#diff-c604d2555e89b3bedcb745c2e268a3f04e2b45f300061e31a7e1782a2000a6baL199-R209">[3]</a>
* <a href="diffhunk://#diff-bb49a1e12580b5a8cd56124a5e43fc4681fe563544546886d6d8445bfaf523a8R55-R61">`src/core/utils/matching/matchRequestUrl.ts`</a>: Introduced a cache in the `matchRequestUrl` function to store and reuse the result of URL-path matching. <a href="diffhunk://#diff-bb49a1e12580b5a8cd56124a5e43fc4681fe563544546886d6d8445bfaf523a8R55-R61">[1]</a> <a href="diffhunk://#diff-bb49a1e12580b5a8cd56124a5e43fc4681fe563544546886d6d8445bfaf523a8L69-R77">[2]</a>
* <a href="diffhunk://#diff-3abcaf3e23405a6ac736486689634065f5c5b6ef27f366f1ea6c1abe997bf1f1R41-R43">`src/core/utils/request/getRequestCookies.ts`</a>: Added a cache to the `getAllRequestCookies` function to store and reuse the parsed cookies from a request. <a href="diffhunk://#diff-3abcaf3e23405a6ac736486689634065f5c5b6ef27f366f1ea6c1abe997bf1f1R41-R43">[1]</a> <a href="diffhunk://#diff-3abcaf3e23405a6ac736486689634065f5c5b6ef27f366f1ea6c1abe997bf1f1L71-R79">[2]</a>



## Code used in test setup:

```tsx
import { createRoot } from "react-dom/client";
import { setupWorker } from "msw/browser";
import { Outlet, RouterProvider, createBrowserRouter } from "react-router-dom";
import { HttpResponse, graphql, http } from "msw";

const worker = setupWorker();
const FIRST = 1;
const LAST = 100_000;
const Layout = () => {
  return (
    <main>
      <nav>
        <ul>
          <li>
            <a href="/graphql">GraphQL</a>
          </li>
          <li>
            <a href="/http">HTTP</a>
          </li>
        </ul>
      </nav>
      <Outlet />
    </main>
  );
};

function GraphQL() {
  return (
    <>
      <h1>GraphQL</h1>
      <button
        onClick={() => {
          makeGraphqlRequest(FIRST);
        }}
      >
        {FIRST}
      </button>
      <button
        onClick={() => {
          makeGraphqlRequest(LAST);
        }}
      >
        {LAST}
      </button>
    </>
  );
}

function Http() {
  return (
    <>
      <h1>Http</h1>
      <button
        onClick={() => {
          makeHttpRequest(FIRST);
        }}
      >
        {FIRST}
      </button>
      <button
        onClick={() => {
          makeHttpRequest(LAST);
        }}
      >
        {LAST}
      </button>
    </>
  );
}

worker.start().then(() => {
  const router = createBrowserRouter([
    {
      path: "/",
      element: <Layout />,
      children: [
        {
          path: "graphql",
          element: <GraphQL />,
          loader() {
            worker.restoreHandlers();
            worker.use(
              ...Array.from({ length: LAST }, (_, i) => {
                return graphql.query(`GetUser${i + 1}`, () => {
                  return HttpResponse.json({
                    data: {
                      user: {
                        id: i + 1,
                      },
                    },
                  });
                });
              })
            );
            return {};
          },
        },
        {
          path: "http",
          element: <Http />,
          loader() {
            worker.restoreHandlers();
            worker.use(
              ...Array.from({ length: LAST }, (_, i) => {
                return http.post(`/http/${i + 1}`, () => {
                  return HttpResponse.json({
                    data: {
                      user: {
                        id: i + 1,
                      },
                    },
                  });
                });
              })
            );
            return {};
          },
        },
      ],
    },
  ]);
  createRoot(document.getElementById("app")!).render(
    <RouterProvider router={router} />
  );
});

// share identical request shape and data to minimze graphql<-> http differences
function toRequestInit(id: number): RequestInit {
  return {
    method: "POST",
    headers: {
      "Content-Type": "application/json",
    },
    body: JSON.stringify({
      query: `
            query GetUser${id} {
              user {
                id
              }
            }
          `,
    }),
  };
}

function makeGraphqlRequest(id: number) {
  return fetch("/graphql", toRequestInit(id));
}

function makeHttpRequest(id: number) {
  return fetch(`/http/${id}`, toRequestInit(id));
}
```