### PR TITLE
test: reproduction of MaxListenersExceededWarning in `msw/node`

### DIFF
--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -19,10 +19,12 @@ class SetupServerApi extends BaseSetupServerApi implements SetupServer {
    */
   protected override onRequest(request: Request): void {
     try {
-      setMaxListeners(
-        Math.max(defaultMaxListeners, this.currentHandlers.length),
-        request.signal,
-      )
+      if (typeof setMaxListeners === 'function') {
+        setMaxListeners(
+          Math.max(defaultMaxListeners, this.currentHandlers.length),
+          request.signal,
+        )
+      }
     } catch (error: unknown) {
       /**
        * @note Mock environments (JSDOM, ...) are not able to implement an internal

--- a/test/node/regressions/many-request-handlers-jsdom.test.ts
+++ b/test/node/regressions/many-request-handlers-jsdom.test.ts
@@ -66,7 +66,7 @@ afterAll(async () => {
 })
 
 it('does not print a memory leak warning when having many request handlers', async () => {
-  const httpResponse = await fetch(`${httpServer.http.url(`/resource/42`)}`, {
+  const httpResponse = await fetch(`${httpServer.http.url(`/resource/99`)}`, {
     method: 'POST',
     body: 'request-body-',
   }).then((response) => response.text())
@@ -78,7 +78,7 @@ it('does not print a memory leak warning when having many request handlers', asy
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      query: `query Get42 { index }`,
+      query: `query Get99 { index }`,
     }),
   }).then((response) => response.json())
 
@@ -87,8 +87,8 @@ it('does not print a memory leak warning when having many request handlers', asy
   expect(process.stderr.write).not.toHaveBeenCalled()
 
   // Must return the mocked response.
-  expect(httpResponse).toBe('request-body-42')
-  expect(graphqlResponse).toEqual({ data: { index: 42 } })
+  expect(httpResponse).toBe('request-body-99')
+  expect(graphqlResponse).toEqual({ data: { index: 99 } })
 
   const unhandledResponse = await fetch(httpServer.http.url('/graphql'), {
     method: 'POST',

--- a/test/node/regressions/many-request-handlers-jsdom.test.ts
+++ b/test/node/regressions/many-request-handlers-jsdom.test.ts
@@ -55,7 +55,7 @@ beforeAll(async () => {
   })
 
   server = setupServer(...restHandlers, ...graphqlHandlers)
-  server.listen({ onUnhandledRequest: 'bypass' })
+  server.listen()
   vi.spyOn(process.stderr, 'write')
 })
 

--- a/test/node/regressions/many-request-handlers.test.ts
+++ b/test/node/regressions/many-request-handlers.test.ts
@@ -1,45 +1,68 @@
 /**
  * @vitest-environment node
  */
+import { HttpServer } from '@open-draft/test-server/http'
 import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import * as nodeEvents from 'node:events'
 
-// Create a large number of request handlers.
-const restHandlers = new Array(100).fill(null).map((_, index) => {
-  return http.post(
-    `https://example.com/resource/${index}`,
-    async ({ request }) => {
-      const text = await request.text()
-      return HttpResponse.text(text + index.toString())
-    },
-  )
-})
-
-const graphqlHanlers = new Array(100).fill(null).map((_, index) => {
-  return graphql.query(`Get${index}`, () => {
-    return HttpResponse.json({ data: { index } })
+const httpServer = new HttpServer((app) => {
+  app.post('/graphql', (_, res) => {
+    return res.status(500).send('original-response')
   })
 })
 
-const server = setupServer(...restHandlers, ...graphqlHanlers)
+vi.mock('node:events', async () => {
+  const actual = (await vi.importActual('node:events')) as import('node:events')
+  return {
+    ...actual,
+    setMaxListeners: vi.fn(actual.setMaxListeners),
+  }
+})
 
-beforeAll(() => {
-  server.listen()
+let server: ReturnType<typeof setupServer>
+
+const spy = vi.mocked(nodeEvents.setMaxListeners)
+
+beforeAll(async () => {
+  await httpServer.listen()
+
+  // Create a large number of request handlers.
+  const restHandlers = new Array(100).fill(null).map((_, index) => {
+    return http.post(
+      httpServer.http.url(`/resource/${index}`),
+      async ({ request }) => {
+        const text = await request.text()
+        return HttpResponse.text(text + index.toString())
+      },
+    )
+  })
+
+  const graphqlHandlers = new Array(100).fill(null).map((_, index) => {
+    return graphql.query(`Get${index}`, () => {
+      return HttpResponse.json({ data: { index } })
+    })
+  })
+
+  server = setupServer(...restHandlers, ...graphqlHandlers)
+  server.listen({ onUnhandledRequest: 'bypass' })
   vi.spyOn(process.stderr, 'write')
 })
 
-afterAll(() => {
+afterAll(async () => {
   server.close()
   vi.restoreAllMocks()
+  await httpServer.close()
 })
 
 it('does not print a memory leak warning when having many request handlers', async () => {
-  const httpResponse = await fetch('https://example.com/resource/42', {
+  const httpResponse = await fetch(`${httpServer.http.url(`/resource/42`)}`, {
     method: 'POST',
     body: 'request-body-',
   }).then((response) => response.text())
+  expect(spy).toHaveBeenNthCalledWith(1, 200, expect.any(AbortSignal))
 
-  const graphqlResponse = await fetch('https://example.com', {
+  const graphqlResponse = await fetch(httpServer.http.url('/graphql'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -49,10 +72,27 @@ it('does not print a memory leak warning when having many request handlers', asy
     }),
   }).then((response) => response.json())
 
+  expect(spy).toHaveBeenNthCalledWith(2, 200, expect.any(AbortSignal))
   // Must not print any memory leak warnings.
   expect(process.stderr.write).not.toHaveBeenCalled()
 
   // Must return the mocked response.
   expect(httpResponse).toBe('request-body-42')
   expect(graphqlResponse).toEqual({ data: { index: 42 } })
+
+  const unhandledResponse = await fetch(httpServer.http.url('/graphql'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: `query NotDefinedAtAll { index }`,
+    }),
+  })
+
+  expect(unhandledResponse.status).toEqual(500)
+
+  expect(spy).toHaveBeenNthCalledWith(3, 200, expect.any(AbortSignal))
+  // Must not print any memory leak warnings.
+  expect(process.stderr.write).not.toHaveBeenCalled()
 })

--- a/test/node/regressions/many-request-handlers.test.ts
+++ b/test/node/regressions/many-request-handlers.test.ts
@@ -56,7 +56,7 @@ afterAll(async () => {
 })
 
 it('does not print a memory leak warning when having many request handlers', async () => {
-  const httpResponse = await fetch(`${httpServer.http.url(`/resource/42`)}`, {
+  const httpResponse = await fetch(`${httpServer.http.url(`/resource/99`)}`, {
     method: 'POST',
     body: 'request-body-',
   }).then((response) => response.text())
@@ -68,7 +68,7 @@ it('does not print a memory leak warning when having many request handlers', asy
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      query: `query Get42 { index }`,
+      query: `query Get99 { index }`,
     }),
   }).then((response) => response.json())
 
@@ -77,8 +77,8 @@ it('does not print a memory leak warning when having many request handlers', asy
   expect(process.stderr.write).not.toHaveBeenCalled()
 
   // Must return the mocked response.
-  expect(httpResponse).toBe('request-body-42')
-  expect(graphqlResponse).toEqual({ data: { index: 42 } })
+  expect(httpResponse).toBe('request-body-99')
+  expect(graphqlResponse).toEqual({ data: { index: 99 } })
 
   const unhandledResponse = await fetch(httpServer.http.url('/graphql'), {
     method: 'POST',

--- a/test/node/regressions/many-request-handlers.test.ts
+++ b/test/node/regressions/many-request-handlers.test.ts
@@ -6,14 +6,6 @@ import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import * as nodeEvents from 'node:events'
 
-const httpServer = new HttpServer((app) => {
-  app.post('/graphql', (_, res) => {
-    return res.status(500).send('original-response')
-  })
-})
-
-const requestCloneSpy = vi.spyOn(Request.prototype, 'clone')
-
 vi.mock('node:events', async () => {
   const actual = (await vi.importActual('node:events')) as import('node:events')
   return {
@@ -22,33 +14,31 @@ vi.mock('node:events', async () => {
   }
 })
 
-let server: ReturnType<typeof setupServer>
+const httpServer = new HttpServer((app) => {
+  app.post('/graphql', (_, res) => {
+    return res.status(500).send('original-response')
+  })
+  app.post('/resource/not-defined', (_, res) => {
+    return res.status(500).send('original-response')
+  })
+})
 
-const spy = vi.mocked(nodeEvents.setMaxListeners)
+const server = setupServer()
+
+const requestCloneSpy = vi.spyOn(Request.prototype, 'clone')
+const setMaxListenersSpy = vi.mocked(nodeEvents.setMaxListeners)
+const stdErrSpy = vi.spyOn(process.stderr, 'write')
+
+const NUMBER_OF_REQUEST_HANDLERS = 100
 
 beforeAll(async () => {
   await httpServer.listen()
-
-  // Create a large number of request handlers.
-  const restHandlers = new Array(100).fill(null).map((_, index) => {
-    return http.post(
-      httpServer.http.url(`/resource/${index}`),
-      async ({ request }) => {
-        const text = await request.text()
-        return HttpResponse.text(text + index.toString())
-      },
-    )
-  })
-
-  const graphqlHandlers = new Array(100).fill(null).map((_, index) => {
-    return graphql.query(`Get${index}`, () => {
-      return HttpResponse.json({ data: { index } })
-    })
-  })
-
-  server = setupServer(...restHandlers, ...graphqlHandlers)
   server.listen()
-  vi.spyOn(process.stderr, 'write')
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  vi.clearAllMocks()
 })
 
 afterAll(async () => {
@@ -57,55 +47,114 @@ afterAll(async () => {
   await httpServer.close()
 })
 
-it('does not print a memory leak warning when having many request handlers', async () => {
-  const httpResponse = await fetch(`${httpServer.http.url(`/resource/99`)}`, {
-    method: 'POST',
-    body: 'request-body-',
-  }).then((response) => response.text())
-  expect(spy).toHaveBeenNthCalledWith(1, 200, expect.any(AbortSignal))
-  // Each clone is a new AbortSignal listener which needs to be registered
-  expect(requestCloneSpy).toHaveBeenCalledTimes(100)
-  expect(process.stderr.write).not.toHaveBeenCalled()
-  requestCloneSpy.mockClear()
-
-  const graphqlResponse = await fetch(httpServer.http.url('/graphql'), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      query: `query Get99 { index }`,
-    }),
-  }).then((response) => response.json())
-
-  expect(spy).toHaveBeenNthCalledWith(2, 200, expect.any(AbortSignal))
-  // Each clone is a new AbortSignal listener which needs to be registered
-  expect(requestCloneSpy).toHaveBeenCalledTimes(300)
-  requestCloneSpy.mockClear()
-
-  // Must not print any memory leak warnings.
-  // expect(process.stderr.write).not.toHaveBeenCalled()
-
-  // Must return the mocked response.
-  expect(httpResponse).toBe('request-body-99')
-  expect(graphqlResponse).toEqual({ data: { index: 99 } })
-  // Must not print any memory leak warnings.
-  expect(process.stderr.write).not.toHaveBeenCalled()
-
-  const unhandledResponse = await fetch(httpServer.http.url('/graphql'), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      query: `query NotDefinedAtAll { index }`,
-    }),
+describe('http handlers', () => {
+  beforeEach(() => {
+    server.use(
+      ...new Array(NUMBER_OF_REQUEST_HANDLERS).fill(null).map((_, index) => {
+        return http.post(
+          httpServer.http.url(`/resource/${index}`),
+          async ({ request }) => {
+            const text = await request.text()
+            return HttpResponse.text(text + index.toString())
+          },
+        )
+      }),
+    )
   })
 
-  expect(unhandledResponse.status).toEqual(500)
+  it('does not print a memory leak warning for the last handler', async () => {
+    const httpResponse = await fetch(
+      `${httpServer.http.url(`/resource/${NUMBER_OF_REQUEST_HANDLERS - 1}`)}`,
+      {
+        method: 'POST',
+        body: 'request-body-',
+      },
+    ).then((response) => response.text())
+    expect(setMaxListenersSpy).toHaveBeenCalledWith(
+      NUMBER_OF_REQUEST_HANDLERS,
+      expect.any(AbortSignal),
+    )
+    // Each clone is a new AbortSignal listener which needs to be registered
+    expect(requestCloneSpy).toHaveBeenCalledTimes(NUMBER_OF_REQUEST_HANDLERS)
+    expect(httpResponse).toBe(`request-body-${NUMBER_OF_REQUEST_HANDLERS - 1}`)
+    expect(stdErrSpy).not.toHaveBeenCalled()
+  })
 
-  expect(requestCloneSpy).toHaveBeenCalledTimes(301)
-  expect(spy).toHaveBeenNthCalledWith(3, 200, expect.any(AbortSignal))
-  // Must not print any memory leak warnings.
-  expect(process.stderr.write).not.toHaveBeenCalled()
+  it('does not print a memory leak warning for onUnhandledRequest', async () => {
+    const httpResponse = await fetch(
+      `${httpServer.http.url(`/resource/not-defined`)}`,
+      {
+        method: 'POST',
+        body: 'request-body-',
+      },
+    )
+    expect(setMaxListenersSpy).toHaveBeenCalledWith(
+      NUMBER_OF_REQUEST_HANDLERS,
+      expect.any(AbortSignal),
+    )
+    // Each clone is a new AbortSignal listener which needs to be registered
+    expect(requestCloneSpy).toHaveBeenCalledTimes(
+      NUMBER_OF_REQUEST_HANDLERS + 1,
+    )
+    expect(httpResponse.status).toBe(500)
+    expect(stdErrSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('graphql handlers', () => {
+  beforeEach(() => {
+    server.use(
+      ...new Array(NUMBER_OF_REQUEST_HANDLERS).fill(null).map((_, index) => {
+        return graphql.query(`Get${index}`, () => {
+          return HttpResponse.json({ data: { index } })
+        })
+      }),
+    )
+  })
+  it('does not print a memory leak warning', async () => {
+    const graphqlResponse = await fetch(httpServer.http.url('/graphql'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: `query Get${NUMBER_OF_REQUEST_HANDLERS - 1} { index }`,
+      }),
+    }).then((response) => response.json())
+
+    expect(setMaxListenersSpy).toHaveBeenCalledWith(
+      NUMBER_OF_REQUEST_HANDLERS,
+      expect.any(AbortSignal),
+    )
+    // Each clone is a new AbortSignal listener which needs to be registered
+    expect(requestCloneSpy).toHaveBeenCalledTimes(
+      NUMBER_OF_REQUEST_HANDLERS * 2,
+    )
+    expect(graphqlResponse).toEqual({
+      data: { index: NUMBER_OF_REQUEST_HANDLERS - 1 },
+    })
+    expect(stdErrSpy).not.toHaveBeenCalled()
+  })
+  it('does not print a memory leak warning for onUnhandledRequest', async () => {
+    const unhandledResponse = await fetch(httpServer.http.url('/graphql'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: `query NotDefinedAtAll { index }`,
+      }),
+    })
+
+    expect(unhandledResponse.status).toEqual(500)
+    expect(requestCloneSpy).toHaveBeenCalledTimes(
+      NUMBER_OF_REQUEST_HANDLERS * 2 + 1,
+    )
+    expect(setMaxListenersSpy).toHaveBeenCalledWith(
+      NUMBER_OF_REQUEST_HANDLERS,
+      expect.any(AbortSignal),
+    )
+    // Must not print any memory leak warnings.
+    expect(stdErrSpy).not.toHaveBeenCalled()
+  })
 })

--- a/test/node/regressions/many-request-handlers.test.ts
+++ b/test/node/regressions/many-request-handlers.test.ts
@@ -45,7 +45,7 @@ beforeAll(async () => {
   })
 
   server = setupServer(...restHandlers, ...graphqlHandlers)
-  server.listen({ onUnhandledRequest: 'bypass' })
+  server.listen()
   vi.spyOn(process.stderr, 'write')
 })
 

--- a/test/node/vitest.config.ts
+++ b/test/node/vitest.config.ts
@@ -1,6 +1,8 @@
 import * as path from 'node:path'
 import { defineConfig } from 'vitest/config'
 
+const LIB_DIR = path.resolve(__dirname, '../../lib')
+
 export default defineConfig({
   test: {
     /**
@@ -9,7 +11,10 @@ export default defineConfig({
     dir: './test/node',
     globals: true,
     alias: {
-      msw: path.resolve(__dirname, '../..'),
+      'msw/node': path.resolve(LIB_DIR, 'node/index.mjs'),
+      'msw/native': path.resolve(LIB_DIR, 'native/index.mjs'),
+      'msw/browser': path.resolve(LIB_DIR, 'browser/index.mjs'),
+      msw: path.resolve(LIB_DIR, 'core/index.mjs'),
     },
     environmentOptions: {
       jsdom: {


### PR DESCRIPTION
This test is expected to fail.  It shows a scenario where the current logic for `setMaxListeners` fails. 

relates to https://github.com/mswjs/msw/issues/1911

We actually have 2 separate places where this fails currently.

1 - some handlers will call multiple `Request.prototype.clone()`
2 - onUnhandledRequest behaviors call another handful of `Request.prototype.clone()`.
3 - Some of our clones are of clones, which will append listeners to the intermediate request (it seems)

The caching proposed in https://github.com/mswjs/msw/pull/1905 should actually help here as well, since we'll be more resource conscious we won't need to make nearly as many clones and therefore many fewer objects extended