### PR TITLE
fix: expose mockServiceWorker.js file in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "import": "./lib/native/index.mjs",
       "default": "./lib/native/index.js"
     },
+    "./mockServiceWorker.js": "./lib/mockServiceWorker.js",
     "./package.json": "./package.json"
   },
   "bin": {


### PR DESCRIPTION
Exposes the `mockServiceWorker.js` file so that it may be `require`d or `import`ed