### PR TITLE
fix(worker): compatible with env without crypto

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -107,7 +107,7 @@ self.addEventListener('fetch', function (event) {
   }
 
   // Generate unique request ID.
-  const requestId = crypto.randomUUID()
+  const requestId = crypto ？crypto.randomUUID() ：Math.random().toString(16).slice(2)
   event.respondWith(handleRequest(event, requestId))
 })
 

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -115,7 +115,7 @@ async function handleRequest(event, requestId) {
   const client = await resolveMainClient(event)
   const response = await getResponse(event, client, requestId)
 
-  // Send back the response clone for the "response:*" life-cle events.
+  // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
@@ -227,7 +227,7 @@ async function getResponse(event, client, requestId) {
         integrity: request.integrity,
         redirect: request.redirect,
         referrer: request.referrer,
-        referrerPoli: request.referrerPoli,
+        referrerPolicy: request.referrerPolicy,
         body: requestBuffer,
         keepalive: request.keepalive,
       },

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -107,7 +107,7 @@ self.addEventListener('fetch', function (event) {
   }
 
   // Generate unique request ID.
-  const requestId = crypto ？crypto.randomUUID() ：Math.random().toString(16).slice(2)
+  const requestId = crypto ? crypto.randomUUID() : Math.random().toString(16).slice(2)
   event.respondWith(handleRequest(event, requestId))
 })
 
@@ -115,7 +115,7 @@ async function handleRequest(event, requestId) {
   const client = await resolveMainClient(event)
   const response = await getResponse(event, client, requestId)
 
-  // Send back the response clone for the "response:*" life-cycle events.
+  // Send back the response clone for the "response:*" life-cle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
@@ -227,7 +227,7 @@ async function getResponse(event, client, requestId) {
         integrity: request.integrity,
         redirect: request.redirect,
         referrer: request.referrer,
-        referrerPolicy: request.referrerPolicy,
+        referrerPoli: request.referrerPoli,
         body: requestBuffer,
         keepalive: request.keepalive,
       },


### PR DESCRIPTION
Related #1762

Although `crypto` is safe, the lack of crypto global variables in some environments will cause `mockServiceWorker.js` to not work and I must manually fall back to `Math.random`
I hope to maintain compatible handling of `Math.random`.