### PR TITLE
fix: additional caching for improved handler performance

### DIFF
--- a/src/core/SetupApi.ts
+++ b/src/core/SetupApi.ts
@@ -59,7 +59,10 @@ export abstract class SetupApi<EventsMap extends EventMap> extends Disposable {
       ),
     )
 
-    this.currentHandlers.unshift(...runtimeHandlers)
+    // we don't spread the handlers to avoid maximum stack errors on very large sets of handlers
+    for (let i = runtimeHandlers.length - 1; i >= 0; i--) {
+      this.currentHandlers.unshift(runtimeHandlers[i])
+    }
   }
 
   public restoreHandlers(): void {

--- a/src/core/handlers/GraphQLHandler.test.ts
+++ b/src/core/handlers/GraphQLHandler.test.ts
@@ -170,6 +170,7 @@ describe('parse', () => {
         operationName: 'GetUser',
         query: GET_USER,
         variables: undefined,
+        cookies: {},
       })
     })
 
@@ -200,6 +201,7 @@ describe('parse', () => {
         variables: {
           userId: 'abc-123',
         },
+        cookies: {},
       })
     })
 
@@ -225,6 +227,7 @@ describe('parse', () => {
         operationName: 'GetUser',
         query: GET_USER,
         variables: undefined,
+        cookies: {},
       })
     })
 
@@ -255,6 +258,7 @@ describe('parse', () => {
         variables: {
           userId: 'abc-123',
         },
+        cookies: {},
       })
     })
   })
@@ -282,6 +286,7 @@ describe('parse', () => {
         operationName: 'Login',
         query: LOGIN,
         variables: undefined,
+        cookies: {},
       })
     })
 
@@ -312,6 +317,7 @@ describe('parse', () => {
         variables: {
           userId: 'abc-123',
         },
+        cookies: {},
       })
     })
 
@@ -337,6 +343,7 @@ describe('parse', () => {
         operationName: 'Login',
         query: LOGIN,
         variables: undefined,
+        cookies: {},
       })
     })
 
@@ -367,6 +374,7 @@ describe('parse', () => {
         variables: {
           userId: 'abc-123',
         },
+        cookies: {},
       })
     })
   })
@@ -403,6 +411,7 @@ describe('parse', () => {
         variables: {
           userId: 'abc-123',
         },
+        cookies: {},
       })
 
       await expect(
@@ -428,6 +437,7 @@ describe('parse', () => {
         variables: {
           userId: 'abc-123',
         },
+        cookies: {},
       })
     })
 
@@ -456,6 +466,7 @@ describe('parse', () => {
           matches: false,
           params: {},
         },
+        cookies: {},
       })
 
       await expect(
@@ -475,6 +486,7 @@ describe('parse', () => {
           matches: false,
           params: {},
         },
+        cookies: {},
       })
     })
 
@@ -503,6 +515,7 @@ describe('parse', () => {
           matches: false,
           params: {},
         },
+        cookies: {},
       })
 
       await expect(
@@ -522,6 +535,7 @@ describe('parse', () => {
           matches: false,
           params: {},
         },
+        cookies: {},
       })
     })
   })
@@ -738,6 +752,7 @@ describe('run', () => {
       variables: {
         userId: 'abc-123',
       },
+      cookies: {},
     })
     expect(result!.request.method).toBe('POST')
     expect(result!.request.url).toBe('https://example.com/')

--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -144,7 +144,7 @@ export class GraphQLHandler extends RequestHandler<
    * GraphQL handlers. This is done to avoid multiple parsing of the
    * request body, which each requires a clone of the request.
    */
-  private static async parseGraphQLRequestOrGetFromCache(
+  async parseGraphQLRequestOrGetFromCache(
     request: Request,
   ): Promise<ParsedGraphQLRequest<GraphQLVariables>> {
     if (!GraphQLHandler.parsedRequestCache.has(request)) {
@@ -165,19 +165,17 @@ export class GraphQLHandler extends RequestHandler<
      * If the request doesn't match a specified endpoint, there's no
      * need to parse it since there's no case where we would handle this
      */
-    const match = RequestHandler.matchRequestURLOrGetMatchFromCache(
+    const match = this.matchRequestURLOrGetMatchFromCache(
       urlFromRequestOrCache(args.request),
       this.endpoint,
     )
-    const cookies = RequestHandler.parseAllRequestCookiesOrGetFromCache(
-      args.request,
-    )
+    const cookies = this.parseAllRequestCookiesOrGetFromCache(args.request)
 
     if (!match.matches) {
       return { match, cookies }
     }
 
-    const parsedResult = await GraphQLHandler.parseGraphQLRequestOrGetFromCache(
+    const parsedResult = await this.parseGraphQLRequestOrGetFromCache(
       args.request,
     )
 

--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -144,7 +144,7 @@ export class GraphQLHandler extends RequestHandler<
    * GraphQL handlers. This is done to avoid multiple parsing of the
    * request body, which each requires a clone of the request.
    */
-  async parseGraphQLRequestOrGetFromCache(
+  private static async parseGraphQLRequestOrGetFromCache(
     request: Request,
   ): Promise<ParsedGraphQLRequest<GraphQLVariables>> {
     if (!GraphQLHandler.parsedRequestCache.has(request)) {
@@ -165,17 +165,19 @@ export class GraphQLHandler extends RequestHandler<
      * If the request doesn't match a specified endpoint, there's no
      * need to parse it since there's no case where we would handle this
      */
-    const match = this.matchRequestURLOrGetMatchFromCache(
+    const match = RequestHandler.matchRequestURLOrGetMatchFromCache(
       urlFromRequestOrCache(args.request),
       this.endpoint,
     )
-    const cookies = this.parseAllRequestCookiesOrGetFromCache(args.request)
+    const cookies = RequestHandler.parseAllRequestCookiesOrGetFromCache(
+      args.request,
+    )
 
     if (!match.matches) {
       return { match, cookies }
     }
 
-    const parsedResult = await this.parseGraphQLRequestOrGetFromCache(
+    const parsedResult = await GraphQLHandler.parseGraphQLRequestOrGetFromCache(
       args.request,
     )
 
@@ -185,11 +187,11 @@ export class GraphQLHandler extends RequestHandler<
 
     return {
       match,
+      cookies,
       query: parsedResult.query,
       operationType: parsedResult.operationType,
       operationName: parsedResult.operationName,
       variables: parsedResult.variables,
-      cookies,
     }
   }
 

--- a/src/core/handlers/HttpHandler.ts
+++ b/src/core/handlers/HttpHandler.ts
@@ -105,14 +105,12 @@ export class HttpHandler extends RequestHandler<
     request: Request
     resolutionContext?: ResponseResolutionContext
   }) {
-    const match = RequestHandler.matchRequestURLOrGetMatchFromCache(
+    const match = this.matchRequestURLOrGetMatchFromCache(
       urlFromRequestOrCache(args.request),
       this.info.path,
       args.resolutionContext?.baseUrl,
     )
-    const cookies = RequestHandler.parseAllRequestCookiesOrGetFromCache(
-      args.request,
-    )
+    const cookies = this.parseAllRequestCookiesOrGetFromCache(args.request)
 
     return {
       match,

--- a/src/core/handlers/HttpHandler.ts
+++ b/src/core/handlers/HttpHandler.ts
@@ -5,14 +5,9 @@ import { getStatusCodeColor } from '../utils/logging/getStatusCodeColor'
 import { getTimestamp } from '../utils/logging/getTimestamp'
 import { serializeRequest } from '../utils/logging/serializeRequest'
 import { serializeResponse } from '../utils/logging/serializeResponse'
-import {
-  matchRequestUrl,
-  Match,
-  Path,
-  PathParams,
-} from '../utils/matching/matchRequestUrl'
+import { Match, Path, PathParams } from '../utils/matching/matchRequestUrl'
 import { getPublicUrlFromRequest } from '../utils/request/getPublicUrlFromRequest'
-import { getAllRequestCookies } from '../utils/request/getRequestCookies'
+import { urlFromRequestOrCache } from '../utils/request/urlFromRequestOrCache'
 import { cleanUrl, getSearchParams } from '../utils/url/cleanUrl'
 import {
   RequestHandler,
@@ -110,13 +105,12 @@ export class HttpHandler extends RequestHandler<
     request: Request
     resolutionContext?: ResponseResolutionContext
   }) {
-    const url = new URL(args.request.url)
-    const match = matchRequestUrl(
-      url,
+    const match = this.matchRequestURLOrGetMatchFromCache(
+      urlFromRequestOrCache(args.request),
       this.info.path,
       args.resolutionContext?.baseUrl,
     )
-    const cookies = getAllRequestCookies(args.request)
+    const cookies = this.parseAllRequestCookiesOrGetFromCache(args.request)
 
     return {
       match,

--- a/src/core/handlers/HttpHandler.ts
+++ b/src/core/handlers/HttpHandler.ts
@@ -105,12 +105,14 @@ export class HttpHandler extends RequestHandler<
     request: Request
     resolutionContext?: ResponseResolutionContext
   }) {
-    const match = this.matchRequestURLOrGetMatchFromCache(
+    const match = RequestHandler.matchRequestURLOrGetMatchFromCache(
       urlFromRequestOrCache(args.request),
       this.info.path,
       args.resolutionContext?.baseUrl,
     )
-    const cookies = this.parseAllRequestCookiesOrGetFromCache(args.request)
+    const cookies = RequestHandler.parseAllRequestCookiesOrGetFromCache(
+      args.request,
+    )
 
     return {
       match,

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -190,7 +190,7 @@ export abstract class RequestHandler<
     Request,
     Record<string, string>
   >()
-  protected static parseAllRequestCookiesOrGetFromCache(
+  protected parseAllRequestCookiesOrGetFromCache(
     request: Request,
   ): Record<string, string> {
     let cookies = RequestHandler.cookiesForRequestCache.get(request)
@@ -202,7 +202,7 @@ export abstract class RequestHandler<
   }
 
   private static matchRequestUrlCache = new Map<string, Match>()
-  protected static matchRequestURLOrGetMatchFromCache(
+  protected matchRequestURLOrGetMatchFromCache(
     url: URL,
     path: Path,
     baseUrl?: string | undefined,

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -207,7 +207,7 @@ export abstract class RequestHandler<
     path: Path,
     baseUrl?: string | undefined,
   ): Match {
-    const cacheKey = `${url.toString()}|${path}|${baseUrl}`
+    const cacheKey = `${url}|${path}|${baseUrl}`
     let match = RequestHandler.matchRequestUrlCache.get(cacheKey)
     if (!match) {
       match = matchRequestUrl(url, path, baseUrl)

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -190,7 +190,7 @@ export abstract class RequestHandler<
     Request,
     Record<string, string>
   >()
-  protected parseAllRequestCookiesOrGetFromCache(
+  protected static parseAllRequestCookiesOrGetFromCache(
     request: Request,
   ): Record<string, string> {
     let cookies = RequestHandler.cookiesForRequestCache.get(request)
@@ -202,7 +202,7 @@ export abstract class RequestHandler<
   }
 
   private static matchRequestUrlCache = new Map<string, Match>()
-  protected matchRequestURLOrGetMatchFromCache(
+  protected static matchRequestURLOrGetMatchFromCache(
     url: URL,
     path: Path,
     baseUrl?: string | undefined,

--- a/src/core/utils/internal/parseGraphQLRequest.ts
+++ b/src/core/utils/internal/parseGraphQLRequest.ts
@@ -9,6 +9,7 @@ import { getPublicUrlFromRequest } from '../request/getPublicUrlFromRequest'
 import { devUtils } from './devUtils'
 import { jsonParse } from './jsonParse'
 import { parseMultipartData } from './parseMultipartData'
+import { urlFromRequestOrCache } from '../request/urlFromRequestOrCache'
 
 interface GraphQLInput {
   query: string | null
@@ -92,7 +93,7 @@ function extractMultipartVariables<VariablesType extends GraphQLVariables>(
 async function getGraphQLInput(request: Request): Promise<GraphQLInput | null> {
   switch (request.method) {
     case 'GET': {
-      const url = new URL(request.url)
+      const url = urlFromRequestOrCache(request)
       const query = url.searchParams.get('query')
       const variables = url.searchParams.get('variables') || ''
 

--- a/src/core/utils/internal/requestHandlerUtils.ts
+++ b/src/core/utils/internal/requestHandlerUtils.ts
@@ -4,7 +4,10 @@ export function use(
   currentHandlers: Array<RequestHandler>,
   ...handlers: Array<RequestHandler>
 ): void {
-  currentHandlers.unshift(...handlers)
+  // we don't spread the handlers to avoid maximum stack errors on very large sets of handlers
+  for (let i = handlers.length - 1; i >= 0; i--) {
+    currentHandlers.unshift(handlers[i])
+  }
 }
 
 export function restoreHandlers(handlers: Array<RequestHandler>): void {

--- a/src/core/utils/logging/serializeRequest.ts
+++ b/src/core/utils/logging/serializeRequest.ts
@@ -1,3 +1,5 @@
+import { urlFromRequestOrCache } from '../request/urlFromRequestOrCache'
+
 export interface LoggedRequest {
   url: URL
   method: string
@@ -15,7 +17,7 @@ export async function serializeRequest(
   const requestText = await requestClone.text()
 
   return {
-    url: new URL(request.url),
+    url: urlFromRequestOrCache(request),
     method: request.method,
     headers: Object.fromEntries(request.headers.entries()),
     body: requestText,

--- a/src/core/utils/request/getPublicUrlFromRequest.ts
+++ b/src/core/utils/request/getPublicUrlFromRequest.ts
@@ -1,3 +1,5 @@
+import { urlFromRequestOrCache } from './urlFromRequestOrCache'
+
 /**
  * Returns a relative URL if the given request URL is relative to the current origin.
  * Otherwise returns an absolute URL.
@@ -7,7 +9,7 @@ export function getPublicUrlFromRequest(request: Request): string {
     return request.url
   }
 
-  const url = new URL(request.url)
+  const url = urlFromRequestOrCache(request)
 
   return url.origin === location.origin
     ? url.pathname

--- a/src/core/utils/request/getRequestCookies.ts
+++ b/src/core/utils/request/getRequestCookies.ts
@@ -1,5 +1,6 @@
 import cookieUtils from '@bundled-es-modules/cookie'
 import { store } from '@mswjs/cookies'
+import { urlFromRequestOrCache } from './urlFromRequestOrCache'
 
 function getAllDocumentCookies() {
   return cookieUtils.parse(document.cookie)
@@ -19,7 +20,7 @@ export function getRequestCookies(request: Request): Record<string, string> {
 
   switch (request.credentials) {
     case 'same-origin': {
-      const url = new URL(request.url)
+      const url = urlFromRequestOrCache(request)
 
       // Return document cookies only when requested a resource
       // from the same origin as the current document.

--- a/src/core/utils/request/readResponseCookies.ts
+++ b/src/core/utils/request/readResponseCookies.ts
@@ -4,6 +4,6 @@ export function readResponseCookies(
   request: Request,
   response: Response,
 ): void {
-  store.add({ ...request, url: request.url.toString() }, response)
+  store.add({ ...request, url: request.url }, response)
   store.persist()
 }

--- a/src/core/utils/request/urlFromRequestOrCache.test.ts
+++ b/src/core/utils/request/urlFromRequestOrCache.test.ts
@@ -1,0 +1,28 @@
+import { urlFromRequestOrCache } from './urlFromRequestOrCache'
+
+test('should return the same URL object for the same request', () => {
+  const request = new Request('https://example.com')
+  const url = urlFromRequestOrCache(request)
+  const url2 = urlFromRequestOrCache(request)
+  expect(url).toBeInstanceOf(URL)
+  expect(url).toBe(url2)
+})
+
+test('should return the same URL object for requests to the same url', () => {
+  const request1 = new Request('https://example.com')
+  const request2 = new Request('https://example.com')
+  const url1 = urlFromRequestOrCache(request1)
+  const url2 = urlFromRequestOrCache(request2)
+  expect(url1).toBeInstanceOf(URL)
+  expect(url1).toBe(url2)
+})
+
+test('should return different URL objects for different requests to different urls', () => {
+  const request1 = new Request('https://example.com')
+  const request2 = new Request('https://example.com/foo')
+  const url1 = urlFromRequestOrCache(request1)
+  const url2 = urlFromRequestOrCache(request2)
+  expect(url1).toBeInstanceOf(URL)
+  expect(url2).toBeInstanceOf(URL)
+  expect(url1).not.toBe(url2)
+})

--- a/src/core/utils/request/urlFromRequestOrCache.ts
+++ b/src/core/utils/request/urlFromRequestOrCache.ts
@@ -1,5 +1,11 @@
 const urlCache = new Map<string, URL>()
 
+/**
+ * Returns the URL object for the given request. The URL object is cached so that
+ * subsequent calls to this function with the same request or requests to the same
+ * url will return the same URL object, to avoid multiple URL object allocations and
+ * parsing the same url multiple times.
+ */
 export function urlFromRequestOrCache(request: Request): URL {
   const requestUrl = request.url
   let url = urlCache.get(requestUrl)

--- a/src/core/utils/request/urlFromRequestOrCache.ts
+++ b/src/core/utils/request/urlFromRequestOrCache.ts
@@ -1,0 +1,11 @@
+const urlCache = new Map<string, URL>()
+
+export function urlFromRequestOrCache(request: Request): URL {
+  const requestUrl = request.url
+  let url = urlCache.get(requestUrl)
+  if (!url) {
+    url = new URL(requestUrl)
+    urlCache.set(requestUrl, url)
+  }
+  return url
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es6",
+    "target": "es2020",
     "module": "esnext",
     "moduleResolution": "node",
     "strictNullChecks": true,


### PR DESCRIPTION
The intent of this PR is to help discover if there's a good general purpose cache api we can expose from the handlers, and if not we can see where caching improves performance further and how much.

These are mostly changes first looked at in https://github.com/mswjs/msw/pull/1905

This is a majority of the low-hanging request cycle optimizations I think we can do with good benefit and little overhead.  
Further performance could be gained with a slightly modified storage structure, potentially (instead of solely linear request parsing, we could order them at registration into a more treelike structure, however this seems fairly complex compared to the low-hanging performance we can unlock from the small changes in this pr 

This pull request introduces changes primarily aimed at improving the efficiency of URL and cookie parsing in the codebase. The changes involve the creation of a caching mechanism to store parsed URLs and cookies from requests, reducing the need for repeated parsing of the same data. The changes affect several files, with the most significant changes in `src/core/handlers/GraphQLHandler.ts`, `src/core/handlers/HttpHandler.ts`, and `src/core/handlers/RequestHandler.ts`.

URL and Cookie Parsing Improvements:

* [`src/core/handlers/GraphQLHandler.ts`](diffhunk://#diff-4f6e30ee2bc5cda860683f2a951c396d0748ca4103bc5011406af10452da15c6L13-R13): The `matchRequestUrl` function has been replaced with a new method `matchRequestURLOrGetMatchFromCache` that retrieves the match from the cache if it exists, otherwise it matches the request URL and stores the result in the cache. The `getAllRequestCookies` function has been replaced with a new method `parseAllRequestCookiesOrGetFromCache` that retrieves the cookies from the cache if they exist, otherwise it parses the request cookies and stores the result in the cache. [[1]](diffhunk://#diff-4f6e30ee2bc5cda860683f2a951c396d0748ca4103bc5011406af10452da15c6L13-R13) [[2]](diffhunk://#diff-4f6e30ee2bc5cda860683f2a951c396d0748ca4103bc5011406af10452da15c6L22-R22) [[3]](diffhunk://#diff-4f6e30ee2bc5cda860683f2a951c396d0748ca4103bc5011406af10452da15c6R36) [[4]](diffhunk://#diff-4f6e30ee2bc5cda860683f2a951c396d0748ca4103bc5011406af10452da15c6L167-R188) [[5]](diffhunk://#diff-4f6e30ee2bc5cda860683f2a951c396d0748ca4103bc5011406af10452da15c6L227-R238)

* [`src/core/handlers/HttpHandler.ts`](diffhunk://#diff-93473d9ff9b2ac402a677635ffd0b18446d403d3f0fdbc3208878821a6f7621eL8-R10): Similar changes to `GraphQLHandler.ts` have been made, with the `matchRequestUrl` function replaced with `matchRequestURLOrGetMatchFromCache` and the `getAllRequestCookies` function replaced with `parseAllRequestCookiesOrGetFromCache`. [[1]](diffhunk://#diff-93473d9ff9b2ac402a677635ffd0b18446d403d3f0fdbc3208878821a6f7621eL8-R10) [[2]](diffhunk://#diff-93473d9ff9b2ac402a677635ffd0b18446d403d3f0fdbc3208878821a6f7621eL113-R113)

* [`src/core/handlers/RequestHandler.ts`](diffhunk://#diff-b2f9353d793b757713c58e3398de4e1f6975c46c5279c9595e1f80a8a6eefca6R7-R8): Added two new methods `parseAllRequestCookiesOrGetFromCache` and `matchRequestURLOrGetMatchFromCache` to handle the caching of parsed cookies and matched URLs. [[1]](diffhunk://#diff-b2f9353d793b757713c58e3398de4e1f6975c46c5279c9595e1f80a8a6eefca6R7-R8) [[2]](diffhunk://#diff-b2f9353d793b757713c58e3398de4e1f6975c46c5279c9595e1f80a8a6eefca6R189-R218)

* [`src/core/utils/internal/parseGraphQLRequest.ts`](diffhunk://#diff-c604d2555e89b3bedcb745c2e268a3f04e2b45f300061e31a7e1782a2000a6baR12): Replaced the direct creation of a new URL object from the request URL with a call to the `urlFromRequestOrCache` function. [[1]](diffhunk://#diff-c604d2555e89b3bedcb745c2e268a3f04e2b45f300061e31a7e1782a2000a6baR12) [[2]](diffhunk://#diff-c604d2555e89b3bedcb745c2e268a3f04e2b45f300061e31a7e1782a2000a6baL95-R96)

* [`src/core/utils/logging/serializeRequest.ts`](diffhunk://#diff-3d2523c54fda96d4289815b08d6ebb64046974137718b3ff6e6f2b929775b0e6R1-R2): Replaced the direct creation of a new URL object from the request URL with a call to the `urlFromRequestOrCache` function. [[1]](diffhunk://#diff-3d2523c54fda96d4289815b08d6ebb64046974137718b3ff6e6f2b929775b0e6R1-R2) [[2]](diffhunk://#diff-3d2523c54fda96d4289815b08d6ebb64046974137718b3ff6e6f2b929775b0e6L18-R20)

* [`src/core/utils/request/getPublicUrlFromRequest.ts`](diffhunk://#diff-d6fe2ee7b22908e609c9fabd5c44b0a46f289cb361e2c6613743aa41146879e6R1-R2): Replaced the direct creation of a new URL object from the request URL with a call to the `urlFromRequestOrCache` function. [[1]](diffhunk://#diff-d6fe2ee7b22908e609c9fabd5c44b0a46f289cb361e2c6613743aa41146879e6R1-R2) [[2]](diffhunk://#diff-d6fe2ee7b22908e609c9fabd5c44b0a46f289cb361e2c6613743aa41146879e6L10-R12)

* [`src/core/utils/request/getRequestCookies.ts`](diffhunk://#diff-3abcaf3e23405a6ac736486689634065f5c5b6ef27f366f1ea6c1abe997bf1f1R3): Replaced the direct creation of a new URL object from the request URL with a call to the `urlFromRequestOrCache` function. [[1]](diffhunk://#diff-3abcaf3e23405a6ac736486689634065f5c5b6ef27f366f1ea6c1abe997bf1f1R3) [[2]](diffhunk://#diff-3abcaf3e23405a6ac736486689634065f5c5b6ef27f366f1ea6c1abe997bf1f1L22-R23)

* [`src/core/utils/request/urlFromRequestOrCache.ts`](diffhunk://#diff-64f9b90225316396831f4860f42c924a2e713b7b4becde1315deb03d5c759a37R1-R17): Added a new utility function `urlFromRequestOrCache` that retrieves a URL object from a cache if it exists, otherwise it creates a new URL object from the request URL and stores it in the cache.

* [`src/core/utils/request/urlFromRequestOrCache.test.ts`](diffhunk://#diff-10691b760a41e2b3e265226621b2f924c96bad8bc56b527f3663d152075acd20R1-R28): Added new tests to verify the functionality of the `urlFromRequestOrCache` function.