### PR TITLE
chore: install playwright browsers on smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install
+
       - name: Test examples
         run: ./config/scripts/smoke-test.sh


### PR DESCRIPTION
Looks like after the recent updates to the examples repo (refreshed lockfile), Playwright browsers fail to install although individual packages install them in their `postinstall` hook.

Add the browser installation as the explicit step to the smoke tests. 