### PR TITLE
fix: annotate the "requestId" response resolver argument

### DIFF
--- a/src/core/handlers/GraphQLHandler.test.ts
+++ b/src/core/handlers/GraphQLHandler.test.ts
@@ -736,7 +736,8 @@ describe('run', () => {
         userId: 'abc-123',
       },
     })
-    const result = await handler.run({ request })
+    const requestId = 'requestId'
+    const result = await handler.run({ request, requestId })
 
     expect(result!.handler).toEqual(handler)
     expect(result!.parsedResult).toEqual({
@@ -777,7 +778,8 @@ describe('run', () => {
     const request = createPostGraphQLRequest({
       query: LOGIN,
     })
-    const result = await handler.run({ request })
+    const requestId = 'requestId'
+    const result = await handler.run({ request, requestId })
 
     expect(result).toBeNull()
   })
@@ -824,7 +826,8 @@ describe('request', () => {
         `,
     })
 
-    await handler.run({ request })
+    const requestId = 'requestId'
+    await handler.run({ request, requestId })
 
     expect(matchAllResolver).toHaveBeenCalledTimes(1)
     expect(matchAllResolver.mock.calls[0][0]).toHaveProperty(

--- a/src/core/handlers/GraphQLHandler.test.ts
+++ b/src/core/handlers/GraphQLHandler.test.ts
@@ -9,6 +9,7 @@ import {
   GraphQLResolverExtras,
   isDocumentNode,
 } from './GraphQLHandler'
+import { uuidv4 } from '../utils/internal/uuidv4'
 import { HttpResponse } from '../HttpResponse'
 import { ResponseResolver } from './RequestHandler'
 
@@ -736,7 +737,7 @@ describe('run', () => {
         userId: 'abc-123',
       },
     })
-    const requestId = 'requestId'
+    const requestId = uuidv4()
     const result = await handler.run({ request, requestId })
 
     expect(result!.handler).toEqual(handler)
@@ -778,7 +779,7 @@ describe('run', () => {
     const request = createPostGraphQLRequest({
       query: LOGIN,
     })
-    const requestId = 'requestId'
+    const requestId = uuidv4()
     const result = await handler.run({ request, requestId })
 
     expect(result).toBeNull()
@@ -826,7 +827,7 @@ describe('request', () => {
         `,
     })
 
-    const requestId = 'requestId'
+    const requestId = uuidv4()
     await handler.run({ request, requestId })
 
     expect(matchAllResolver).toHaveBeenCalledTimes(1)

--- a/src/core/handlers/HttpHandler.test.ts
+++ b/src/core/handlers/HttpHandler.test.ts
@@ -151,7 +151,8 @@ describe('run', () => {
   test('returns a mocked response given a matching request', async () => {
     const handler = new HttpHandler('GET', '/user/:userId', resolver)
     const request = new Request(new URL('/user/abc-123', location.href))
-    const result = await handler.run({ request })
+    const requestId = 'requestId'
+    const result = await handler.run({ request, requestId })
 
     expect(result!.handler).toEqual(handler)
     expect(result!.parsedResult).toEqual({
@@ -174,6 +175,7 @@ describe('run', () => {
     const handler = new HttpHandler('POST', '/login', resolver)
     const result = await handler.run({
       request: new Request(new URL('/users', location.href)),
+      requestId: 'requestId',
     })
 
     expect(result).toBeNull()
@@ -183,12 +185,13 @@ describe('run', () => {
     const handler = new HttpHandler('GET', '/users', resolver)
     const result = await handler.run({
       request: new Request(new URL('/users', location.href)),
+      requestId: 'requestId',
     })
 
     expect(result?.parsedResult?.match?.params).toEqual({})
   })
 
-  test('exhauses resolver until its generator completes', async () => {
+  test('exhausts resolver until its generator completes', async () => {
     const handler = new HttpHandler('GET', '/users', function* () {
       let count = 0
 
@@ -203,6 +206,7 @@ describe('run', () => {
     const run = async () => {
       const result = await handler.run({
         request: new Request(new URL('/users', location.href)),
+        requestId: 'requestId',
       })
       return result?.response?.text()
     }

--- a/src/core/handlers/HttpHandler.test.ts
+++ b/src/core/handlers/HttpHandler.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+import { uuidv4 } from '../utils/internal/uuidv4'
 import { HttpHandler, HttpRequestResolverExtras } from './HttpHandler'
 import { HttpResponse } from '..'
 import { ResponseResolver } from './RequestHandler'
@@ -151,7 +152,7 @@ describe('run', () => {
   test('returns a mocked response given a matching request', async () => {
     const handler = new HttpHandler('GET', '/user/:userId', resolver)
     const request = new Request(new URL('/user/abc-123', location.href))
-    const requestId = 'requestId'
+    const requestId = uuidv4()
     const result = await handler.run({ request, requestId })
 
     expect(result!.handler).toEqual(handler)
@@ -175,7 +176,7 @@ describe('run', () => {
     const handler = new HttpHandler('POST', '/login', resolver)
     const result = await handler.run({
       request: new Request(new URL('/users', location.href)),
-      requestId: 'requestId',
+      requestId: uuidv4(),
     })
 
     expect(result).toBeNull()
@@ -185,7 +186,7 @@ describe('run', () => {
     const handler = new HttpHandler('GET', '/users', resolver)
     const result = await handler.run({
       request: new Request(new URL('/users', location.href)),
-      requestId: 'requestId',
+      requestId: uuidv4(),
     })
 
     expect(result?.parsedResult?.match?.params).toEqual({})
@@ -206,7 +207,7 @@ describe('run', () => {
     const run = async () => {
       const result = await handler.run({
         request: new Request(new URL('/users', location.href)),
-        requestId: 'requestId',
+        requestId: uuidv4(),
       })
       return result?.response?.text()
     }

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -64,6 +64,7 @@ export type ResponseResolverInfo<
   RequestBodyType extends DefaultBodyType = DefaultBodyType,
 > = {
   request: StrictRequest<RequestBodyType>
+  requestId: string
 } & ResolverExtraInfo
 
 export type ResponseResolver<


### PR DESCRIPTION
After trying out https://github.com/mswjs/msw/pull/1942 I found the types weren't working as expected even though `requestId` was passing through

**Before**

<details>
<img width="403" alt="Screenshot 2024-01-15 at 8 07 00 AM" src="https://github.com/mswjs/msw/assets/5314713/5c56cd71-9780-47d1-826f-1a98899f1e78">
<img width="781" alt="Screenshot 2024-01-15 at 8 06 46 AM" src="https://github.com/mswjs/msw/assets/5314713/5915037a-679f-433a-b3fa-2b8d53ac8e53">

</details>

**After**
<details>
<img width="406" alt="Screenshot 2024-01-15 at 8 04 21 AM" src="https://github.com/mswjs/msw/assets/5314713/422d64c7-3f4a-4079-8e7e-dfb16e49170a">
</details>