### PR TITLE
fix: export "HttpRequestHandler" and "GraphQLRequestHandler" types

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,7 +34,7 @@ export type {
   RequestQuery,
   HttpRequestParsedResult,
 } from './handlers/HttpHandler'
-export type { HttpResponseResolver } from './http'
+export type { HttpRequestHandler, HttpResponseResolver } from './http'
 
 export type {
   GraphQLQuery,
@@ -42,7 +42,7 @@ export type {
   GraphQLRequestBody,
   GraphQLJsonRequestBody,
 } from './handlers/GraphQLHandler'
-export type { GraphQLResponseResolver } from './graphql'
+export type { GraphQLRequestHandler, GraphQLResponseResolver } from './graphql'
 
 export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
 export type { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'

--- a/test/typings/custom-handler.test-d.ts
+++ b/test/typings/custom-handler.test-d.ts
@@ -1,14 +1,23 @@
-import { http, HttpHandler, GraphQLHandler, graphql } from 'msw'
+import { http, HttpRequestHandler, GraphQLRequestHandler, graphql } from 'msw'
 import { setupWorker } from 'msw/browser'
 import { setupServer } from 'msw/node'
 
-function generateHttpHandler(): HttpHandler {
-  return http.get('/user', () => {})
+const generateHttpHandler: HttpRequestHandler = (path, resolver, options) => {
+  return http.get(path, resolver, options)
 }
 
-function generateGraphQLHandler(): GraphQLHandler {
-  return graphql.query('GetUser', () => {})
+const generateGraphQLHandler: GraphQLRequestHandler = (
+  operationName,
+  resolver,
+) => {
+  return graphql.query(operationName, resolver)
 }
 
-setupWorker(generateHttpHandler(), generateGraphQLHandler())
-setupServer(generateHttpHandler(), generateGraphQLHandler())
+setupWorker(
+  generateHttpHandler('/', () => {}),
+  generateGraphQLHandler('GetResource', () => {}),
+)
+setupServer(
+  generateHttpHandler('/', () => {}),
+  generateGraphQLHandler('GetResource', () => {}),
+)


### PR DESCRIPTION
In #1961, I forgot to export the newly introduced `HttpRequestHandler` and `GraphQLRequestHandler` types. This adds them to the exports of the core. Also, adjusts the type tests for custom handlers to actually use those types. 