### PR TITLE
chore: update minimal node version in browser template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-issue-browser.yml
+++ b/.github/ISSUE_TEMPLATE/01-issue-browser.yml
@@ -22,7 +22,7 @@ body:
       options:
         - label: I'm using the [latest](https://github.com/mswjs/msw/releases/latest) `msw` version
           required: true
-        - label: I'm using Node.js version 14 or higher
+        - label: I'm using Node.js version 18 or higher
           required: true
 
   - type: dropdown


### PR DESCRIPTION
Prevents wrong Node version mentions in browser issue reports. 