### PR TITLE
fix: export "getResponse" for batched GraphQL queries

### DIFF
--- a/src/core/getResponse.test.ts
+++ b/src/core/getResponse.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment node
+ */
+import { http } from './http'
+import { getResponse } from './getResponse'
+
+it('returns undefined given empty headers array', async () => {
+  expect(
+    await getResponse([], new Request('http://localhost/')),
+  ).toBeUndefined()
+})
+
+it('returns undefined given no matching handlers', async () => {
+  expect(
+    await getResponse(
+      [http.get('/product', () => void 0)],
+      new Request('http://localhost/user'),
+    ),
+  ).toBeUndefined()
+})
+
+it('returns undefined given a matching handler that returned no response', async () => {
+  expect(
+    await getResponse(
+      [http.get('*/user', () => void 0)],
+      new Request('http://localhost/user'),
+    ),
+  ).toBeUndefined()
+})
+
+it('returns undefined given a matching handler that returned explicit undefined', async () => {
+  expect(
+    await getResponse(
+      [http.get('*/user', () => undefined)],
+      new Request('http://localhost/user'),
+    ),
+  ).toBeUndefined()
+})
+
+it('returns the response returned from a matching handler', async () => {
+  const response = await getResponse(
+    [http.get('*/user', () => Response.json({ name: 'John' }))],
+    new Request('http://localhost/user'),
+  )
+
+  expect(response?.status).toBe(200)
+  expect(response?.headers.get('Content-Type')).toBe('application/json')
+  expect(await response?.json()).toEqual({ name: 'John' })
+})
+
+it('returns the response from the first matching handler if multiple match', async () => {
+  const response = await getResponse(
+    [
+      http.get('*/user', () => Response.json({ name: 'John' })),
+      http.get('*/user', () => Response.json({ name: 'Kate' })),
+    ],
+    new Request('http://localhost/user'),
+  )
+
+  expect(response?.status).toBe(200)
+  expect(response?.headers.get('Content-Type')).toBe('application/json')
+  expect(await response?.json()).toEqual({ name: 'John' })
+})

--- a/src/core/getResponse.ts
+++ b/src/core/getResponse.ts
@@ -1,0 +1,16 @@
+import type { RequestHandler } from './handlers/RequestHandler'
+import { executeHandlers } from './utils/executeHandlers'
+import { randomId } from './utils/internal/randomId'
+
+export const getResponse = async (args: {
+  request: Request
+  handlers: Array<RequestHandler>
+}): Promise<Response | undefined> => {
+  const result = await executeHandlers({
+    request: args.request,
+    requestId: randomId(),
+    handlers: args.handlers,
+  })
+
+  return result?.response
+}

--- a/src/core/getResponse.ts
+++ b/src/core/getResponse.ts
@@ -2,14 +2,21 @@ import type { RequestHandler } from './handlers/RequestHandler'
 import { executeHandlers } from './utils/executeHandlers'
 import { randomId } from './utils/internal/randomId'
 
-export const getResponse = async (args: {
-  request: Request
-  handlers: Array<RequestHandler>
-}): Promise<Response | undefined> => {
+/**
+ * Finds a response for the given request instance
+ * in the array of request handlers.
+ * @param handlers The array of request handlers.
+ * @param request The `Request` instance.
+ * @returns {Response} A mocked response, if any.
+ */
+export const getResponse = async (
+  handlers: Array<RequestHandler>,
+  request: Request,
+): Promise<Response | undefined> => {
   const result = await executeHandlers({
-    request: args.request,
+    request,
     requestId: randomId(),
-    handlers: args.handlers,
+    handlers,
   })
 
   return result?.response

--- a/src/core/handlers/GraphQLHandler.test.ts
+++ b/src/core/handlers/GraphQLHandler.test.ts
@@ -9,7 +9,7 @@ import {
   GraphQLResolverExtras,
   isDocumentNode,
 } from './GraphQLHandler'
-import { uuidv4 } from '../utils/internal/uuidv4'
+import { randomId } from '../utils/internal/randomId'
 import { HttpResponse } from '../HttpResponse'
 import { ResponseResolver } from './RequestHandler'
 
@@ -737,7 +737,7 @@ describe('run', () => {
         userId: 'abc-123',
       },
     })
-    const requestId = uuidv4()
+    const requestId = randomId()
     const result = await handler.run({ request, requestId })
 
     expect(result!.handler).toEqual(handler)
@@ -779,7 +779,7 @@ describe('run', () => {
     const request = createPostGraphQLRequest({
       query: LOGIN,
     })
-    const requestId = uuidv4()
+    const requestId = randomId()
     const result = await handler.run({ request, requestId })
 
     expect(result).toBeNull()
@@ -827,7 +827,7 @@ describe('request', () => {
         `,
     })
 
-    const requestId = uuidv4()
+    const requestId = randomId()
     await handler.run({ request, requestId })
 
     expect(matchAllResolver).toHaveBeenCalledTimes(1)

--- a/src/core/handlers/HttpHandler.test.ts
+++ b/src/core/handlers/HttpHandler.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { uuidv4 } from '../utils/internal/uuidv4'
+import { randomId } from '../utils/internal/randomId'
 import { HttpHandler, HttpRequestResolverExtras } from './HttpHandler'
 import { HttpResponse } from '..'
 import { ResponseResolver } from './RequestHandler'
@@ -152,7 +152,7 @@ describe('run', () => {
   test('returns a mocked response given a matching request', async () => {
     const handler = new HttpHandler('GET', '/user/:userId', resolver)
     const request = new Request(new URL('/user/abc-123', location.href))
-    const requestId = uuidv4()
+    const requestId = randomId()
     const result = await handler.run({ request, requestId })
 
     expect(result!.handler).toEqual(handler)
@@ -176,7 +176,7 @@ describe('run', () => {
     const handler = new HttpHandler('POST', '/login', resolver)
     const result = await handler.run({
       request: new Request(new URL('/users', location.href)),
-      requestId: uuidv4(),
+      requestId: randomId(),
     })
 
     expect(result).toBeNull()
@@ -186,7 +186,7 @@ describe('run', () => {
     const handler = new HttpHandler('GET', '/users', resolver)
     const result = await handler.run({
       request: new Request(new URL('/users', location.href)),
-      requestId: uuidv4(),
+      requestId: randomId(),
     })
 
     expect(result?.parsedResult?.match?.params).toEqual({})
@@ -207,7 +207,7 @@ describe('run', () => {
     const run = async () => {
       const result = await handler.run({
         request: new Request(new URL('/users', location.href)),
-        requestId: uuidv4(),
+        requestId: randomId(),
       })
       return result?.response?.text()
     }

--- a/src/core/handlers/HttpHandler.ts
+++ b/src/core/handlers/HttpHandler.ts
@@ -1,4 +1,4 @@
-import { ResponseResolutionContext } from '../utils/getResponse'
+import { ResponseResolutionContext } from '../utils/executeHandlers'
 import { devUtils } from '../utils/internal/devUtils'
 import { isStringEqual } from '../utils/internal/isStringEqual'
 import { getStatusCodeColor } from '../utils/logging/getStatusCodeColor'

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -1,7 +1,7 @@
 import { invariant } from 'outvariant'
 import { getCallFrame } from '../utils/internal/getCallFrame'
 import { isIterable } from '../utils/internal/isIterable'
-import type { ResponseResolutionContext } from '../utils/getResponse'
+import type { ResponseResolutionContext } from '../utils/executeHandlers'
 import type { MaybePromise } from '../typeUtils'
 import { StrictRequest, StrictResponse } from '..//HttpResponse'
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,7 +12,7 @@ export { GraphQLHandler } from './handlers/GraphQLHandler'
 /* Utils */
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'
 export * from './utils/handleRequest'
-export { getResponse } from './utils/getResponse'
+export { executeHandlers } from './utils/executeHandlers'
 export { cleanUrl } from './utils/url/cleanUrl'
 
 /**
@@ -46,9 +46,9 @@ export type {
 export type { GraphQLRequestHandler, GraphQLResponseResolver } from './graphql'
 
 export type {
-  ResponseLookupResult,
+  HandlersExecutionResult,
   ResponseResolutionContext,
-} from './utils/getResponse'
+} from './utils/executeHandlers'
 export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
 export type { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,6 +12,7 @@ export { GraphQLHandler } from './handlers/GraphQLHandler'
 /* Utils */
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'
 export * from './utils/handleRequest'
+export { getResponse } from './utils/getResponse'
 export { cleanUrl } from './utils/url/cleanUrl'
 
 /**
@@ -44,6 +45,10 @@ export type {
 } from './handlers/GraphQLHandler'
 export type { GraphQLRequestHandler, GraphQLResponseResolver } from './graphql'
 
+export type {
+  ResponseLookupResult,
+  ResponseResolutionContext,
+} from './utils/getResponse'
 export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
 export type { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,7 +12,7 @@ export { GraphQLHandler } from './handlers/GraphQLHandler'
 /* Utils */
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'
 export * from './utils/handleRequest'
-export { executeHandlers } from './utils/executeHandlers'
+export { getResponse } from './getResponse'
 export { cleanUrl } from './utils/url/cleanUrl'
 
 /**
@@ -45,10 +45,6 @@ export type {
 } from './handlers/GraphQLHandler'
 export type { GraphQLRequestHandler, GraphQLResponseResolver } from './graphql'
 
-export type {
-  HandlersExecutionResult,
-  ResponseResolutionContext,
-} from './utils/executeHandlers'
 export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
 export type { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'
 

--- a/src/core/utils/executeHandlers.ts
+++ b/src/core/utils/executeHandlers.ts
@@ -3,7 +3,7 @@ import {
   RequestHandlerExecutionResult,
 } from '../handlers/RequestHandler'
 
-export interface ResponseLookupResult {
+export interface HandlersExecutionResult {
   handler: RequestHandler
   parsedResult?: any
   response?: Response
@@ -14,9 +14,11 @@ export interface ResponseResolutionContext {
 }
 
 /**
- * Returns a mocked response for a given request using following request handlers.
+ * Executes the list of request handlers against the given request.
+ * Returns the execution result object containing any matching request
+ * handler and any mocked response it returned.
  */
-export const getResponse = async <Handler extends Array<RequestHandler>>({
+export const executeHandlers = async <Handler extends Array<RequestHandler>>({
   request,
   requestId,
   handlers,
@@ -26,7 +28,7 @@ export const getResponse = async <Handler extends Array<RequestHandler>>({
   requestId: string
   handlers: Handler
   resolutionContext?: ResponseResolutionContext
-}): Promise<ResponseLookupResult | null> => {
+}): Promise<HandlersExecutionResult | null> => {
   let matchingHandler: RequestHandler | null = null
   let result: RequestHandlerExecutionResult<any> | null = null
 

--- a/src/core/utils/executeHandlers.ts
+++ b/src/core/utils/executeHandlers.ts
@@ -18,7 +18,7 @@ export interface ResponseResolutionContext {
  * Returns the execution result object containing any matching request
  * handler and any mocked response it returned.
  */
-export const executeHandlers = async <Handler extends Array<RequestHandler>>({
+export const executeHandlers = async <Handlers extends Array<RequestHandler>>({
   request,
   requestId,
   handlers,
@@ -26,7 +26,7 @@ export const executeHandlers = async <Handler extends Array<RequestHandler>>({
 }: {
   request: Request
   requestId: string
-  handlers: Handler
+  handlers: Handlers
   resolutionContext?: ResponseResolutionContext
 }): Promise<HandlersExecutionResult | null> => {
   let matchingHandler: RequestHandler | null = null

--- a/src/core/utils/handleRequest.test.ts
+++ b/src/core/utils/handleRequest.test.ts
@@ -7,7 +7,7 @@ import { RequestHandler } from '../handlers/RequestHandler'
 import { http } from '../http'
 import { handleRequest, HandleRequestOptions } from './handleRequest'
 import { RequiredDeep } from '../typeUtils'
-import { uuidv4 } from './internal/uuidv4'
+import { randomId } from './internal/randomId'
 import { HttpResponse } from '../HttpResponse'
 import { passthrough } from '../passthrough'
 
@@ -51,7 +51,7 @@ afterEach(() => {
 test('returns undefined for a request with the "x-msw-intention" header equal to "bypass"', async () => {
   const { emitter, events } = setup()
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request(new URL('http://localhost/user'), {
     headers: new Headers({
       'x-msw-intention': 'bypass',
@@ -97,7 +97,7 @@ test('does not bypass a request with "x-msw-intention" header set to arbitrary v
 
   const result = await handleRequest(
     request,
-    uuidv4(),
+    randomId(),
     handlers,
     options,
     emitter,
@@ -112,7 +112,7 @@ test('does not bypass a request with "x-msw-intention" header set to arbitrary v
 test('reports request as unhandled when it has no matching request handlers', async () => {
   const { emitter, events } = setup()
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request(new URL('http://localhost/user'))
   const handlers: Array<RequestHandler> = []
 
@@ -145,7 +145,7 @@ test('reports request as unhandled when it has no matching request handlers', as
 test('returns undefined on a request handler that returns no response', async () => {
   const { emitter, events } = setup()
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request(new URL('http://localhost/user'))
   const handlers: Array<RequestHandler> = [
     http.get('/user', () => {
@@ -184,7 +184,7 @@ test('returns undefined on a request handler that returns no response', async ()
 test('returns the mocked response for a request with a matching request handler', async () => {
   const { emitter, events } = setup()
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request(new URL('http://localhost/user'))
   const mockedResponse = HttpResponse.json({ firstName: 'John' })
   const handlers: Array<RequestHandler> = [
@@ -242,7 +242,7 @@ test('returns the mocked response for a request with a matching request handler'
 test('returns a transformed response if the "transformResponse" option is provided', async () => {
   const { emitter, events } = setup()
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request(new URL('http://localhost/user'))
   const mockedResponse = HttpResponse.json({ firstName: 'John' })
   const handlers: Array<RequestHandler> = [
@@ -325,7 +325,7 @@ test('returns a transformed response if the "transformResponse" option is provid
 it('returns undefined without warning on a passthrough request', async () => {
   const { emitter, events } = setup()
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request(new URL('http://localhost/user'))
   const handlers: Array<RequestHandler> = [
     http.get('/user', () => {
@@ -358,7 +358,7 @@ it('returns undefined without warning on a passthrough request', async () => {
 it('calls the handler with the requestId', async () => {
   const { emitter } = setup()
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request(new URL('http://localhost/user'))
   const handlerFn = vi.fn()
   const handlers: Array<RequestHandler> = [http.get('/user', handlerFn)]
@@ -390,7 +390,7 @@ it('marks the first matching one-time handler as used', async () => {
   })
   const handlers: Array<RequestHandler> = [oneTimeHandler, anotherHandler]
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request('http://localhost/resource')
   const firstResult = await handleRequest(
     request,
@@ -438,7 +438,7 @@ it('does not mark non-matching one-time handlers as used', async () => {
   )
   const handlers: Array<RequestHandler> = [oneTimeHandler, anotherHandler]
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const firstResult = await handleRequest(
     new Request('http://localhost/another'),
     requestId,
@@ -481,7 +481,7 @@ it('handles parallel requests with one-time handlers', async () => {
   })
   const handlers: Array<RequestHandler> = [oneTimeHandler, anotherHandler]
 
-  const requestId = uuidv4()
+  const requestId = randomId()
   const request = new Request('http://localhost/resource')
   const firstResultPromise = handleRequest(
     request,
@@ -526,7 +526,7 @@ describe('[Private] - resolutionContext - used for extensions', () => {
 
       const handlers: Array<RequestHandler> = [handler]
 
-      const requestId = uuidv4()
+      const requestId = randomId()
       const request = new Request(new URL('/resource', baseUrl))
       const response = await handleRequest(
         request,
@@ -555,7 +555,7 @@ describe('[Private] - resolutionContext - used for extensions', () => {
 
       const handlers: Array<RequestHandler> = [handler]
 
-      const requestId = uuidv4()
+      const requestId = randomId()
       const request = new Request(
         new URL('/resource', `http://not-the-base-url.com`),
       )

--- a/src/core/utils/handleRequest.ts
+++ b/src/core/utils/handleRequest.ts
@@ -3,7 +3,7 @@ import { Emitter } from 'strict-event-emitter'
 import { RequestHandler } from '../handlers/RequestHandler'
 import { LifeCycleEventsMap, SharedOptions } from '../sharedOptions'
 import { RequiredDeep } from '../typeUtils'
-import { ResponseLookupResult, getResponse } from './getResponse'
+import { HandlersExecutionResult, executeHandlers } from './executeHandlers'
 import { onUnhandledRequest } from './request/onUnhandledRequest'
 import { readResponseCookies } from './request/readResponseCookies'
 
@@ -38,7 +38,7 @@ export interface HandleRequestOptions {
    */
   onMockedResponse?(
     response: Response,
-    handler: RequiredDeep<ResponseLookupResult>,
+    handler: RequiredDeep<HandlersExecutionResult>,
   ): void
 }
 
@@ -61,7 +61,7 @@ export async function handleRequest(
 
   // Resolve a mocked response from the list of request handlers.
   const lookupResult = await until(() => {
-    return getResponse({
+    return executeHandlers({
       request,
       requestId,
       handlers,
@@ -116,7 +116,7 @@ export async function handleRequest(
   emitter.emit('request:match', { request, requestId })
 
   const requiredLookupResult =
-    lookupResult.data as RequiredDeep<ResponseLookupResult>
+    lookupResult.data as RequiredDeep<HandlersExecutionResult>
 
   const transformedResponse =
     handleRequestOptions?.transformResponse?.(response) ||

--- a/src/core/utils/internal/randomId.ts
+++ b/src/core/utils/internal/randomId.ts
@@ -1,3 +1,3 @@
-export function uuidv4(): string {
+export function randomId(): string {
   return Math.random().toString(16).slice(2)
 }

--- a/test/node/graphql-api/batched-queries.apollo.test.ts
+++ b/test/node/graphql-api/batched-queries.apollo.test.ts
@@ -4,7 +4,7 @@
  * @see https://github.com/mswjs/msw/issues/510
  * @see https://www.apollographql.com/docs/router/executing-operations/query-batching
  */
-import { http, graphql, HttpResponse, getResponse } from 'msw'
+import { http, graphql, HttpResponse, executeHandlers } from 'msw'
 import { setupServer } from 'msw/node'
 
 const graphqlHandlers = [
@@ -43,7 +43,7 @@ export const handlers = [
           body: JSON.stringify(operation),
         })
 
-        const result = await getResponse({
+        const result = await executeHandlers({
           request: scopedRequest,
           requestId,
           handlers: graphqlHandlers,

--- a/test/node/graphql-api/batched-queries.apollo.test.ts
+++ b/test/node/graphql-api/batched-queries.apollo.test.ts
@@ -46,12 +46,7 @@ function batchedGraphQLQuery(url: string, handlers: Array<RequestHandler>) {
         const scopedRequest = new Request(request, {
           body: JSON.stringify(operation),
         })
-
-        const response = await getResponse({
-          request: scopedRequest,
-          handlers,
-        })
-
+        const response = await getResponse(handlers, scopedRequest)
         return response || fetch(bypass(scopedRequest))
       }),
     )

--- a/test/node/graphql-api/batched-queries.apollo.test.ts
+++ b/test/node/graphql-api/batched-queries.apollo.test.ts
@@ -4,9 +4,8 @@
  * @see https://github.com/mswjs/msw/issues/510
  * @see https://www.apollographql.com/docs/router/executing-operations/query-batching
  */
-import { http, graphql, HttpResponse, handleRequest } from 'msw'
+import { http, graphql, HttpResponse, getResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { gql } from '../../support/graphql'
 
 const graphqlHandlers = [
   graphql.query('GetUser', () => {
@@ -44,16 +43,13 @@ export const handlers = [
           body: JSON.stringify(operation),
         })
 
-        const response = await handleRequest(
-          scopedRequest,
+        const result = await getResponse({
+          request: scopedRequest,
           requestId,
-          graphqlHandlers,
-          { onUnhandledRequest: 'warn' },
-          server['emitter'],
-          server['resolvedOptions'],
-        )
+          handlers: graphqlHandlers,
+        })
 
-        return response
+        return result?.response
       }),
     )
 
@@ -85,7 +81,7 @@ it('sends a mocked response to a batched GraphQL query', async () => {
     },
     body: JSON.stringify([
       {
-        query: gql`
+        query: `
           query GetUser {
             user {
               id
@@ -94,7 +90,7 @@ it('sends a mocked response to a batched GraphQL query', async () => {
         `,
       },
       {
-        query: gql`
+        query: `
           query GetProduct {
             product {
               name

--- a/test/node/graphql-api/batched-queries.apollo.test.ts
+++ b/test/node/graphql-api/batched-queries.apollo.test.ts
@@ -4,14 +4,7 @@
  * @see https://github.com/mswjs/msw/issues/510
  * @see https://www.apollographql.com/docs/router/executing-operations/query-batching
  */
-import {
-  http,
-  graphql,
-  HttpResponse,
-  executeHandlers,
-  RequestHandler,
-  HttpHandler,
-} from 'msw'
+import { http, graphql, HttpResponse, getResponse, RequestHandler } from 'msw'
 import { setupServer } from 'msw/node'
 
 /**
@@ -20,7 +13,7 @@ import { setupServer } from 'msw/node'
  * of request handlers.
  */
 function batchedGraphQLQuery(url: string, handlers: Array<RequestHandler>) {
-  return http.post(url, async ({ request, requestId }) => {
+  return http.post(url, async ({ request }) => {
     const data = await request.json()
 
     // Ignore GraphQL queries that are not batched queries.
@@ -36,13 +29,10 @@ function batchedGraphQLQuery(url: string, handlers: Array<RequestHandler>) {
           body: JSON.stringify(operation),
         })
 
-        const result = await executeHandlers({
+        return getResponse({
           request: scopedRequest,
-          requestId,
           handlers,
         })
-
-        return result?.response
       }),
     )
 

--- a/test/node/graphql-api/batched-queries.apollo.test.ts
+++ b/test/node/graphql-api/batched-queries.apollo.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment node
+ * Example of mocking batched GraphQL queries via Apollo.
+ * @see https://github.com/mswjs/msw/issues/510
+ * @see https://www.apollographql.com/docs/router/executing-operations/query-batching
+ */
+import { http, graphql, HttpResponse, handleRequest } from 'msw'
+import { setupServer } from 'msw/node'
+import { gql } from '../../support/graphql'
+
+const graphqlHandlers = [
+  graphql.query('GetUser', () => {
+    return HttpResponse.json({
+      data: {
+        user: { id: 1 },
+      },
+    })
+  }),
+  graphql.query('GetProduct', () => {
+    return HttpResponse.json({
+      data: {
+        product: { name: 'Hoover 2000' },
+      },
+    })
+  }),
+]
+
+export const handlers = [
+  // Let's create a request handler for batched GraphQL requests
+  // made using Apollo.
+  http.post('http://localhost/graphql', async ({ request, requestId }) => {
+    const data = await request.json()
+
+    // Ignore GraphQL queries that are not batched queries.
+    if (!Array.isArray(data)) {
+      return
+    }
+
+    const responses = await Promise.all(
+      // Resolve each individual query against the existing
+      // array of GraphQL request handlers.
+      data.map(async (operation) => {
+        const scopedRequest = new Request(request, {
+          body: JSON.stringify(operation),
+        })
+
+        const response = await handleRequest(
+          scopedRequest,
+          requestId,
+          graphqlHandlers,
+          { onUnhandledRequest: 'warn' },
+          server['emitter'],
+          server['resolvedOptions'],
+        )
+
+        return response
+      }),
+    )
+
+    // Read the mocked response JSON bodies to use
+    // in the response to the entire batched query.
+    const queryData = await Promise.all(
+      responses.map((response) => response?.json()),
+    )
+
+    return HttpResponse.json(queryData)
+  }),
+]
+
+const server = setupServer(...handlers, ...graphqlHandlers)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it('sends a mocked response to a batched GraphQL query', async () => {
+  const response = await fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify([
+      {
+        query: gql`
+          query GetUser {
+            user {
+              id
+            }
+          }
+        `,
+      },
+      {
+        query: gql`
+          query GetProduct {
+            product {
+              name
+            }
+          }
+        `,
+      },
+    ]),
+  })
+
+  expect(await response.json()).toEqual([
+    {
+      data: { user: { id: 1 } },
+    },
+    {
+      data: { product: { name: 'Hoover 2000' } },
+    },
+  ])
+})

--- a/test/node/graphql-api/batched-queries.batched-execute.test.ts
+++ b/test/node/graphql-api/batched-queries.batched-execute.test.ts
@@ -4,9 +4,25 @@
  * @see https://github.com/mswjs/msw/issues/510
  * @see https://www.apollographql.com/docs/router/executing-operations/query-batching
  */
-import { http, HttpResponse, GraphQLVariables } from 'msw'
-import { buildSchema, graphql as executeGraphQL } from 'graphql'
+import {
+  buildSchema,
+  graphql as executeGraphQL,
+  print,
+  defaultFieldResolver,
+} from 'graphql'
+import { http, HttpResponse, GraphQLVariables, bypass } from 'msw'
 import { setupServer } from 'msw/node'
+import { HttpServer } from '@open-draft/test-server/http'
+
+const httpServer = new HttpServer((app) => {
+  app.post('/graphql', (req, res) => {
+    res.json({
+      data: {
+        server: { url: httpServer.http.address.href },
+      },
+    })
+  })
+})
 
 const schema = buildSchema(`
 type User {
@@ -17,50 +33,82 @@ type Product {
   name: String!
 }
 
+type Server {
+  url: String!
+}
+
 type Query {
   user: User
   product: Product
+  server: Server
 }
 `)
 
-export const handlers = [
-  http.post<never, { query: string; variables?: GraphQLVariables }>(
-    'http://localhost/graphql',
-    async ({ request }) => {
-      const data = await request.json()
+const server = setupServer()
 
-      // "batched-execute" produces a standard-compliant GraphQL query
-      // so you can resolve it against the mocked schema as-is!
-      const result = await executeGraphQL({
-        source: data.query,
-        variableValues: data.variables,
-        schema,
-        rootValue: {
-          // Since "batched-execute" produces a single query
-          // with individual queries as fields, you have to
-          // go with a field-based mocking.
-          user: () => ({ id: 'abc-123' }),
-          product: () => ({ name: 'Hoover 2000' }),
-        },
-      })
-
-      return HttpResponse.json(result)
-    },
-  ),
-]
-
-const server = setupServer(...handlers)
-
-beforeAll(() => {
+beforeAll(async () => {
+  await httpServer.listen()
   server.listen()
+  server.use(
+    http.post<never, { query: string; variables?: GraphQLVariables }>(
+      httpServer.http.url('/graphql'),
+      async ({ request }) => {
+        const data = await request.json()
+
+        // "batched-execute" produces a standard-compliant GraphQL query
+        // so you can resolve it against the mocked schema as-is!
+        const result = await executeGraphQL({
+          source: data.query,
+          variableValues: data.variables,
+          schema,
+          rootValue: {
+            // Since "batched-execute" produces a single query
+            // with individual queries as fields, you have to
+            // go with a field-based mocking.
+            user: () => ({ id: 'abc-123' }),
+            product: () => ({ name: 'Hoover 2000' }),
+          },
+          async fieldResolver(source, args, context, info) {
+            // Resolve known fields in "rootValue" as usual.
+            if (source[info.fieldName]) {
+              return defaultFieldResolver(source, args, context, info)
+            }
+
+            // Proxy the unknown fields to the actual GraphQL server.
+            const compiledQuery = info.fieldNodes
+              .map((node) => print(node))
+              .join('\n')
+
+            const query = `${info.operation.operation} { ${compiledQuery} }`
+            const bypassedRequest = bypass(
+              new Request(request, {
+                body: JSON.stringify({ query }),
+              }),
+            )
+            const response = await fetch(bypassedRequest)
+            const { error, data } = await response.json()
+
+            if (error) {
+              throw error
+            }
+
+            return data[info.fieldName]
+          },
+        })
+
+        return HttpResponse.json(result)
+      },
+    ),
+  )
 })
 
-afterAll(() => {
+afterAll(async () => {
+  await httpServer.close()
   server.close()
 })
 
 it('sends a mocked response to a batched GraphQL query', async () => {
-  const response = await fetch('http://localhost/graphql', {
+  const response = await fetch(httpServer.http.url('/graphql'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -85,5 +133,34 @@ it('sends a mocked response to a batched GraphQL query', async () => {
   expect(data).toEqual({
     user_0: { id: 'abc-123' },
     product_0: { name: 'Hoover 2000' },
+  })
+})
+
+it('combines mocked and original responses in a single batched query', async () => {
+  const response = await fetch(httpServer.http.url('/graphql'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: `
+        query {
+          user_0: user {
+            id
+          }
+          server_0: server {
+            url
+          }
+        }
+      `,
+    }),
+  })
+
+  const { errors, data } = await response.json()
+
+  expect(errors).toEqual(undefined)
+  expect(data).toEqual({
+    user_0: { id: 'abc-123' },
+    server_0: { url: httpServer.http.address.href },
   })
 })

--- a/test/node/graphql-api/batched-queries.batched-execute.test.ts
+++ b/test/node/graphql-api/batched-queries.batched-execute.test.ts
@@ -7,7 +7,6 @@
 import { http, HttpResponse, GraphQLVariables } from 'msw'
 import { buildSchema, graphql as executeGraphQL } from 'graphql'
 import { setupServer } from 'msw/node'
-import { gql } from '../../support/graphql'
 
 const schema = buildSchema(`
 type User {
@@ -67,7 +66,7 @@ it('sends a mocked response to a batched GraphQL query', async () => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      query: gql`
+      query: `
         query {
           user_0: user {
             id

--- a/test/node/graphql-api/batched-queries.batched-execute.test.ts
+++ b/test/node/graphql-api/batched-queries.batched-execute.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  * Example of mocking batched GraphQL queries via "batched-execute".
  * @see https://github.com/mswjs/msw/issues/510
- * @see https://www.apollographql.com/docs/router/executing-operations/query-batching
+ * @see https://the-guild.dev/graphql/stitching/handbook/appendices/batching-arrays-and-queries
  */
 import {
   buildSchema,
@@ -80,12 +80,10 @@ beforeAll(async () => {
               .join('\n')
 
             const query = `${info.operation.operation} { ${compiledQuery} }`
-            const bypassedRequest = bypass(
-              new Request(request, {
-                body: JSON.stringify({ query }),
-              }),
-            )
-            const response = await fetch(bypassedRequest)
+            const queryRequest = new Request(request, {
+              body: JSON.stringify({ query }),
+            })
+            const response = await fetch(bypass(queryRequest))
             const { error, data } = await response.json()
 
             if (error) {

--- a/test/node/graphql-api/batched-queries.batched-execute.test.ts
+++ b/test/node/graphql-api/batched-queries.batched-execute.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment node
+ * Example of mocking batched GraphQL queries via "batched-execute".
+ * @see https://github.com/mswjs/msw/issues/510
+ * @see https://www.apollographql.com/docs/router/executing-operations/query-batching
+ */
+import { http, HttpResponse, GraphQLVariables } from 'msw'
+import { buildSchema, graphql as executeGraphQL } from 'graphql'
+import { setupServer } from 'msw/node'
+import { gql } from '../../support/graphql'
+
+const schema = buildSchema(`
+type User {
+  id: ID!
+}
+
+type Product {
+  name: String!
+}
+
+type Query {
+  user: User
+  product: Product
+}
+`)
+
+export const handlers = [
+  http.post<never, { query: string; variables?: GraphQLVariables }>(
+    'http://localhost/graphql',
+    async ({ request }) => {
+      const data = await request.json()
+
+      // "batched-execute" produces a standard-compliant GraphQL query
+      // so you can resolve it against the mocked schema as-is!
+      const result = await executeGraphQL({
+        source: data.query,
+        variableValues: data.variables,
+        schema,
+        rootValue: {
+          // Since "batched-execute" produces a single query
+          // with individual queries as fields, you have to
+          // go with a field-based mocking.
+          user: () => ({ id: 'abc-123' }),
+          product: () => ({ name: 'Hoover 2000' }),
+        },
+      })
+
+      return HttpResponse.json(result)
+    },
+  ),
+]
+
+const server = setupServer(...handlers)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it('sends a mocked response to a batched GraphQL query', async () => {
+  const response = await fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: gql`
+        query {
+          user_0: user {
+            id
+          }
+          product_0: product {
+            name
+          }
+        }
+      `,
+    }),
+  })
+
+  const { errors, data } = await response.json()
+
+  expect(errors).toBeUndefined()
+  expect(data).toEqual({
+    user_0: { id: 'abc-123' },
+    product_0: { name: 'Hoover 2000' },
+  })
+})


### PR DESCRIPTION
- Closes #510 
- Closes #513 
- Closes #1585 
- Documented in https://github.com/mswjs/mswjs.io/pull/351

Provides two integration test examples of how to intercept and mock a batched GraphQL query that's created by Apollo and batched-execute.

## Roadmap

- [x] Provide the way to call `handleRequest` so it doesn't require tapping into `server.emitter` and `server.resolvedOptions` internals. 
- [x] Consider if `getResponse` is a good public API. Rename it to `resolveResponse`? Usage-wise, it's good, just wondering about the naming. 
  - Renamed to `executeHandlers`. It's precisely what this function does. 
- [x] Add tests that combine some mocked and some bypassed queries within a single batched query response. 
- [x] Add the "Batched GraphQL queries" recipe to the documentation. 
- [x] Change `getResponse` signature to `(handlers, request)`. No need for an object, its contract is unlikely to change (its intention is simple). 
- [x] Add unit tests for `getResponse`. 
- [x] Rename this pull request as a `fix` that gets `getResponse`