### PR TITLE
fix: support typescript@5.3 for version 1.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "webpack-http-server": "^0.5.0"
   },
   "peerDependencies": {
-    "typescript": ">= 4.4.x <= 5.2.x"
+    "typescript": ">= 4.4.x <= 5.3.x"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/test/typings/tsconfig.5.3.json
+++ b/test/typings/tsconfig.5.3.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.4.7.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  }
+}


### PR DESCRIPTION
Tested locally in the project with TypeScript 5.3 without errors:

1. Run pnpm add typescript@5.3
2. Run pnpm build
3. Run pnpm test:ts

Basically just cherry picked [this commit](https://github.com/mswjs/msw/pull/1874/commits/300ebf9410f3ea5ac53214af9c0c53bd2fe20fa9) and much of the PR description as well ;)