### PR TITLE
fix: resolve relative fetch urls in jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@bundled-es-modules/cookie": "^2.0.0",
     "@bundled-es-modules/statuses": "^1.0.1",
     "@mswjs/cookies": "^1.1.0",
-    "@mswjs/interceptors": "^0.25.14",
+    "@mswjs/interceptors": "^0.25.15",
     "@open-draft/until": "^2.1.0",
     "@types/cookie": "^0.6.0",
     "@types/statuses": "^2.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@commitlint/cli': ^18.4.4
   '@commitlint/config-conventional': ^18.4.4
   '@mswjs/cookies': ^1.1.0
-  '@mswjs/interceptors': ^0.25.14
+  '@mswjs/interceptors': ^0.25.15
   '@open-draft/test-server': ^0.4.2
   '@open-draft/until': ^2.1.0
   '@ossjs/release': ^0.8.0
@@ -73,7 +73,7 @@ dependencies:
   '@bundled-es-modules/cookie': 2.0.0
   '@bundled-es-modules/statuses': 1.0.1
   '@mswjs/cookies': 1.1.0
-  '@mswjs/interceptors': 0.25.14
+  '@mswjs/interceptors': 0.25.15
   '@open-draft/until': 2.1.0
   '@types/cookie': 0.6.0
   '@types/statuses': 2.0.4
@@ -1269,8 +1269,8 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /@mswjs/interceptors/0.25.14:
-    resolution: {integrity: sha512-2dnIxl+obqIqjoPXTFldhe6pcdOrqiz+GcLaQQ6hmL02OldAF7nIC+rUgTWm+iF6lvmyCVhFFqbgbapNhR8eag==}
+  /@mswjs/interceptors/0.25.15:
+    resolution: {integrity: sha512-s4jdyxmq1eeftfDXJ7MUiK/jlvYaU8Sr75+42hHCVBrYez0k51RHbMitKIKdmsF92Q6gwhp8Sm1MmvdA9llpcg==}
     engines: {node: '>=18'}
     dependencies:
       '@open-draft/deferred-promise': 2.2.0

--- a/test/node/rest-api/request/matching/relative-url.node.test.ts
+++ b/test/node/rest-api/request/matching/relative-url.node.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const server = setupServer(
+  http.get('/api/movies', () => {
+    return HttpResponse.json([
+      { title: 'The Lord of the Rings' },
+      { title: 'The Matrix' },
+    ])
+  }),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it('responds to a relative URL in jsdom', async () => {
+  const response = await fetch('/api/movies')
+
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual([
+    { title: 'The Lord of the Rings' },
+    { title: 'The Matrix' },
+  ])
+})


### PR DESCRIPTION
- Fixes #1625
- The actual fix is on the Interceptors' side: https://github.com/mswjs/interceptors/releases/tag/v0.25.15