### PR TITLE
feat: support concurrent test runs via "server.boundary"

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "check:exports": "node \"./config/scripts/validate-esm.js\"",
     "test": "pnpm test:unit && pnpm test:node && pnpm test:browser && pnpm test:native",
     "test:unit": "vitest",
-    "test:node": "vitest --config=./test/node/vitest.config.ts",
+    "test:node": "vitest run --config=./test/node/vitest.config.ts",
     "test:native": "vitest --config=./test/native/vitest.config.ts",
     "test:browser": "playwright test -c ./test/browser/playwright.config.ts",
     "test:modules:node": "vitest --config=./test/modules/node/vitest.config.ts",

--- a/src/browser/setupWorker/glossary.ts
+++ b/src/browser/setupWorker/glossary.ts
@@ -102,7 +102,7 @@ export interface SetupWorkerInternalContext {
   startOptions: RequiredDeep<StartOptions>
   worker: ServiceWorker | null
   registration: ServiceWorkerRegistration | null
-  requestHandlers: Array<RequestHandler>
+  currentHandlers(): Array<RequestHandler>
   requests: Map<string, Request>
   emitter: Emitter<LifeCycleEventsMap>
   keepAliveInterval?: number

--- a/src/browser/setupWorker/glossary.ts
+++ b/src/browser/setupWorker/glossary.ts
@@ -102,7 +102,7 @@ export interface SetupWorkerInternalContext {
   startOptions: RequiredDeep<StartOptions>
   worker: ServiceWorker | null
   registration: ServiceWorkerRegistration | null
-  currentHandlers(): Array<RequestHandler>
+  getRequestHandlers(): Array<RequestHandler>
   requests: Map<string, Request>
   emitter: Emitter<LifeCycleEventsMap>
   keepAliveInterval?: number

--- a/src/browser/setupWorker/setupWorker.ts
+++ b/src/browser/setupWorker/setupWorker.ts
@@ -58,8 +58,10 @@ export class SetupWorkerApi
       isMockingEnabled: false,
       startOptions: null as any,
       worker: null,
+      currentHandlers: () => {
+        return this.handlersController.currentHandlers()
+      },
       registration: null,
-      requestHandlers: this.currentHandlers,
       requests: new Map(),
       emitter: this.emitter,
       workerChannel: {
@@ -150,16 +152,6 @@ export class SetupWorkerApi
         readableStreamTransfer: supportsReadableStreamTransfer(),
       },
     }
-
-    /**
-     * @todo Not sure I like this but "this.currentHandlers"
-     * updates never bubble to "this.context.requestHandlers".
-     */
-    Object.defineProperties(context, {
-      requestHandlers: {
-        get: () => this.currentHandlers,
-      },
-    })
 
     this.startHandler = context.supports.serviceWorkerApi
       ? createFallbackStart(context)

--- a/src/browser/setupWorker/setupWorker.ts
+++ b/src/browser/setupWorker/setupWorker.ts
@@ -58,7 +58,7 @@ export class SetupWorkerApi
       isMockingEnabled: false,
       startOptions: null as any,
       worker: null,
-      currentHandlers: () => {
+      getRequestHandlers: () => {
         return this.handlersController.currentHandlers()
       },
       registration: null,

--- a/src/browser/setupWorker/start/createFallbackRequestListener.ts
+++ b/src/browser/setupWorker/start/createFallbackRequestListener.ts
@@ -24,7 +24,7 @@ export function createFallbackRequestListener(
     const response = await handleRequest(
       request,
       requestId,
-      context.requestHandlers,
+      context.getRequestHandlers(),
       options,
       context.emitter,
       {

--- a/src/browser/setupWorker/start/createRequestListener.ts
+++ b/src/browser/setupWorker/start/createRequestListener.ts
@@ -43,7 +43,7 @@ export const createRequestListener = (
       await handleRequest(
         request,
         requestId,
-        context.requestHandlers,
+        context.getRequestHandlers(),
         options,
         context.emitter,
         {

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -1,6 +1,6 @@
 import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
-import { RequestHandler } from '~/core/handlers/RequestHandler'
-import { SetupServerApi } from '../node/SetupServerApi'
+import type { RequestHandler } from '~/core/handlers/RequestHandler'
+import { SetupServerCommonApi } from '../node/SetupServerCommonApi'
 
 /**
  * Sets up a requests interception in React Native with the given request handlers.
@@ -10,8 +10,8 @@ import { SetupServerApi } from '../node/SetupServerApi'
  */
 export function setupServer(
   ...handlers: Array<RequestHandler>
-): SetupServerApi {
+): SetupServerCommonApi {
   // Provision request interception via patching the `XMLHttpRequest` class only
   // in React Native. There is no `http`/`https` modules in that environment.
-  return new SetupServerApi([XMLHttpRequestInterceptor], ...handlers)
+  return new SetupServerCommonApi([XMLHttpRequestInterceptor], handlers)
 }

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -1,23 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import {
-  BatchInterceptor,
-  HttpRequestEventMap,
-  Interceptor,
-  InterceptorReadyState,
-} from '@mswjs/interceptors'
-import { invariant } from 'outvariant'
-import { HandlersController, SetupApi } from '~/core/SetupApi'
-import { RequestHandler } from '~/core/handlers/RequestHandler'
-import { LifeCycleEventsMap, SharedOptions } from '~/core/sharedOptions'
-import { RequiredDeep } from '~/core/typeUtils'
-import { handleRequest } from '~/core/utils/handleRequest'
-import { devUtils } from '~/core/utils/internal/devUtils'
-import { mergeRight } from '~/core/utils/internal/mergeRight'
-import { SetupServer } from './glossary'
-
-const DEFAULT_LISTEN_OPTIONS: RequiredDeep<SharedOptions> = {
-  onUnhandledRequest: 'warn',
-}
+import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
+import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
+import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+import { HandlersController } from '~/core/SetupApi'
+import type { RequestHandler } from '~/core/handlers/RequestHandler'
+import type { SetupServer } from './glossary'
+import { SetupServerCommonApi } from './SetupServerCommonApi'
 
 const store = new AsyncLocalStorage<RequestHandlersContext>()
 
@@ -60,94 +48,16 @@ class AsyncHandlersController implements HandlersController {
 }
 
 export class SetupServerApi
-  extends SetupApi<LifeCycleEventsMap>
+  extends SetupServerCommonApi
   implements SetupServer
 {
-  protected readonly interceptor: BatchInterceptor<
-    Array<Interceptor<HttpRequestEventMap>>,
-    HttpRequestEventMap
-  >
-  private resolvedOptions: RequiredDeep<SharedOptions>
-
-  constructor(
-    interceptors: Array<{
-      new (): Interceptor<HttpRequestEventMap>
-    }>,
-    ...handlers: Array<RequestHandler>
-  ) {
-    super(...handlers)
+  constructor(handlers: Array<RequestHandler>) {
+    super(
+      [ClientRequestInterceptor, XMLHttpRequestInterceptor, FetchInterceptor],
+      handlers,
+    )
 
     this.handlersController = new AsyncHandlersController(handlers)
-
-    this.interceptor = new BatchInterceptor({
-      name: 'setup-server',
-      interceptors: interceptors.map((Interceptor) => new Interceptor()),
-    })
-    this.resolvedOptions = {} as RequiredDeep<SharedOptions>
-
-    this.init()
-  }
-
-  /**
-   * Subscribe to all requests that are using the interceptor object
-   */
-  private init(): void {
-    this.interceptor.on('request', async ({ request, requestId }) => {
-      const response = await handleRequest(
-        request,
-        requestId,
-        this.handlersController.currentHandlers(),
-        this.resolvedOptions,
-        this.emitter,
-      )
-
-      if (response) {
-        request.respondWith(response)
-      }
-
-      return
-    })
-
-    this.interceptor.on(
-      'response',
-      ({ response, isMockedResponse, request, requestId }) => {
-        this.emitter.emit(
-          isMockedResponse ? 'response:mocked' : 'response:bypass',
-          {
-            response,
-            request,
-            requestId,
-          },
-        )
-      },
-    )
-  }
-
-  public listen(options: Partial<SharedOptions> = {}): void {
-    this.resolvedOptions = mergeRight(
-      DEFAULT_LISTEN_OPTIONS,
-      options,
-    ) as RequiredDeep<SharedOptions>
-
-    // Apply the interceptor when starting the server.
-    this.interceptor.apply()
-
-    this.subscriptions.push(() => {
-      this.interceptor.dispose()
-    })
-
-    // Assert that the interceptor has been applied successfully.
-    // Also guards us from forgetting to call "interceptor.apply()"
-    // as a part of the "listen" method.
-    invariant(
-      [InterceptorReadyState.APPLYING, InterceptorReadyState.APPLIED].includes(
-        this.interceptor.readyState,
-      ),
-      devUtils.formatMessage(
-        'Failed to start "setupServer": the interceptor failed to apply. This is likely an issue with the library and you should report it at "%s".',
-      ),
-      'https://github.com/mswjs/msw/issues/new/choose',
-    )
   }
 
   public boundary<Fn extends (...args: Array<any>) => unknown>(
@@ -166,7 +76,7 @@ export class SetupServerApi
   }
 
   public close(): void {
-    this.dispose()
+    super.close()
     store.disable()
   }
 }

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -150,12 +150,6 @@ export class SetupServerApi
     )
   }
 
-  /**
-   * Wraps the given function in a boundary. Any changes to the
-   * network behavior (e.g. adding runtime request handlers via
-   * `server.use()`) will be scoped to this boundary only.
-   * @param callback A function to run (e.g. a test)
-   */
   public boundary<Fn extends (...args: Array<any>) => unknown>(
     callback: Fn,
   ): (...args: Parameters<Fn>) => ReturnType<Fn> {

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -156,7 +156,7 @@ export class SetupServerApi
    * `server.use()`) will be scoped to this boundary only.
    * @param callback A function to run (e.g. a test)
    */
-  public boundary<Fn extends (...args: Array<unknown>) => unknown>(
+  public boundary<Fn extends (...args: Array<any>) => unknown>(
     callback: Fn,
   ): (...args: Parameters<Fn>) => ReturnType<Fn> {
     return (...args: Parameters<Fn>): ReturnType<Fn> => {
@@ -166,7 +166,7 @@ export class SetupServerApi
           handlers: [],
         },
         callback,
-        args,
+        ...args,
       )
     }
   }

--- a/src/node/SetupServerCommonApi.ts
+++ b/src/node/SetupServerCommonApi.ts
@@ -1,0 +1,116 @@
+/**
+ * @note This API is extended by both "msw/node" and "msw/native"
+ * so be minding about the things you import!
+ */
+import type { RequiredDeep } from 'type-fest'
+import { invariant } from 'outvariant'
+import {
+  BatchInterceptor,
+  InterceptorReadyState,
+  type HttpRequestEventMap,
+  type Interceptor,
+} from '@mswjs/interceptors'
+import type { LifeCycleEventsMap, SharedOptions } from '~/core/sharedOptions'
+import { SetupApi } from '~/core/SetupApi'
+import { handleRequest } from '~/core/utils/handleRequest'
+import type { RequestHandler } from '~/core/handlers/RequestHandler'
+import { mergeRight } from '~/core/utils/internal/mergeRight'
+import { devUtils } from '~/core/utils/internal/devUtils'
+import type { SetupServerCommon } from './glossary'
+
+export const DEFAULT_LISTEN_OPTIONS: RequiredDeep<SharedOptions> = {
+  onUnhandledRequest: 'warn',
+}
+
+export class SetupServerCommonApi
+  extends SetupApi<LifeCycleEventsMap>
+  implements SetupServerCommon
+{
+  protected readonly interceptor: BatchInterceptor<
+    Array<Interceptor<HttpRequestEventMap>>,
+    HttpRequestEventMap
+  >
+  private resolvedOptions: RequiredDeep<SharedOptions>
+
+  constructor(
+    interceptors: Array<{ new (): Interceptor<HttpRequestEventMap> }>,
+    handlers: Array<RequestHandler>,
+  ) {
+    super(...handlers)
+
+    this.interceptor = new BatchInterceptor({
+      name: 'setup-server',
+      interceptors: interceptors.map((Interceptor) => new Interceptor()),
+    })
+
+    this.resolvedOptions = {} as RequiredDeep<SharedOptions>
+
+    this.init()
+  }
+
+  /**
+   * Subscribe to all requests that are using the interceptor object
+   */
+  private init(): void {
+    this.interceptor.on('request', async ({ request, requestId }) => {
+      const response = await handleRequest(
+        request,
+        requestId,
+        this.handlersController.currentHandlers(),
+        this.resolvedOptions,
+        this.emitter,
+      )
+
+      if (response) {
+        request.respondWith(response)
+      }
+
+      return
+    })
+
+    this.interceptor.on(
+      'response',
+      ({ response, isMockedResponse, request, requestId }) => {
+        this.emitter.emit(
+          isMockedResponse ? 'response:mocked' : 'response:bypass',
+          {
+            response,
+            request,
+            requestId,
+          },
+        )
+      },
+    )
+  }
+
+  public listen(options: Partial<SharedOptions> = {}): void {
+    this.resolvedOptions = mergeRight(
+      DEFAULT_LISTEN_OPTIONS,
+      options,
+    ) as RequiredDeep<SharedOptions>
+
+    // Apply the interceptor when starting the server.
+    this.interceptor.apply()
+
+    this.subscriptions.push(() => {
+      this.interceptor.dispose()
+    })
+
+    // Assert that the interceptor has been applied successfully.
+    // Also guards us from forgetting to call "interceptor.apply()"
+    // as a part of the "listen" method.
+    invariant(
+      [InterceptorReadyState.APPLYING, InterceptorReadyState.APPLIED].includes(
+        this.interceptor.readyState,
+      ),
+      devUtils.formatMessage(
+        'Failed to start "setupServer": the interceptor failed to apply. This is likely an issue with the library and you should report it at "%s".',
+      ),
+      'https://github.com/mswjs/msw/issues/new/choose',
+    )
+  }
+
+  public close(): void {
+    this.dispose()
+  }
+}

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -17,7 +17,7 @@ export interface SetupServer {
    */
   listen(options?: PartialDeep<SharedOptions>): void
 
-  boundary<Fn extends (...args: Array<unknown>) => unknown>(
+  boundary<Fn extends (...args: Array<any>) => unknown>(
     callback: Fn,
   ): (...args: Parameters<Fn>) => ReturnType<Fn>
 

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -17,6 +17,10 @@ export interface SetupServer {
    */
   listen(options?: PartialDeep<SharedOptions>): void
 
+  boundary<Fn extends (...args: Array<unknown>) => unknown>(
+    callback: Fn,
+  ): (...args: Parameters<Fn>) => ReturnType<Fn>
+
   /**
    * Stops requests interception by restoring all augmented modules.
    *

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -1,33 +1,21 @@
 import type { PartialDeep } from 'type-fest'
-import {
+import type {
   RequestHandler,
   RequestHandlerDefaultInfo,
 } from '~/core/handlers/RequestHandler'
-import {
+import type {
   LifeCycleEventEmitter,
   LifeCycleEventsMap,
   SharedOptions,
 } from '~/core/sharedOptions'
 
-export interface SetupServer {
+export interface SetupServerCommon {
   /**
    * Starts requests interception based on the previously provided request handlers.
    *
    * @see {@link https://mswjs.io/docs/api/setup-server/listen `server.listen()` API reference}
    */
   listen(options?: PartialDeep<SharedOptions>): void
-
-  /**
-   * Wraps the given function in a boundary. Any changes to the
-   * network behavior (e.g. adding runtime request handlers via
-   * `server.use()`) will be scoped to this boundary only.
-   * @param callback A function to run (e.g. a test)
-   *
-   * @see {@link https://mswjs.io/docs/api/setup-server/boundary `server.boundary()` API reference}
-   */
-  boundary<Fn extends (...args: Array<any>) => unknown>(
-    callback: Fn,
-  ): (...args: Parameters<Fn>) => ReturnType<Fn>
 
   /**
    * Stops requests interception by restoring all augmented modules.
@@ -71,4 +59,18 @@ export interface SetupServer {
    * @see {@link https://mswjs.io/docs/api/life-cycle-events Life-cycle Events API reference}
    */
   events: LifeCycleEventEmitter<LifeCycleEventsMap>
+}
+
+export interface SetupServer extends SetupServerCommon {
+  /**
+   * Wraps the given function in a boundary. Any changes to the
+   * network behavior (e.g. adding runtime request handlers via
+   * `server.use()`) will be scoped to this boundary only.
+   * @param callback A function to run (e.g. a test)
+   *
+   * @see {@link https://mswjs.io/docs/api/setup-server/boundary `server.boundary()` API reference}
+   */
+  boundary<Fn extends (...args: Array<any>) => unknown>(
+    callback: Fn,
+  ): (...args: Parameters<Fn>) => ReturnType<Fn>
 }

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -17,6 +17,14 @@ export interface SetupServer {
    */
   listen(options?: PartialDeep<SharedOptions>): void
 
+  /**
+   * Wraps the given function in a boundary. Any changes to the
+   * network behavior (e.g. adding runtime request handlers via
+   * `server.use()`) will be scoped to this boundary only.
+   * @param callback A function to run (e.g. a test)
+   *
+   * @see {@link https://mswjs.io/docs/api/setup-server/boundary `server.boundary()` API reference}
+   */
   boundary<Fn extends (...args: Array<any>) => unknown>(
     callback: Fn,
   ): (...args: Parameters<Fn>) => ReturnType<Fn>

--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,9 +1,5 @@
-import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
-import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
-import { FetchInterceptor } from '@mswjs/interceptors/fetch'
-import { RequestHandler } from '~/core/handlers/RequestHandler'
+import type { RequestHandler } from '~/core/handlers/RequestHandler'
 import { SetupServerApi } from './SetupServerApi'
-import { SetupServer } from './glossary'
 
 /**
  * Sets up a requests interception in Node.js with the given request handlers.
@@ -13,9 +9,6 @@ import { SetupServer } from './glossary'
  */
 export const setupServer = (
   ...handlers: Array<RequestHandler>
-): SetupServer => {
-  return new SetupServerApi(
-    [ClientRequestInterceptor, XMLHttpRequestInterceptor, FetchInterceptor],
-    ...handlers,
-  )
+): SetupServerApi => {
+  return new SetupServerApi(handlers)
 }

--- a/test/node/msw-api/setup-server/boundary/boundary.args.test.ts
+++ b/test/node/msw-api/setup-server/boundary/boundary.args.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment node
+ */
+import { setupServer } from 'msw/node'
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it.concurrent('forwards arguments to the callback function', async () => {
+  server.boundary((...args) => {
+    expect(args).toEqual([1, { 2: true }, [3]])
+  })(1, { 2: true }, [3])
+})
+
+it.concurrent('returns the result of the callback function', async () => {
+  const result = server.boundary((number: number) => {
+    return number * 10
+  })(2)
+
+  expect(result).toBe(20)
+})

--- a/test/node/msw-api/setup-server/boundary/boundary.concurrency.test.ts
+++ b/test/node/msw-api/setup-server/boundary/boundary.concurrency.test.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment jsdom
+ * @vitest-environment jsdom
  */
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'

--- a/test/node/msw-api/setup-server/boundary/boundary.handlers.test.ts
+++ b/test/node/msw-api/setup-server/boundary/boundary.handlers.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment node
+ */
+import { HttpResponse, http } from 'msw'
+import { setupServer } from 'msw/node'
+
+const server = setupServer(
+  http.get('https://example.com', () => {
+    return HttpResponse.json({ name: 'John' })
+  }),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it.concurrent(
+  'treats higher scope handlers as initial handlers',
+  server.boundary(async () => {
+    expect(
+      await await fetch('https://example.com').then((response) =>
+        response.json(),
+      ),
+    ).toEqual({ name: 'John' })
+
+    server.use(
+      http.get('https://example.com', () => {
+        return HttpResponse.json({ override: true })
+      }),
+    )
+    expect(
+      await await fetch('https://example.com').then((response) =>
+        response.json(),
+      ),
+    ).toEqual({ override: true })
+  }),
+)
+
+it.concurrent(
+  'resets the runtime handlers to the initial handlers',
+  server.boundary(async () => {
+    server.use(
+      http.get('https://example.com', () => {
+        return HttpResponse.json({ override: true })
+      }),
+    )
+    expect(
+      await await fetch('https://example.com').then((response) =>
+        response.json(),
+      ),
+    ).toEqual({ override: true })
+
+    server.resetHandlers()
+
+    expect(
+      await await fetch('https://example.com').then((response) =>
+        response.json(),
+      ),
+    ).toEqual({ name: 'John' })
+  }),
+)
+
+it.concurrent(
+  'treats the higher boundary handlers as initial handlers for nested boundary',
+  server.boundary(async () => {
+    server.use(
+      http.get('https://example.com', () => {
+        return HttpResponse.json({ override: true })
+      }),
+    )
+
+    await server.boundary(async () => {
+      expect(
+        await await fetch('https://example.com').then((response) =>
+          response.json(),
+        ),
+      ).toEqual({ override: true })
+
+      server.resetHandlers()
+
+      // Reset does nothing at this point because no runtime
+      // request handlers were added within this boundary.
+      expect(
+        await await fetch('https://example.com').then((response) =>
+          response.json(),
+        ),
+      ).toEqual({ override: true })
+
+      server.use(
+        http.get('https://example.com', () => {
+          return HttpResponse.json({ nested: true })
+        }),
+      )
+
+      expect(
+        await await fetch('https://example.com').then((response) =>
+          response.json(),
+        ),
+      ).toEqual({ nested: true })
+    })
+  }),
+)

--- a/test/node/msw-api/setup-server/concurrency.test.ts
+++ b/test/node/msw-api/setup-server/concurrency.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const server = setupServer(
+  http.get('/initial', () => {
+    return HttpResponse.text('initial')
+  }),
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe.concurrent('concurrent tests', () => {
+  it(
+    'resolves request against the initial handlers',
+    server.boundary(async () => {
+      const response = await fetch('/initial')
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('initial')
+    }),
+  )
+
+  it(
+    'resolves request against the in-test handler override',
+    server.boundary(async () => {
+      server.use(
+        http.get('/initial', () => {
+          return HttpResponse.text('override')
+        }),
+      )
+
+      const response = await fetch('/initial')
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('override')
+    }),
+  )
+
+  it(
+    'resolves requests against the initial handlers again',
+    server.boundary(async () => {
+      const response = await fetch('/initial')
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('initial')
+    }),
+  )
+})

--- a/test/node/msw-api/setup-server/life-cycle-events/on.node.test.ts
+++ b/test/node/msw-api/setup-server/life-cycle-events/on.node.test.ts
@@ -63,7 +63,9 @@ beforeAll(async () => {
     'response:mocked',
     async ({ response, request, requestId }) => {
       listener(
-        `[response:mocked] ${await response.text()} ${request.method} ${request.url} ${requestId}`,
+        `[response:mocked] ${await response.text()} ${request.method} ${
+          request.url
+        } ${requestId}`,
       )
     },
   )
@@ -72,7 +74,9 @@ beforeAll(async () => {
     'response:bypass',
     async ({ response, request, requestId }) => {
       listener(
-        `[response:bypass] ${await response.text()} ${request.method} ${request.url} ${requestId}`,
+        `[response:bypass] ${await response.text()} ${request.method} ${
+          request.url
+        } ${requestId}`,
       )
     },
   )


### PR DESCRIPTION
- Fixes #474 
- Closes #1370
- A bit about how this works: https://github.com/mswjs/msw/issues/474#issuecomment-1912327731
- Documented in https://github.com/mswjs/mswjs.io/pull/356

## Changes

The `server.boundary()` API is a Node.js-only API that provides encapsulation to whichever given callback function by executing it within an `AsyncLocalStorage` context. This API is designed to support using MSW in concurrent test runs since no changes to request handlers (e.g. using `server.use()`) will ever leave the boundary function.  

`server.boundary()` has its practical use outside of testing as well. You can use it in any concurrent logic that performs network request, if you wish to handle those requests differently on a per-boundary basis. 

## Usage

You must wrap each test function in a concurrent test suite in the `server.boundary()` function to ensure proper isolation.

```js
it.concurrent('one', server.boundary(async () => {
  await fetch('/resource') // 200 OK
}))

it.concurrent('two', server.boundary(async () => {
  // This request handler override will only affect the network
  // calls that happen within this server boundary. Neat!
  server.use(http.get('/resource', () => HttpResponse.error()))
  await fetch('/resource') // Failed to fetch
}))
```

Server boundary can also be used anywhere else in your application to affect the network only within the given function scope. For example, you can debug what network requests a subtree of your application makes:

```js
server.boundary(() => {
  http.all('*', ({ request }) => console.log(request.method, request.url))
  subtree()
})()
```

## Todos

- [x] **Test `server.boundary()`**. Every behavior must be verified in tests. 
- [x] Ensure React Native build isn't broken. I doubt there's `node:async_events` there, so a dependency on it in `SetupServerApi` may throw on runtime. 4a1c9833dbe4bca0fc98f1d8923ae8f329e024b9
- [x] Document `server.boundary()`