### PR TITLE
fix: return type of "passthrough"

### DIFF
--- a/src/core/passthrough.ts
+++ b/src/core/passthrough.ts
@@ -1,3 +1,5 @@
+import type { StrictResponse } from './HttpResponse'
+
 /**
  * Performs the intercepted request as-is.
  *
@@ -12,12 +14,12 @@
  *
  * @see {@link https://mswjs.io/docs/api/passthrough `passthrough()` API reference}
  */
-export function passthrough(): Response {
+export function passthrough(): StrictResponse<any> {
   return new Response(null, {
     status: 302,
     statusText: 'Passthrough',
     headers: {
       'x-msw-intention': 'passthrough',
     },
-  })
+  }) as StrictResponse<any>
 }

--- a/test/typings/graphql.test-d.ts
+++ b/test/typings/graphql.test-d.ts
@@ -1,5 +1,5 @@
 import { parse } from 'graphql'
-import { graphql, HttpResponse } from 'msw'
+import { graphql, HttpResponse, passthrough } from 'msw'
 
 /**
  * Variables type.
@@ -81,6 +81,18 @@ graphql.query<{ id: string }>(
   // @ts-expect-error incompatible response body type
   () => HttpResponse.text('hello'),
 )
+
+// Passthrough responses.
+graphql.query('GetUser', () => passthrough())
+graphql.mutation('AddPost', () => passthrough())
+graphql.operation(() => passthrough())
+graphql.query('GetUser', ({ request }) => {
+  if (request.headers.has('cookie')) {
+    return passthrough()
+  }
+
+  return HttpResponse.json({ data: {} })
+})
 
 ///
 ///

--- a/test/typings/http.test-d.ts
+++ b/test/typings/http.test-d.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw'
+import { http, HttpResponse, passthrough } from 'msw'
 
 /**
  * Request path parameters.
@@ -119,3 +119,14 @@ http.get<never, never, string | string[]>('/user', () =>
 http.get<never, never, { label: boolean }>('/user', () =>
   HttpResponse.json({ label: true }),
 )
+
+// Passthrough responses.
+http.all('/', () => passthrough())
+http.get('/', () => passthrough())
+http.get<never, never, { id: number }>('/', ({ request }) => {
+  if (request.headers.has('cookie')) {
+    return passthrough()
+  }
+
+  return HttpResponse.json({ id: 1 })
+})


### PR DESCRIPTION
- Fixes #1977

## Root cause

The return type of `passthrough()`, which was `Response`, was incompatible with `StrictResponse` that exists on the return type of the response resolver. 