### PR TITLE
fix: use specific import over barrel file import

### DIFF
--- a/src/core/utils/internal/parseGraphQLRequest.ts
+++ b/src/core/utils/internal/parseGraphQLRequest.ts
@@ -3,7 +3,7 @@ import type {
   OperationDefinitionNode,
   OperationTypeNode,
 } from 'graphql'
-import { parse } from 'graphql'
+import { parse } from 'graphql/language/parser'
 import type { GraphQLVariables } from '../../handlers/GraphQLHandler'
 import { toPublicUrl } from '../request/toPublicUrl'
 import { devUtils } from './devUtils'

--- a/src/core/utils/internal/parseGraphQLRequest.ts
+++ b/src/core/utils/internal/parseGraphQLRequest.ts
@@ -3,7 +3,7 @@ import type {
   OperationDefinitionNode,
   OperationTypeNode,
 } from 'graphql'
-import { parse } from 'graphql/language/parser'
+import { parse } from 'graphql/language/parser.js'
 import type { GraphQLVariables } from '../../handlers/GraphQLHandler'
 import { toPublicUrl } from '../request/toPublicUrl'
 import { devUtils } from './devUtils'


### PR DESCRIPTION
Reduces the module graph from importing 179 modules total to 74

Before:
```
  [ERROR]: "/Users/au87xu/msw/lib/core/index.mjs" leads to a module graph of 179 modules, which is more than the allowed maxModuleGraphSize of 10.
```

After:
```
  [ERROR]: "/Users/au87xu/msw/lib/core/index.mjs" leads to a module graph of 74 modules, which is more than the allowed maxModuleGraphSize of 10.
```

as discussed in https://github.com/mswjs/msw/issues/1984