### PR TITLE
chore: recommend cloning examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-issue-browser.yml
+++ b/.github/ISSUE_TEMPLATE/01-issue-browser.yml
@@ -38,7 +38,7 @@ body:
   - type: input
     attributes:
       label: Reproduction repository
-      description: A link to the repository where your issue can be reproduced. You can clone one of [our examples](https://github.com/mswjs/examples/tree/master/examples) or [our CodeSandbox template](https://codesandbox.io/s/msw-react-xx1c8) to create a reproduction repository much faster. Issues without a reproduction repository **will be closed**.
+      description: A link to the repository where your issue can be reproduced. You can clone one of [our examples](https://github.com/mswjs/examples) to create a reproduction repository much faster. **Issues without a reproduction repository will be closed**.
       placeholder: i.e. https://github.com/you/msw-issue
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/02-issue-nodejs.yml
+++ b/.github/ISSUE_TEMPLATE/02-issue-nodejs.yml
@@ -37,7 +37,7 @@ body:
   - type: input
     attributes:
       label: Reproduction repository
-      description: A link to the repository where your issue can be reproduced. You can clone one of [our examples](https://github.com/mswjs/examples/tree/master/examples) or [our CodeSandbox template](https://codesandbox.io/s/msw-react-xx1c8) to create a reproduction repository much faster. Issues without a reproduction repository **will be closed**.
+      description: A link to the repository where your issue can be reproduced. You can clone one of [our examples](https://github.com/mswjs/examples) to create a reproduction repository much faster. **Issues without a reproduction repository will be closed**.
       placeholder: i.e. https://github.com/you/msw-issue
     validations:
       required: true


### PR DESCRIPTION
- Closes #1588

The standalone MSW sandbox is old and I can't seem to find an easy way to update it (lost with all those devboxes/credits/templates changes). Drop it, and recommend cloning any of the existing examples (which also have CodeSandbox projects attached) instead. 