### PR TITLE
fix(setupWorker): set "response.url" in "response:*" events

### DIFF
--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -48,6 +48,19 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
             responseJson,
           )
 
+    /**
+     * Set response URL if it's not set already.
+     * @see https://github.com/mswjs/msw/issues/2030
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Response/url
+     */
+    if (!response.url) {
+      Object.defineProperty(response, 'url', {
+        value: request.url,
+        enumerable: true,
+        writable: false,
+      })
+    }
+
     context.emitter.emit(
       responseJson.isMockedResponse ? 'response:mocked' : 'response:bypass',
       {

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
@@ -40,7 +40,7 @@ worker.events.on(
   async ({ response, request, requestId }) => {
     const body = await response.clone().text()
     console.warn(
-      `[response:mocked] ${body} ${request.method} ${request.url} ${requestId}`,
+      `[response:mocked] ${response.url} ${body} ${request.method} ${request.url} ${requestId}`,
     )
   },
 )
@@ -50,7 +50,7 @@ worker.events.on(
   async ({ response, request, requestId }) => {
     const body = await response.clone().text()
     console.warn(
-      `[response:bypass] ${body} ${request.method} ${request.url} ${requestId}`,
+      `[response:bypass] ${response.url} ${body} ${request.method} ${request.url} ${requestId}`,
     )
   },
 )

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.test.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.test.ts
@@ -54,7 +54,7 @@ test('emits events for a handled request and mocked response', async ({
     `[request:start] GET ${url} ${requestId}`,
     `[request:match] GET ${url} ${requestId}`,
     `[request:end] GET ${url} ${requestId}`,
-    `[response:mocked] response-body GET ${url} ${requestId}`,
+    `[response:mocked] ${url} response-body GET ${url} ${requestId}`,
   ])
 })
 
@@ -80,7 +80,7 @@ test('emits events for a handled request with no response', async ({
   expect(consoleSpy.get('warning')).toEqual([
     `[request:start] POST ${url} ${requestId}`,
     `[request:end] POST ${url} ${requestId}`,
-    `[response:bypass] original-response POST ${url} ${requestId}`,
+    `[response:bypass] ${url} original-response POST ${url} ${requestId}`,
   ])
 })
 
@@ -107,7 +107,7 @@ test('emits events for an unhandled request', async ({
     `[request:start] GET ${url} ${requestId}`,
     `[request:unhandled] GET ${url} ${requestId}`,
     `[request:end] GET ${url} ${requestId}`,
-    `[response:bypass] majestic-unknown GET ${url} ${requestId}`,
+    `[response:bypass] ${url} majestic-unknown GET ${url} ${requestId}`,
   ])
 })
 


### PR DESCRIPTION
- Fixes #2030 