### PR TITLE
fix: set correct "Content-Length" response header for special characters (#2045)

### DIFF
--- a/src/core/HttpResponse.test.ts
+++ b/src/core/HttpResponse.test.ts
@@ -27,6 +27,19 @@ describe('HttpResponse.text()', () => {
     })
   })
 
+  it('creates a text response with special characters', async () => {
+    const response = HttpResponse.text('안녕 세상', { status: 201 })
+
+    expect(response.status).toBe(201)
+    expect(response.statusText).toBe('Created')
+    expect(response.body).toBeInstanceOf(ReadableStream)
+    expect(await response.text()).toBe('안녕 세상')
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-length': '13',
+      'content-type': 'text/plain',
+    })
+  })
+
   it('allows overriding the "Content-Type" response header', async () => {
     const response = HttpResponse.text('hello world', {
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },
@@ -64,6 +77,19 @@ describe('HttpResponse.json()', () => {
     expect(await response.json()).toEqual({ firstName: 'John' })
     expect(Object.fromEntries(response.headers.entries())).toEqual({
       'content-length': '20',
+      'content-type': 'application/json',
+    })
+  })
+
+  it('creates a json response given an object with special characters', async () => {
+    const response = HttpResponse.json({ firstName: '제로' })
+
+    expect(response.status).toBe(200)
+    expect(response.statusText).toBe('OK')
+    expect(response.body).toBeInstanceOf(ReadableStream)
+    expect(await response.json()).toEqual({ firstName: '제로' })
+    expect(Object.fromEntries(response.headers.entries())).toEqual({
+      'content-length': '22',
       'content-type': 'application/json',
     })
   })
@@ -229,3 +255,4 @@ it('creates a form data response', async () => {
     ),
   })
 })
+

--- a/src/core/HttpResponse.test.ts
+++ b/src/core/HttpResponse.test.ts
@@ -255,4 +255,3 @@ it('creates a form data response', async () => {
     ),
   })
 })
-

--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -63,7 +63,7 @@ export class HttpResponse extends Response {
     if (!responseInit.headers.has('Content-Length')) {
       responseInit.headers.set(
         'Content-Length',
-        body ? body.length.toString() : '0',
+        body ? new Blob([body]).size.toString() : '0',
       )
     }
 
@@ -95,7 +95,7 @@ export class HttpResponse extends Response {
     if (!responseInit.headers.has('Content-Length')) {
       responseInit.headers.set(
         'Content-Length',
-        responseText ? responseText.length.toString() : '0',
+        responseText ? new Blob([responseText]).size.toString() : '0',
       )
     }
 


### PR DESCRIPTION
- Fixes #2045 

@kettanaito 
fyi, '안녕 세상', which has 13 bytes (4 Korean characters * 3b + 1b(space) === 13b), means 'hello world' in Korean.
`{ firstName: '제로' }` turns into `{"firstName":"제로"}` which has 22 bytes (16 ASCII characters + 2 Korean characters * 3b === 22b)