### PR TITLE
fix: add guard for missing context requests

### DIFF
--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -15,9 +15,11 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
   ) => {
     const { payload: responseJson } = message
 
-    // Get the Request instance reference stored in the
-    // request listener for intercepted requests
-    // (bypass and passthrough requests will not be present here).
+    /**
+     * Get the Request instance reference stored in the
+     * request listener for intercepted requests
+     * (bypass and passthrough requests will not be present here).
+     */
     const { requestId } = responseJson
     const request = context.requests.get(requestId)
     context.requests.delete(requestId)

--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -16,9 +16,10 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
     const { payload: responseJson } = message
 
     // Get the Request instance reference stored in the
-    // request listener.
+    // request listener for intercepted requests
+    // (bypass and passthrough requests will not be present here).
     const { requestId } = responseJson
-    const request = context.requests.get(requestId)!
+    const request = context.requests.get(requestId)
     context.requests.delete(requestId)
 
     /**
@@ -53,7 +54,7 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
      * @see https://github.com/mswjs/msw/issues/2030
      * @see https://developer.mozilla.org/en-US/docs/Web/API/Response/url
      */
-    if (!response.url) {
+    if (!response.url && request) {
       Object.defineProperty(response, 'url', {
         value: request.url,
         enumerable: true,

--- a/src/core/sharedOptions.ts
+++ b/src/core/sharedOptions.ts
@@ -48,7 +48,7 @@ export type LifeCycleEventsMap = {
   'response:bypass': [
     args: {
       response: Response
-      request: Request
+      request: Request | undefined
       requestId: string
     },
   ]


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/2053

The current code for `createResponseListener` assumes the `request` is always present in `context` but when `bypass` and `passthrough` functions are used with `fetch`, requests never get added to the `context`. Example [usage](https://mswjs.io/docs/recipes/response-patching/#proxying-requests) from the docs for a proxy request. 

This is the most straightforward fix that doesn't change the original logic, but something else may be desired if the intent of the code should be that those types of requests are added to context and handled specifically. Its unclear why they do not go through the normal flow if there are provisions to deal with these in `core/utils/handleRequest.ts` which is used in `createRequestListener`. 

The tests are TypeScript. If the non-null assertion was not there, the type system would have demanded undefined be handled.

Further, to ensure the Response URL is always set as intended in `createResponseListener`, perhaps the original request can be passed explicitly to the `RESPONSE` event to use when its not in context. 