### PR TITLE
fix: remove upper version range for "typescript"

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "webpack-http-server": "^0.5.0"
   },
   "peerDependencies": {
-    "typescript": ">= 4.4.x <= 5.2.x"
+    "typescript": ">= 4.4.x"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
- Backports #2077 to v1.
- Closes #2029
- Related to https://github.com/mswjs/msw/issues/1875 and https://github.com/mswjs/msw/issues/2025