### PR TITLE
fix: make worker integrity mismatch a warning

### DIFF
--- a/src/browser/setupWorker/start/createStartHandler.ts
+++ b/src/browser/setupWorker/start/createStartHandler.ts
@@ -80,7 +80,7 @@ Please consider using a custom "serviceWorker.url" option to point to the actual
       )
 
       if (integrityCheckResult.error) {
-        devUtils.error(`\
+        devUtils.warn(`\
 Detected outdated Service Worker: ${integrityCheckResult.error.message}
 
 The mocking is still enabled, but it's highly recommended that you update your Service Worker by running:

--- a/test/browser/msw-api/integrity-check.test.ts
+++ b/test/browser/msw-api/integrity-check.test.ts
@@ -65,7 +65,7 @@ test('errors when activating the worker with an outdated integrity', async ({
 
   await waitFor(() => {
     // Produces a meaningful error in the browser's console.
-    expect(consoleSpy.get('error')).toEqual(
+    expect(consoleSpy.get('warning')).toEqual(
       expect.arrayContaining([
         expect.stringContaining('[MSW] Detected outdated Service Worker'),
       ]),


### PR DESCRIPTION
- Prerequisite for #2054

There's no need to treat service worker integrity mismatches as errors anymore. Using a mismatched version of the worker script _may_ result in issues but it's extremely unlikely. Not every change to the worker script implies a breaking change. In fact, it's up to us to ensure that the breaking changes there are accompanied by major version bumps. The worker logic has been consistent for years now, and we rely on the worker only as the interception mechanism. 