### PR TITLE
fix(setupWorker): emit the correct life-cycle events for bypassed requests

### DIFF
--- a/src/browser/setupWorker/start/createRequestListener.ts
+++ b/src/browser/setupWorker/start/createRequestListener.ts
@@ -48,7 +48,7 @@ export const createRequestListener = (
         context.emitter,
         {
           onPassthroughResponse() {
-            messageChannel.postMessage('NOT_FOUND')
+            messageChannel.postMessage('PASSTHROUGH')
           },
           async onMockedResponse(response, { handler, parsedResult }) {
             // Clone the mocked response so its body could be read

--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -21,6 +21,8 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
     const request = context.requests.get(requestId)!
     context.requests.delete(requestId)
 
+    console.log('RESPONSE LISTENER', responseJson, context.requests)
+
     /**
      * CORS requests with `mode: "no-cors"` result in "opaque" responses.
      * That kind of responses cannot be manipulated in JavaScript due

--- a/src/browser/setupWorker/start/utils/createMessageChannel.ts
+++ b/src/browser/setupWorker/start/utils/createMessageChannel.ts
@@ -16,7 +16,7 @@ interface WorkerChannelEventsMap {
     data: StringifiedResponse,
     transfer?: [ReadableStream<Uint8Array>],
   ]
-  NOT_FOUND: []
+  PASSTHROUGH: []
 }
 
 export class WorkerChannel {

--- a/src/core/utils/handleRequest.ts
+++ b/src/core/utils/handleRequest.ts
@@ -52,7 +52,7 @@ export async function handleRequest(
 ): Promise<Response | undefined> {
   emitter.emit('request:start', { request, requestId })
 
-  // Perform bypassed requests (i.e. issued via "ctx.fetch") as-is.
+  // Perform bypassed requests (i.e. wrapped in "bypass()") as-is.
   if (request.headers.get('x-msw-intention') === 'bypass') {
     emitter.emit('request:end', { request, requestId })
     handleRequestOptions?.onPassthroughResponse?.(request)

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -237,7 +237,7 @@ async function getResponse(event, client, requestId) {
       return respondWithMock(clientMessage.data)
     }
 
-    case 'MOCK_NOT_FOUND': {
+    case 'PASSTHROUGH': {
       return passthrough()
     }
   }

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -206,13 +206,6 @@ async function getResponse(event, client, requestId) {
     return passthrough()
   }
 
-  // Bypass requests with the explicit bypass header.
-  // Such requests can be issued by "ctx.fetch()".
-  const mswIntention = request.headers.get('x-msw-intention')
-  if (['bypass', 'passthrough'].includes(mswIntention)) {
-    return passthrough()
-  }
-
   // Notify the client that a request has been intercepted.
   const requestBuffer = await request.arrayBuffer()
   const clientMessage = await sendToClient(

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
@@ -1,4 +1,10 @@
-import { HttpResponse, http, LifeCycleEventsMap, passthrough } from 'msw'
+import {
+  HttpResponse,
+  http,
+  LifeCycleEventsMap,
+  passthrough,
+  bypass,
+} from 'msw'
 import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker(
@@ -10,6 +16,9 @@ const worker = setupWorker(
   }),
   http.get('*/passthrough', () => {
     return passthrough()
+  }),
+  http.get('*/bypass', async ({ request }) => {
+    return fetch(bypass(request, { method: 'POST' }))
   }),
   http.get('*/unhandled-exception', () => {
     throw new Error('Unhandled resolver error')

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, http, LifeCycleEventsMap } from 'msw'
+import { HttpResponse, http, LifeCycleEventsMap, passthrough } from 'msw'
 import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker(
@@ -7,6 +7,9 @@ const worker = setupWorker(
   }),
   http.post('*/no-response', () => {
     return
+  }),
+  http.get('*/passthrough', () => {
+    return passthrough()
   }),
   http.get('*/unhandled-exception', () => {
     throw new Error('Unhandled resolver error')

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.test.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.test.ts
@@ -146,7 +146,7 @@ test('emits events for a passthrough request', async ({
   })
 })
 
-test.only('emits events for a bypassed request', async ({
+test('emits events for a bypassed request', async ({
   loadExample,
   spyOnConsole,
   fetch,
@@ -161,16 +161,30 @@ test.only('emits events for a bypassed request', async ({
 
   const url = server.http.url('/bypass')
   await fetch(url)
-  const requestId = getRequestId(consoleSpy)
-
-  await page.pause()
 
   await waitFor(() => {
-    expect(consoleSpy.get('warning')).toEqual([
-      `[request:start] GET ${url} ${requestId}`,
-      `[request:end] GET ${url} ${requestId}`,
-      `[response:bypass] ${url} bypassed-response GET ${url} ${requestId}`,
-    ])
+    // First, must print the events for the original (mocked) request.
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`[request:start] GET ${url}`),
+        expect.stringContaining(`[request:end] GET ${url}`),
+        expect.stringContaining(
+          `[response:mocked] ${url} bypassed-response GET ${url}`,
+        ),
+      ]),
+    )
+
+    // Then, must also print events for the bypassed request.
+    expect(consoleSpy.get('warning')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(`[request:start] POST ${url}`),
+        expect.stringContaining(`[request:end] POST ${url}`),
+        expect.stringContaining(
+          `[response:bypass] ${url} bypassed-response POST ${url}`,
+        ),
+      ]),
+    )
+
     expect(pageErrors).toEqual([])
   })
 })


### PR DESCRIPTION
- Fixes #2053
- Fixes #2083
- Closes #2054
- Depends on #2093 