### PR TITLE
fix: resolve "~/core" import for .d.mts modules

### DIFF
--- a/config/replaceCoreImports.js
+++ b/config/replaceCoreImports.js
@@ -1,10 +1,17 @@
-function replaceCoreImports(fileContents, isEsm) {
-  const importPattern = isEsm
-    ? /from ["'](~\/core(.*))["'](;)?$/gm
-    : /require\(["'](~\/core(.*))["']\)(;)?/gm
+const CORE_ESM_IMPORT_PATTERN = /from ["'](~\/core(.*))["'](;)?/gm
+const CORE_CJS_IMPORT_PATTERN = /require\(["'](~\/core(.*))["']\)(;)?/gm
 
+function getCoreImportPattern(isEsm) {
+  return isEsm ? CORE_ESM_IMPORT_PATTERN : CORE_CJS_IMPORT_PATTERN
+}
+
+function hasCoreImports(fileContents, isEsm) {
+  return getCoreImportPattern(isEsm).test(fileContents)
+}
+
+function replaceCoreImports(fileContents, isEsm) {
   return fileContents.replace(
-    importPattern,
+    getCoreImportPattern(isEsm),
     (_, __, maybeSubmodulePath, maybeSemicolon) => {
       const submodulePath = maybeSubmodulePath || '/index'
       const semicolon = maybeSemicolon || ''
@@ -17,5 +24,6 @@ function replaceCoreImports(fileContents, isEsm) {
 }
 
 module.exports = {
+  hasCoreImports,
   replaceCoreImports,
 }

--- a/config/scripts/patch-ts.js
+++ b/config/scripts/patch-ts.js
@@ -1,30 +1,106 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const { exec } = require('node:child_process')
+const path = require('node:path')
+const { promisify } = require('node:util')
+const { invariant } = require('outvariant')
 const glob = require('glob')
 const { hasCoreImports, replaceCoreImports } = require('../replaceCoreImports')
 
+const execAsync = promisify(exec)
+
+const BUILD_DIR = path.resolve(__dirname, '../../lib')
+
 async function patchTypeDefs() {
   const typeDefsPaths = glob.sync('**/*.d.{ts,mts}', {
-    cwd: path.resolve(__dirname, '../../lib'),
+    cwd: BUILD_DIR,
     absolute: true,
   })
+  const typeDefsWithCoreImports = typeDefsPaths
+    .map((modulePath) => {
+      const fileContents = fs.readFileSync(modulePath, 'utf8')
+      if (hasCoreImports(fileContents, true)) {
+        return [modulePath, fileContents]
+      }
+    })
+    .filter(Boolean)
 
-  for (const typeDefsPath of typeDefsPaths) {
-    const fileContents = fs.readFileSync(typeDefsPath, 'utf8')
+  if (typeDefsWithCoreImports.length === 0) {
+    console.log(
+      'Found no .d.ts modules containing the "~/core" import, skipping...',
+    )
+    return process.exit(0)
+  }
 
-    // Ignore type definition modules that don't have "~/core" imports.
-    if (!hasCoreImports(fileContents, true)) {
-      continue
-    }
+  console.log(
+    'Found %d module(s) with the "~/core" import, resolving...',
+    typeDefsWithCoreImports.length,
+  )
 
+  for (const [typeDefsPath, fileContents] of typeDefsWithCoreImports) {
     // Treat ".d.ts" files as ESM to replace "import" statements.
     // Force no extension on the ".d.ts" imports.
     const nextFileContents = replaceCoreImports(fileContents, true)
-
     fs.writeFileSync(typeDefsPath, nextFileContents, 'utf8')
-
-    console.log('Successfully patched at "%s"!', typeDefsPath)
+    console.log('Successfully patched "%s"!', typeDefsPath)
   }
+
+  console.log(
+    'Imports resolved in %d file(s), verifying...',
+    typeDefsWithCoreImports.length,
+  )
+
+  // Next, validate that we left no "~/core" imports unresolved.
+  const result = await execAsync(
+    `grep "~/core" ./**/*.{ts,mts} -R -l || exit 0`,
+    {
+      cwd: BUILD_DIR,
+      shell: '/bin/bash',
+    },
+  )
+
+  invariant(
+    result.stderr === '',
+    'Failed to validate the .d.ts modules for the presence of the "~/core" import. See the original error below.',
+    result.stderr,
+  )
+
+  if (result.stdout !== '') {
+    const modulesWithUnresolvedImports = result.stdout
+      .split('\n')
+      .filter(Boolean)
+
+    console.error(
+      `Found .d.ts modules containing unresolved "~/core" import after the patching:
+
+  ${modulesWithUnresolvedImports.map((path) => `  - ${path}`).join('\n')}
+        `,
+    )
+
+    return process.exit(1)
+  }
+
+  // Ensure that the .d.ts files compile without errors after resolving the "~/core" imports.
+  console.log('Compiling the .d.ts modules with tsc...')
+  const tscCompilation = await execAsync(
+    `tsc --noEmit --skipLibCheck ${typeDefsPaths.join(' ')}`,
+    {
+      cwd: BUILD_DIR,
+    },
+  )
+
+  if (tscCompilation.stderr !== '') {
+    console.error(
+      'Failed to compile the .d.ts modules with tsc. See the original error below.',
+      tscCompilation.stderr,
+    )
+
+    return process.exit(1)
+  }
+
+  console.log(
+    'The "~/core" imports resolved successfully in %d .d.ts modules! 🎉',
+    typeDefsWithCoreImports.length,
+  )
 }
 
 patchTypeDefs()


### PR DESCRIPTION
We use a custom script that resolves the `~/core` in the import paths in `.d.ts` files (since those won't resolve). But we miss to do that for `.d.mts` files, which leaves them broken. 

Also added two layers of protection to prevent this issue in the future:

- `grep` for any `~/core` in the resolved `.d.{ts,mts}` modules;
- `tsc` run on all the `.d.{ts,mts}` modules to make sure they compile. 