### PR TITLE
fix(setupWorker): remove left-over console.log()

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
-lib
-node
-native
-test/typings
+/lib
+/node
+/native
+/config
+/test

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,13 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
   rules: {
+    // Forbid "console.debug()" statements.
+    'no-console': [
+      'error',
+      {
+        allow: ['log', 'warn', 'error', 'group', 'groupCollapsed', 'groupEnd'],
+      },
+    ],
     '@typescript-eslint/prefer-ts-expect-error': 2,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,

--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -21,8 +21,6 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
     const request = context.requests.get(requestId)!
     context.requests.delete(requestId)
 
-    console.log('RESPONSE LISTENER', responseJson, context.requests)
-
     /**
      * CORS requests with `mode: "no-cors"` result in "opaque" responses.
      * That kind of responses cannot be manipulated in JavaScript due

--- a/src/core/typeUtils.ts
+++ b/src/core/typeUtils.ts
@@ -8,13 +8,13 @@ export type RequiredDeep<
 > = Type extends Fn
   ? Type
   : /**
-   * @note The "Fn" type satisfies the predicate below.
-   * It must always come first, before the Record check.
-   */
-  Type extends Record<string, any>
-  ? {
-      [Key in keyof Type]-?: NonNullable<Type[Key]> extends NonNullable<U>
-        ? NonNullable<Type[Key]>
-        : RequiredDeep<NonNullable<Type[Key]>, U>
-    }
-  : Type
+     * @note The "Fn" type satisfies the predicate below.
+     * It must always come first, before the Record check.
+     */
+    Type extends Record<string, any>
+    ? {
+        [Key in keyof Type]-?: NonNullable<Type[Key]> extends NonNullable<U>
+          ? NonNullable<Type[Key]>
+          : RequiredDeep<NonNullable<Type[Key]>, U>
+      }
+    : Type

--- a/src/core/utils/internal/mergeRight.ts
+++ b/src/core/utils/internal/mergeRight.ts
@@ -8,20 +8,23 @@ export function mergeRight(
   left: Record<string, any>,
   right: Record<string, any>,
 ) {
-  return Object.entries(right).reduce((result, [key, rightValue]) => {
-    const leftValue = result[key]
+  return Object.entries(right).reduce(
+    (result, [key, rightValue]) => {
+      const leftValue = result[key]
 
-    if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
-      result[key] = leftValue.concat(rightValue)
+      if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
+        result[key] = leftValue.concat(rightValue)
+        return result
+      }
+
+      if (isObject(leftValue) && isObject(rightValue)) {
+        result[key] = mergeRight(leftValue, rightValue)
+        return result
+      }
+
+      result[key] = rightValue
       return result
-    }
-
-    if (isObject(leftValue) && isObject(rightValue)) {
-      result[key] = mergeRight(leftValue, rightValue)
-      return result
-    }
-
-    result[key] = rightValue
-    return result
-  }, Object.assign({}, left))
+    },
+    Object.assign({}, left),
+  )
 }


### PR DESCRIPTION
- Fixes #2096 
- Fixes #2098
- Configures eslint to ban `console.debug()`. Please use `console.debug()` for debugging. Logs, warnings, errors, and others are valid output. 