### PR TITLE
fix(setupServer): infer function args and return in ".boundary()"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,15 @@ module.exports = {
     '@typescript-eslint/prefer-ts-expect-error': 2,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        types: {
+          Function: false,
+        },
+        extendDefaults: true,
+      },
+    ],
     '@typescript-eslint/ban-ts-comment': 0,
     '@typescript-eslint/no-namespace': [
       2,

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -70,7 +70,5 @@ export interface SetupServer extends SetupServerCommon {
    *
    * @see {@link https://mswjs.io/docs/api/setup-server/boundary `server.boundary()` API reference}
    */
-  boundary<Fn extends (...args: Array<any>) => unknown>(
-    callback: Fn,
-  ): (...args: Parameters<Fn>) => ReturnType<Fn>
+  boundary<T>(callback: T & Function): T & Function
 }

--- a/test/typings/server.boundary.test-d.ts
+++ b/test/typings/server.boundary.test-d.ts
@@ -1,0 +1,16 @@
+import { setupServer } from 'msw/node'
+
+const fn = (_args: { a: number }): string => 'hello'
+
+const server = setupServer()
+const bound = server.boundary(fn)
+
+bound({ a: 1 }).toUpperCase()
+
+bound({
+  // @ts-expect-error Expected number, got string.
+  a: '1',
+})
+
+// @ts-expect-error Unknown method ".fooBar()" on string.
+bound({ a: 1 }).fooBar()


### PR DESCRIPTION
- Fixes #2069 

