### PR TITLE
fix: properly infer parameter and return types in  `server.boundary()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,15 @@ module.exports = {
     '@typescript-eslint/prefer-ts-expect-error': 2,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        types: {
+          Function: false,
+        },
+        extendDefaults: true,
+      },
+    ],
     '@typescript-eslint/ban-ts-comment': 0,
     '@typescript-eslint/no-namespace': [
       2,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,15 +19,6 @@ module.exports = {
     '@typescript-eslint/prefer-ts-expect-error': 2,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,
-    '@typescript-eslint/ban-types': [
-      'error',
-      {
-        types: {
-          Function: false,
-        },
-        extendDefaults: true,
-      },
-    ],
     '@typescript-eslint/ban-ts-comment': 0,
     '@typescript-eslint/no-namespace': [
       2,

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -60,10 +60,10 @@ export class SetupServerApi
     this.handlersController = new AsyncHandlersController(handlers)
   }
 
-  public boundary<Fn extends (...args: Array<any>) => unknown>(
-    callback: Fn,
-  ): (...args: Parameters<Fn>) => ReturnType<Fn> {
-    return (...args: Parameters<Fn>): ReturnType<Fn> => {
+  public boundary<Args extends Array<any>, R>(
+    callback: (...args: Args) => R,
+  ): (...args: Args) => R {
+    return (...args: Args): R => {
       return store.run<any, any>(
         {
           initialHandlers: this.handlersController.currentHandlers(),

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -70,7 +70,5 @@ export interface SetupServer extends SetupServerCommon {
    *
    * @see {@link https://mswjs.io/docs/api/setup-server/boundary `server.boundary()` API reference}
    */
-  boundary<Fn extends (...args: Array<any>) => unknown>(
-    callback: Fn,
-  ): (...args: Parameters<Fn>) => ReturnType<Fn>
+  boundary<T>(callback: T & Function): T & Function
 }

--- a/src/node/glossary.ts
+++ b/src/node/glossary.ts
@@ -70,5 +70,7 @@ export interface SetupServer extends SetupServerCommon {
    *
    * @see {@link https://mswjs.io/docs/api/setup-server/boundary `server.boundary()` API reference}
    */
-  boundary<T>(callback: T & Function): T & Function
+  boundary<Args extends Array<any>, R>(
+    callback: (...args: Args) => R,
+  ): (...args: Args) => R
 }

--- a/test/typings/server.boundary.test-d.ts
+++ b/test/typings/server.boundary.test-d.ts
@@ -1,0 +1,16 @@
+import { setupServer } from 'msw/node'
+
+const fn = (_args: { a: number }): string => 'hello'
+
+const server = setupServer()
+const bound = server.boundary(fn)
+
+bound({ a: 1 }).toUpperCase()
+
+bound({
+  // @ts-expect-error Expected number, got string.
+  a: '1',
+})
+
+// @ts-expect-error Unknown method ".fooBar()" on string.
+bound({ a: 1 }).fooBar()

--- a/test/typings/server.boundary.test-d.ts
+++ b/test/typings/server.boundary.test-d.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node'
+import { test } from 'vitest'
 
 const fn = (_args: { a: number }): string => 'hello'
 
@@ -12,5 +13,15 @@ bound({
   a: '1',
 })
 
-// @ts-expect-error Unknown method ".fooBar()" on string.
-bound({ a: 1 }).fooBar()
+bound({ a: 1 })
+  // @ts-expect-error Unknown method ".fooBar()" on string.
+  .fooBar()
+
+test(
+  'should work',
+  server.boundary(({ expect }) => {
+    expect(true).toBe(true)
+    // @ts-expect-error Property 'doesntExist' does not exist on type 'ExpectStatic'
+    expect.doesntExist
+  }),
+)


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/2069
- Closes https://github.com/mswjs/msw/pull/2100