### PR TITLE
fix: accept a narrower response body type by default

### DIFF
--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -1,4 +1,5 @@
 import type { DefaultBodyType, JsonBodyType } from './handlers/RequestHandler'
+import type { NoInfer } from './typeUtils'
 import {
   decorateResponse,
   normalizeResponseInit,
@@ -48,7 +49,7 @@ export class HttpResponse extends Response {
    * HttpResponse.text('Error', { status: 500 })
    */
   static text<BodyType extends string>(
-    body?: BodyType | null,
+    body?: NoInfer<BodyType> | null,
     init?: HttpResponseInit,
   ): StrictResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
@@ -77,7 +78,7 @@ export class HttpResponse extends Response {
    * HttpResponse.json({ error: 'Not Authorized' }, { status: 401 })
    */
   static json<BodyType extends JsonBodyType>(
-    body?: BodyType | null,
+    body?: NoInfer<BodyType> | null,
     init?: HttpResponseInit,
   ): StrictResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)

--- a/src/core/graphql.ts
+++ b/src/core/graphql.ts
@@ -31,7 +31,10 @@ export type GraphQLRequestHandler = <
     | GraphQLHandlerNameSelector
     | DocumentNode
     | TypedDocumentNode<Query, Variables>,
-  resolver: GraphQLResponseResolver<Query, Variables>,
+  resolver: GraphQLResponseResolver<
+    [Query] extends [never] ? GraphQLQuery : Query,
+    Variables
+  >,
   options?: RequestHandlerOptions,
 ) => GraphQLHandler
 
@@ -41,7 +44,7 @@ export type GraphQLResponseResolver<
 > = ResponseResolver<
   GraphQLResolverExtras<Variables>,
   null,
-  GraphQLResponseBody<Query>
+  GraphQLResponseBody<[Query] extends [never] ? GraphQLQuery : Query>
 >
 
 function createScopedGraphQLHandler(
@@ -61,7 +64,7 @@ function createScopedGraphQLHandler(
 
 function createGraphQLOperationHandler(url: Path) {
   return <
-    Query extends Record<string, any>,
+    Query extends GraphQLQuery = GraphQLQuery,
     Variables extends GraphQLVariables = GraphQLVariables,
   >(
     resolver: ResponseResolver<

--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -68,10 +68,13 @@ export interface GraphQLJsonRequestBody<Variables extends GraphQLVariables> {
   variables?: Variables
 }
 
-export interface GraphQLResponseBody<BodyType extends DefaultBodyType> {
-  data?: BodyType | null
-  errors?: readonly Partial<GraphQLError>[] | null
-}
+export type GraphQLResponseBody<BodyType extends DefaultBodyType> =
+  | {
+      data?: BodyType | null
+      errors?: readonly Partial<GraphQLError>[] | null
+    }
+  | null
+  | undefined
 
 export function isDocumentNode(
   value: DocumentNode | any,

--- a/src/core/typeUtils.ts
+++ b/src/core/typeUtils.ts
@@ -18,3 +18,9 @@ export type RequiredDeep<
           : RequiredDeep<NonNullable<Type[Key]>, U>
       }
     : Type
+
+/**
+ * @fixme Remove this once TS 5.4 is the lowest supported version.
+ * Because "NoInfer" is a built-in type utility there.
+ */
+export type NoInfer<T> = [T][T extends any ? 0 : never]

--- a/test/typings/custom-resolver.test-d.ts
+++ b/test/typings/custom-resolver.test-d.ts
@@ -72,12 +72,12 @@ it('custom graphql resolver has correct variables and response type', () => {
 it('custom graphql resolver does not accept unknown variables', () => {
   graphql.query<{ number: number }, { id: string }>(
     'GetUser',
-    // @ts-expect-error Incompatible response query type.
     identityGraphQLResolver(({ variables }) => {
       expectTypeOf(variables).toEqualTypeOf<{ id: string }>()
 
       return HttpResponse.json({
         data: {
+          // @ts-expect-error Incompatible response query type.
           user: {
             id: variables.id,
           },

--- a/test/typings/custom-resolver.test-d.ts
+++ b/test/typings/custom-resolver.test-d.ts
@@ -35,10 +35,12 @@ it('custom http resolver has correct parameters type', () => {
 
   http.get<{ id: string }, never, 'hello'>(
     '/user/:id',
-    // @ts-expect-error Response body doesn't match the response type.
     withDelay(250, ({ params }) => {
       expectTypeOf(params).toEqualTypeOf<{ id: string }>()
-      return HttpResponse.text('non-matching')
+      return HttpResponse.text(
+        // @ts-expect-error Response body doesn't match the response type.
+        'non-matching',
+      )
     }),
   )
 })

--- a/test/typings/graphql.test-d.ts
+++ b/test/typings/graphql.test-d.ts
@@ -37,13 +37,12 @@ it('graphql mutation allows explicit null as the response body type for the muta
   })
 })
 it('graphql mutation does not allow mismatched mutation response', () => {
-  graphql.mutation<{ key: string }>(
-    'MutateData',
-    // @ts-expect-error Response data doesn't match the query type.
-    () => {
-      return HttpResponse.json({ data: {} })
-    },
-  )
+  graphql.mutation<{ key: string }>('MutateData', () => {
+    return HttpResponse.json({
+      // @ts-expect-error Response data doesn't match the query type.
+      data: {},
+    })
+  })
 })
 
 it("graphql query does not accept null as variables' generic query type ", () => {
@@ -53,6 +52,7 @@ it("graphql query does not accept null as variables' generic query type ", () =>
     null
   >('', () => {})
 })
+
 it("graphql query accepts the correct type for the variables' generic query type", () => {
   /**
    * Response body type (GraphQL query type).
@@ -76,15 +76,14 @@ it('graphql query allows explicit null as the response body type for the query',
 })
 
 it('graphql query does not accept invalid data type for the response body type for the query', () => {
-  graphql.query<{ id: string }>(
-    'GetUser',
-    // @ts-expect-error "id" type is incorrect
-    () => {
-      return HttpResponse.json({
-        data: { id: 123 },
-      })
-    },
-  )
+  graphql.query<{ id: string }>('GetUser', () => {
+    return HttpResponse.json({
+      data: {
+        // @ts-expect-error "id" type is incorrect
+        id: 123,
+      },
+    })
+  })
 })
 
 it('graphql query does not allow empty response when the query type is defined', () => {
@@ -114,12 +113,12 @@ it("graphql operation does not accept null as variables' generic operation type"
 })
 
 it('graphql operation does not allow mismatched operation response', () => {
-  graphql.operation<{ key: string }>(
-    // @ts-expect-error Response data doesn't match the query type.
-    () => {
-      return HttpResponse.json({ data: {} })
-    },
-  )
+  graphql.operation<{ key: string }>(() => {
+    return HttpResponse.json({
+      // @ts-expect-error Response data doesn't match the query type.
+      data: {},
+    })
+  })
 })
 
 it('graphql operation allows explicit null as the response body type for the operation', () => {
@@ -140,64 +139,62 @@ it('graphql handlers allow passthrough responses', () => {
 
     return HttpResponse.json({ data: {} })
   })
+})
 
-  it("graphql variables cannot extract type from the runtime 'DocumentNode'", () => {
-    /**
-     * Supports `DocumentNode` as the GraphQL operation name.
-     */
-    const getUser = parse(`
+it("graphql variables cannot extract type from the runtime 'DocumentNode'", () => {
+  /**
+   * Supports `DocumentNode` as the GraphQL operation name.
+   */
+  const getUser = parse(`
         query GetUser {
           user {
             firstName
           }
         }
       `)
-    graphql.query(getUser, () => {
-      return HttpResponse.json({
-        // Cannot extract query type from the runtime `DocumentNode`.
-        data: { arbitrary: true },
-      })
+  graphql.query(getUser, () => {
+    return HttpResponse.json({
+      // Cannot extract query type from the runtime `DocumentNode`.
+      data: { arbitrary: true },
     })
   })
+})
 
-  it('graphql query cannot extract variable and reponse types', () => {
-    const getUserById = parse(`
+it('graphql query cannot extract variable and reponse types', () => {
+  const getUserById = parse(`
       query GetUserById($userId: String!) {
         user(id: $userId) {
           firstName
         }
       }
       `)
-    graphql.query(getUserById, ({ variables }) => {
-      variables.userId.toUpperCase()
+  graphql.query(getUserById, ({ variables }) => {
+    // Cannot extract variables type from a DocumentNode.
+    expectTypeOf(variables).toEqualTypeOf<Record<string, any>>()
 
-      // Extracting variables from the native "DocumentNode" is impossible.
-      variables.foo
-
-      return HttpResponse.json({
-        data: {
-          user: {
-            firstName: 'John',
-            // Extracting a query body type from the "DocumentNode" is impossible.
-            lastName: 'Maverick',
-          },
+    return HttpResponse.json({
+      data: {
+        user: {
+          firstName: 'John',
+          // Extracting a query body type from the "DocumentNode" is impossible.
+          lastName: 'Maverick',
         },
-      })
+      },
     })
   })
+})
 
-  it('graphql mutation cannot extract variable and reponse types', () => {
-    const createUser = parse(`
+it('graphql mutation cannot extract variable and reponse types', () => {
+  const createUser = parse(`
         mutation CreateUser {
           user {
             id
           }
         }
       `)
-    graphql.mutation(createUser, () => {
-      return HttpResponse.json({
-        data: { arbitrary: true },
-      })
+  graphql.mutation(createUser, () => {
+    return HttpResponse.json({
+      data: { arbitrary: true },
     })
   })
 })

--- a/test/typings/http.test-d.ts
+++ b/test/typings/http.test-d.ts
@@ -95,6 +95,37 @@ it('supports narrow object as a response body generic argument', () => {
   })
 })
 
+it('supports object with extra keys as a response body generic argument', () => {
+  type ResponseBody = {
+    [key: string]: number | string
+    id: 123
+  }
+
+  http.get<never, never, ResponseBody>('/user', () => {
+    return HttpResponse.json({
+      id: 123,
+      // Extra keys are allowed if they satisfy the index signature.
+      name: 'John',
+    })
+  })
+
+  http.get<never, never, ResponseBody>('/user', () => {
+    return HttpResponse.json({
+      // @ts-expect-error Must be 123.
+      id: 456,
+      name: 'John',
+    })
+  })
+
+  http.get<never, never, ResponseBody>('/user', () => {
+    return HttpResponse.json({
+      id: 123,
+      // @ts-expect-error Must satisfy the index signature.
+      name: { a: 1 },
+    })
+  })
+})
+
 it('supports response body generic declared via type', () => {
   type ResponseBodyType = { id: number }
   http.get<never, never, ResponseBodyType>('/user', () => {


### PR DESCRIPTION
- Fixes #2105 

## Changes

- `HttpResponse.text()` and `HttpResponse.json()` _do not_ infer the given body type anymore. This allows them to correctly infer whichever response body type is set on the wrapping request handler. As a consequence, the response body type will now respect the narrower type provided to the handler:

```ts
http.get<never, never, { a: number }>('/', () => {
  // Error: Unknown property "b".
  return HttpResponse.json({ a: 1, b: 2 })
})
```

> Previously, this mocked response would satisfy the `{ a: number }` argument.


- When GraphQL handlers are used without explicit type arguments for the query/variables, those generic parameters become `never` even though they have fallback types. To prevent that, we are now explicitly checking for never: `GraphQLResponseBody<[Query] extends [never] ? GraphQLQuery : Query>`. This makes the GraphQL handlers compatible with the `NoInfer` changes to `HttpResponse.json()`. 
- Default GraphQL response body now supports `null | undefined`. It's still technically possible to respond to a GraphQL response with those. 
- Polishes a few type tests to take advantage of type asserting utilities instead of relying on `x.toUpperCase()` and such.

> [!WARNING]
> With the `NoInfer` changes to `HttpResponse.json()`, extra keys in the response body object _will cause type errors_. You have to explicitly allow (and describe) any extra keys your object may have:
>
> ```ts
> http.get<never, never, { [key: string]: string, a: number }>('/', () => {
>   return HttpResponse.json({ a: 1, b: 'hello' })
> })
> 
> I find this to be a good default because allowing extra keys is far easier than forbidding them in TypeScript. 

- As a nice side effect of this change, the type errors related to the response body are now displayed in the right place (now next to the actual properties at question; previously, next to the entire response resolver function):

```diff
   http.get<{ id: string }, never, 'hello'>(
     '/user/:id',
-    // Previously, errored here.
     withDelay(250, ({ params }) => {
       expectTypeOf(params).toEqualTypeOf<{ id: string }>()
-      return HttpResponse.text('non-matching')
+      return HttpResponse.text(
+        // Now, errors here.
+        'non-matching',
+      )
     }),
```