### PR TITLE
fix: use `createRequestId()` instead of `crypto.randomUUID()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@bundled-es-modules/statuses": "^1.0.1",
     "@inquirer/confirm": "^3.0.0",
     "@mswjs/cookies": "^1.1.0",
-    "@mswjs/interceptors": "^0.26.12",
+    "@mswjs/interceptors": "^0.26.14",
     "@open-draft/until": "^2.1.0",
     "@types/cookie": "^0.6.0",
     "@types/statuses": "^2.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ specifiers:
   '@commitlint/config-conventional': ^18.4.4
   '@inquirer/confirm': ^3.0.0
   '@mswjs/cookies': ^1.1.0
-  '@mswjs/interceptors': ^0.26.12
+  '@mswjs/interceptors': ^0.26.14
   '@open-draft/test-server': ^0.4.2
   '@open-draft/until': ^2.1.0
   '@ossjs/release': ^0.8.1
@@ -70,7 +70,7 @@ dependencies:
   '@bundled-es-modules/statuses': 1.0.1
   '@inquirer/confirm': 3.0.0
   '@mswjs/cookies': 1.1.0
-  '@mswjs/interceptors': 0.26.12
+  '@mswjs/interceptors': 0.26.14
   '@open-draft/until': 2.1.0
   '@types/cookie': 0.6.0
   '@types/statuses': 2.0.4
@@ -1099,8 +1099,8 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /@mswjs/interceptors/0.26.12:
-    resolution: {integrity: sha512-hF28Q4GwkElyvIYNKdbO2d+Cg1tgktl83LdBomeq7qJsph0lNHoouDMolBonBxI4ZjwntHNwa8qMlE2RgDuqmQ==}
+  /@mswjs/interceptors/0.26.14:
+    resolution: {integrity: sha512-q4S8RGjOUzv3A3gCawuKkUEcNJXjdPaSqoRHFvuZPWQnc7yOw702iGBRDMJoBK+l0KSv9XN8YP5ek6duRzrpqw==}
     engines: {node: '>=18'}
     dependencies:
       '@open-draft/deferred-promise': 2.2.0

--- a/src/core/getResponse.ts
+++ b/src/core/getResponse.ts
@@ -1,6 +1,6 @@
+import { createRequestId } from '@mswjs/interceptors'
 import type { RequestHandler } from './handlers/RequestHandler'
 import { executeHandlers } from './utils/executeHandlers'
-import { randomId } from './utils/internal/randomId'
 
 /**
  * Finds a response for the given request instance
@@ -15,7 +15,7 @@ export const getResponse = async (
 ): Promise<Response | undefined> => {
   const result = await executeHandlers({
     request,
-    requestId: randomId(),
+    requestId: createRequestId(),
     handlers,
   })
 

--- a/src/core/handlers/GraphQLHandler.test.ts
+++ b/src/core/handlers/GraphQLHandler.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { encodeBuffer } from '@mswjs/interceptors'
+import { createRequestId, encodeBuffer } from '@mswjs/interceptors'
 import { OperationTypeNode, parse } from 'graphql'
 import {
   GraphQLHandler,
@@ -9,7 +9,6 @@ import {
   GraphQLResolverExtras,
   isDocumentNode,
 } from './GraphQLHandler'
-import { randomId } from '../utils/internal/randomId'
 import { HttpResponse } from '../HttpResponse'
 import { ResponseResolver } from './RequestHandler'
 
@@ -737,7 +736,7 @@ describe('run', () => {
         userId: 'abc-123',
       },
     })
-    const requestId = randomId()
+    const requestId = createRequestId()
     const result = await handler.run({ request, requestId })
 
     expect(result!.handler).toEqual(handler)
@@ -779,7 +778,7 @@ describe('run', () => {
     const request = createPostGraphQLRequest({
       query: LOGIN,
     })
-    const requestId = randomId()
+    const requestId = createRequestId()
     const result = await handler.run({ request, requestId })
 
     expect(result).toBeNull()
@@ -827,7 +826,7 @@ describe('request', () => {
         `,
     })
 
-    const requestId = randomId()
+    const requestId = createRequestId()
     await handler.run({ request, requestId })
 
     expect(matchAllResolver).toHaveBeenCalledTimes(1)

--- a/src/core/handlers/HttpHandler.test.ts
+++ b/src/core/handlers/HttpHandler.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { randomId } from '../utils/internal/randomId'
+import { createRequestId } from '@mswjs/interceptors'
 import { HttpHandler, HttpRequestResolverExtras } from './HttpHandler'
 import { HttpResponse } from '..'
 import { ResponseResolver } from './RequestHandler'
@@ -152,7 +152,7 @@ describe('run', () => {
   test('returns a mocked response given a matching request', async () => {
     const handler = new HttpHandler('GET', '/user/:userId', resolver)
     const request = new Request(new URL('/user/abc-123', location.href))
-    const requestId = randomId()
+    const requestId = createRequestId()
     const result = await handler.run({ request, requestId })
 
     expect(result!.handler).toEqual(handler)
@@ -176,7 +176,7 @@ describe('run', () => {
     const handler = new HttpHandler('POST', '/login', resolver)
     const result = await handler.run({
       request: new Request(new URL('/users', location.href)),
-      requestId: randomId(),
+      requestId: createRequestId(),
     })
 
     expect(result).toBeNull()
@@ -186,7 +186,7 @@ describe('run', () => {
     const handler = new HttpHandler('GET', '/users', resolver)
     const result = await handler.run({
       request: new Request(new URL('/users', location.href)),
-      requestId: randomId(),
+      requestId: createRequestId(),
     })
 
     expect(result?.parsedResult?.match?.params).toEqual({})
@@ -207,7 +207,7 @@ describe('run', () => {
     const run = async () => {
       const result = await handler.run({
         request: new Request(new URL('/users', location.href)),
-        requestId: randomId(),
+        requestId: createRequestId(),
       })
       return result?.response?.text()
     }

--- a/src/core/utils/handleRequest.test.ts
+++ b/src/core/utils/handleRequest.test.ts
@@ -2,12 +2,12 @@
  * @vitest-environment jsdom
  */
 import { Emitter } from 'strict-event-emitter'
+import { createRequestId } from '@mswjs/interceptors'
 import { LifeCycleEventsMap, SharedOptions } from '../sharedOptions'
 import { RequestHandler } from '../handlers/RequestHandler'
 import { http } from '../http'
 import { handleRequest, HandleRequestOptions } from './handleRequest'
 import { RequiredDeep } from '../typeUtils'
-import { randomId } from './internal/randomId'
 import { HttpResponse } from '../HttpResponse'
 import { passthrough } from '../passthrough'
 
@@ -51,7 +51,7 @@ afterEach(() => {
 test('returns undefined for a request with the "x-msw-intention" header equal to "bypass"', async () => {
   const { emitter, events } = setup()
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request(new URL('http://localhost/user'), {
     headers: new Headers({
       'x-msw-intention': 'bypass',
@@ -97,7 +97,7 @@ test('does not bypass a request with "x-msw-intention" header set to arbitrary v
 
   const result = await handleRequest(
     request,
-    randomId(),
+    createRequestId(),
     handlers,
     options,
     emitter,
@@ -112,7 +112,7 @@ test('does not bypass a request with "x-msw-intention" header set to arbitrary v
 test('reports request as unhandled when it has no matching request handlers', async () => {
   const { emitter, events } = setup()
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request(new URL('http://localhost/user'))
   const handlers: Array<RequestHandler> = []
 
@@ -145,7 +145,7 @@ test('reports request as unhandled when it has no matching request handlers', as
 test('returns undefined on a request handler that returns no response', async () => {
   const { emitter, events } = setup()
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request(new URL('http://localhost/user'))
   const handlers: Array<RequestHandler> = [
     http.get('/user', () => {
@@ -184,7 +184,7 @@ test('returns undefined on a request handler that returns no response', async ()
 test('returns the mocked response for a request with a matching request handler', async () => {
   const { emitter, events } = setup()
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request(new URL('http://localhost/user'))
   const mockedResponse = HttpResponse.json({ firstName: 'John' })
   const handlers: Array<RequestHandler> = [
@@ -242,7 +242,7 @@ test('returns the mocked response for a request with a matching request handler'
 test('returns a transformed response if the "transformResponse" option is provided', async () => {
   const { emitter, events } = setup()
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request(new URL('http://localhost/user'))
   const mockedResponse = HttpResponse.json({ firstName: 'John' })
   const handlers: Array<RequestHandler> = [
@@ -325,7 +325,7 @@ test('returns a transformed response if the "transformResponse" option is provid
 it('returns undefined without warning on a passthrough request', async () => {
   const { emitter, events } = setup()
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request(new URL('http://localhost/user'))
   const handlers: Array<RequestHandler> = [
     http.get('/user', () => {
@@ -358,7 +358,7 @@ it('returns undefined without warning on a passthrough request', async () => {
 it('calls the handler with the requestId', async () => {
   const { emitter } = setup()
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request(new URL('http://localhost/user'))
   const handlerFn = vi.fn()
   const handlers: Array<RequestHandler> = [http.get('/user', handlerFn)]
@@ -390,7 +390,7 @@ it('marks the first matching one-time handler as used', async () => {
   })
   const handlers: Array<RequestHandler> = [oneTimeHandler, anotherHandler]
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request('http://localhost/resource')
   const firstResult = await handleRequest(
     request,
@@ -438,7 +438,7 @@ it('does not mark non-matching one-time handlers as used', async () => {
   )
   const handlers: Array<RequestHandler> = [oneTimeHandler, anotherHandler]
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const firstResult = await handleRequest(
     new Request('http://localhost/another'),
     requestId,
@@ -481,7 +481,7 @@ it('handles parallel requests with one-time handlers', async () => {
   })
   const handlers: Array<RequestHandler> = [oneTimeHandler, anotherHandler]
 
-  const requestId = randomId()
+  const requestId = createRequestId()
   const request = new Request('http://localhost/resource')
   const firstResultPromise = handleRequest(
     request,
@@ -526,7 +526,7 @@ describe('[Private] - resolutionContext - used for extensions', () => {
 
       const handlers: Array<RequestHandler> = [handler]
 
-      const requestId = randomId()
+      const requestId = createRequestId()
       const request = new Request(new URL('/resource', baseUrl))
       const response = await handleRequest(
         request,
@@ -555,7 +555,7 @@ describe('[Private] - resolutionContext - used for extensions', () => {
 
       const handlers: Array<RequestHandler> = [handler]
 
-      const requestId = randomId()
+      const requestId = createRequestId()
       const request = new Request(
         new URL('/resource', `http://not-the-base-url.com`),
       )

--- a/src/core/utils/internal/randomId.ts
+++ b/src/core/utils/internal/randomId.ts
@@ -1,3 +1,0 @@
-export function randomId(): string {
-  return Math.random().toString(16).slice(2)
-}


### PR DESCRIPTION
- Fixes #2111
- See https://github.com/mswjs/interceptors/releases/tag/v0.26.14

## Changes

MSW no longer relies on UUID for request IDs (non-public-facing). Previously, Interceptors used UUID while the browser code in MSW used `Math.random()`. Now, everything uses `Math.random()`. 