### PR TITLE
fix(WebSocketClientManager): use localStorage for clients persistence

### DIFF
--- a/src/browser/setupWorker/stop/createStop.ts
+++ b/src/browser/setupWorker/stop/createStop.ts
@@ -1,4 +1,5 @@
 import { devUtils } from '~/core/utils/internal/devUtils'
+import { MSW_WEBSOCKET_CLIENTS_KEY } from '~/core/ws/WebSocketClientManager'
 import { SetupWorkerInternalContext, StopHandler } from '../glossary'
 import { printStopMessage } from './utils/printStopMessage'
 
@@ -23,6 +24,9 @@ export const createStop = (
     context.workerChannel.send('MOCK_DEACTIVATE')
     context.isMockingEnabled = false
     window.clearInterval(context.keepAliveInterval)
+
+    // Clear the WebSocket clients from the shared storage.
+    localStorage.removeItem(MSW_WEBSOCKET_CLIENTS_KEY)
 
     printStopMessage({ quiet: context.startOptions?.quiet })
   }

--- a/src/core/ws.ts
+++ b/src/core/ws.ts
@@ -72,10 +72,12 @@ function createWebSocketLinkHandler(url: Path): WebSocketLink {
     typeof url,
   )
 
-  const clientManager = new WebSocketClientManager(wsBroadcastChannel)
+  const clientManager = new WebSocketClientManager(wsBroadcastChannel, url)
 
   return {
-    clients: clientManager.clients,
+    get clients() {
+      return clientManager.clients
+    },
     on(event, listener) {
       const handler = new WebSocketHandler(url)
 

--- a/src/core/ws/WebSocketClientManager.test.ts
+++ b/src/core/ws/WebSocketClientManager.test.ts
@@ -38,6 +38,30 @@ it('adds a client from this runtime to the list of clients', () => {
   expect(Array.from(manager.clients.values())).toEqual([connection])
 })
 
+it('adds multiple clients from this runtime to the list of clients', () => {
+  const manager = new WebSocketClientManager(channel, '*')
+  const connectionOne = new WebSocketClientConnection(
+    socket,
+    new TestWebSocketTransport(),
+  )
+  manager.addConnection(connectionOne)
+
+  // Must add the client to the list of clients.
+  expect(Array.from(manager.clients.values())).toEqual([connectionOne])
+
+  const connectionTwo = new WebSocketClientConnection(
+    socket,
+    new TestWebSocketTransport(),
+  )
+  manager.addConnection(connectionTwo)
+
+  // Must add the new cilent to the list as well.
+  expect(Array.from(manager.clients.values())).toEqual([
+    connectionOne,
+    connectionTwo,
+  ])
+})
+
 it('replays a "send" event coming from another runtime', async () => {
   const manager = new WebSocketClientManager(channel, '*')
   const connection = new WebSocketClientConnection(

--- a/src/core/ws/WebSocketClientManager.test.ts
+++ b/src/core/ws/WebSocketClientManager.test.ts
@@ -17,9 +17,8 @@ vi.spyOn(channel, 'postMessage')
 
 const socket = new WebSocket('ws://localhost')
 const transport = {
-  onOutgoing: vi.fn(),
-  onIncoming: vi.fn(),
-  onClose: vi.fn(),
+  addEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
   send: vi.fn(),
   close: vi.fn(),
 } satisfies WebSocketTransport
@@ -135,7 +134,7 @@ it('removes the extraneous message listener when the connection closes', async (
      * All we care here is that closing the connection triggers
      * the transport closure, which it always does.
      */
-    connection['transport'].onClose()
+    connection['transport'].dispatchEvent(new Event('close'))
   })
   vi.spyOn(connection, 'send')
 

--- a/src/core/ws/WebSocketClientManager.ts
+++ b/src/core/ws/WebSocketClientManager.ts
@@ -1,17 +1,14 @@
+import { invariant } from 'outvariant'
 import type {
   WebSocketData,
   WebSocketClientConnection,
   WebSocketClientConnectionProtocol,
 } from '@mswjs/interceptors/WebSocket'
+import { matchRequestUrl, type Path } from '../utils/matching/matchRequestUrl'
+
+const MSW_WEBSOCKET_CLIENTS_KEY = 'msw:ws:clients'
 
 export type WebSocketBroadcastChannelMessage =
-  | {
-      type: 'connection:open'
-      payload: {
-        clientId: string
-        url: string
-      }
-    }
   | {
       type: 'extraneous:send'
       payload: {
@@ -28,33 +25,104 @@ export type WebSocketBroadcastChannelMessage =
       }
     }
 
-export const kAddByClientId = Symbol('kAddByClientId')
+type SerializedClient = {
+  clientId: string
+  url: string
+}
 
 /**
  * A manager responsible for accumulating WebSocket client
  * connections across different browser runtimes.
  */
 export class WebSocketClientManager {
+  private inMemoryClients: Set<WebSocketClientConnectionProtocol>
+
+  constructor(
+    private channel: BroadcastChannel,
+    private url: Path,
+  ) {
+    this.inMemoryClients = new Set()
+  }
+
   /**
    * All active WebSocket client connections.
    */
-  public clients: Set<WebSocketClientConnectionProtocol>
+  get clients(): Set<WebSocketClientConnectionProtocol> {
+    // In the browser, different runtimes use "localStorage"
+    // as the shared source of all the clients.
+    if (typeof localStorage !== 'undefined') {
+      const inMemoryClients = Array.from(this.inMemoryClients)
 
-  constructor(private channel: BroadcastChannel) {
-    this.clients = new Set()
+      return new Set(
+        inMemoryClients.concat(
+          this.getSerializedClients()
+            // Filter out the serialized clients that are already present
+            // in this runtime in-memory. This is crucial because a remote client
+            // wrapper CANNOT send a message to the client in THIS runtime
+            // (the "message" event on broadcast channel won't trigger).
+            .filter((serializedClient) => {
+              if (
+                inMemoryClients.every(
+                  (client) => client.id !== serializedClient.clientId,
+                )
+              ) {
+                return serializedClient
+              }
+            })
+            .map((serializedClient) => {
+              return new WebSocketRemoteClientConnection(
+                serializedClient.clientId,
+                new URL(serializedClient.url),
+                this.channel,
+              )
+            }),
+        ),
+      )
+    }
 
-    this.channel.addEventListener('message', (message) => {
-      const { type, payload } = message.data as WebSocketBroadcastChannelMessage
+    // In Node.js, the manager acts as a singleton, and all clients
+    // are kept in-memory.
+    return this.inMemoryClients
+  }
 
-      switch (type) {
-        case 'connection:open': {
-          // When another runtime notifies about a new connection,
-          // create a connection wrapper class and add it to the set.
-          this.onRemoteConnection(payload.clientId, new URL(payload.url))
-          break
-        }
-      }
+  private getSerializedClients(): Array<SerializedClient> {
+    invariant(
+      typeof localStorage !== 'undefined',
+      'Failed to call WebSocketClientManager#getSerializedClients() in a non-browser environment. This is likely a bug in MSW. Please, report it on GitHub: https://github.com/mswjs/msw',
+    )
+
+    const clientsJson = localStorage.getItem(MSW_WEBSOCKET_CLIENTS_KEY)
+
+    if (!clientsJson) {
+      return []
+    }
+
+    const allClients = JSON.parse(clientsJson) as Array<SerializedClient>
+    const matchingClients = allClients.filter((client) => {
+      return matchRequestUrl(new URL(client.url), this.url).matches
     })
+
+    return matchingClients
+  }
+
+  private addClient(client: WebSocketClientConnection): void {
+    this.inMemoryClients.add(client)
+
+    if (typeof localStorage !== 'undefined') {
+      const serializedClients = this.getSerializedClients()
+
+      // Serialize the current client for other runtimes to create
+      // a remote wrapper over it. This has no effect on the current runtime.
+      const nextSerializedClients = serializedClients.concat({
+        clientId: client.id,
+        url: client.url.href,
+      } as SerializedClient)
+
+      localStorage.setItem(
+        MSW_WEBSOCKET_CLIENTS_KEY,
+        JSON.stringify(nextSerializedClients),
+      )
+    }
   }
 
   /**
@@ -64,16 +132,7 @@ export class WebSocketClientManager {
    * for the opened connections in the same runtime.
    */
   public addConnection(client: WebSocketClientConnection): void {
-    this.clients.add(client)
-
-    // Signal to other runtimes about this connection.
-    this.channel.postMessage({
-      type: 'connection:open',
-      payload: {
-        clientId: client.id,
-        url: client.url.toString(),
-      },
-    } as WebSocketBroadcastChannelMessage)
+    this.addClient(client)
 
     // Instruct the current client how to handle events
     // coming from other runtimes (e.g. when calling `.broadcast()`).
@@ -115,19 +174,6 @@ export class WebSocketClientManager {
     client.addEventListener('close', () => abortController.abort(), {
       once: true,
     })
-  }
-
-  /**
-   * Adds a client connection wrapper to operate with
-   * WebSocket client connections in other runtimes.
-   */
-  private onRemoteConnection(id: string, url: URL): void {
-    this.clients.add(
-      // Create a connection-compatible instance that can
-      // operate with this client from a different runtime
-      // using the BroadcastChannel messages.
-      new WebSocketRemoteClientConnection(id, url, this.channel),
-    )
   }
 }
 

--- a/test/browser/ws-api/ws.clients.browser.test.ts
+++ b/test/browser/ws-api/ws.clients.browser.test.ts
@@ -1,0 +1,166 @@
+import type { WebSocketLink, ws } from 'msw'
+import type { setupWorker } from 'msw/browser'
+import { test, expect } from '../playwright.extend'
+
+declare global {
+  interface Window {
+    msw: {
+      ws: typeof ws
+      setupWorker: typeof setupWorker
+    }
+    link: WebSocketLink
+    ws: WebSocket
+    messages: string[]
+  }
+}
+
+test('returns the number of active clients in the same runtime', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(require.resolve('./ws.runtime.js'), {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, ws } = window.msw
+    const api = ws.link('wss://example.com')
+    const worker = setupWorker(api.on('connection', () => {}))
+    window.link = api
+    await worker.start()
+  })
+
+  // Must return 0 when no clients are present.
+  expect(
+    await page.evaluate(() => {
+      return window.link.clients.size
+    }),
+  ).toBe(0)
+
+  await page.evaluate(async () => {
+    const ws = new WebSocket('wss://example.com')
+    await new Promise((done) => (ws.onopen = done))
+  })
+
+  // Must return 1 after a single client joined.
+  expect(
+    await page.evaluate(() => {
+      return window.link.clients.size
+    }),
+  ).toBe(1)
+
+  await page.evaluate(async () => {
+    const ws = new WebSocket('wss://example.com')
+    await new Promise((done) => (ws.onopen = done))
+  })
+
+  // Must return 2 now that another client has joined.
+  expect(
+    await page.evaluate(() => {
+      return window.link.clients.size
+    }),
+  ).toBe(2)
+})
+
+test('returns the number of active clients across different runtimes', async ({
+  loadExample,
+  context,
+}) => {
+  const { compilation } = await loadExample(
+    require.resolve('./ws.runtime.js'),
+    {
+      skipActivation: true,
+    },
+  )
+
+  const pageOne = await context.newPage()
+  const pageTwo = await context.newPage()
+
+  for (const page of [pageOne, pageTwo]) {
+    await page.goto(compilation.previewUrl)
+    await page.evaluate(async () => {
+      const { setupWorker, ws } = window.msw
+      const api = ws.link('wss://example.com')
+      const worker = setupWorker(api.on('connection', () => {}))
+      window.link = api
+      await worker.start()
+    })
+  }
+
+  await pageOne.bringToFront()
+  await pageOne.evaluate(async () => {
+    const ws = new WebSocket('wss://example.com')
+    await new Promise((done) => (ws.onopen = done))
+  })
+
+  expect(await pageOne.evaluate(() => window.link.clients.size)).toBe(1)
+  expect(await pageTwo.evaluate(() => window.link.clients.size)).toBe(1)
+
+  await pageTwo.bringToFront()
+  await pageTwo.evaluate(async () => {
+    const ws = new WebSocket('wss://example.com')
+    await new Promise((done) => (ws.onopen = done))
+  })
+
+  expect(await pageTwo.evaluate(() => window.link.clients.size)).toBe(2)
+  expect(await pageOne.evaluate(() => window.link.clients.size)).toBe(2)
+})
+
+test('broadcasts messages across runtimes', async ({
+  loadExample,
+  context,
+}) => {
+  const { compilation } = await loadExample(
+    require.resolve('./ws.runtime.js'),
+    {
+      skipActivation: true,
+    },
+  )
+
+  const pageOne = await context.newPage()
+  const pageTwo = await context.newPage()
+
+  for (const page of [pageOne, pageTwo]) {
+    await page.goto(compilation.previewUrl)
+    await page.evaluate(async () => {
+      const { setupWorker, ws } = window.msw
+      const api = ws.link('wss://example.com')
+      const worker = setupWorker(
+        api.on('connection', ({ client }) => {
+          client.addEventListener('message', (event) => {
+            api.broadcast(event.data)
+          })
+        }),
+      )
+      await worker.start()
+    })
+
+    await page.evaluate(() => {
+      window.messages = []
+      const ws = new WebSocket('wss://example.com')
+      window.ws = ws
+      ws.onmessage = (event) => {
+        window.messages.push(event.data)
+      }
+    })
+  }
+
+  await pageOne.evaluate(() => {
+    window.ws.send('hi from one')
+  })
+  expect(await pageOne.evaluate(() => window.messages)).toEqual(['hi from one'])
+  expect(await pageTwo.evaluate(() => window.messages)).toEqual(['hi from one'])
+
+  await pageTwo.evaluate(() => {
+    window.ws.send('hi from two')
+  })
+
+  expect(await pageTwo.evaluate(() => window.messages)).toEqual([
+    'hi from one',
+    'hi from two',
+  ])
+  expect(await pageOne.evaluate(() => window.messages)).toEqual([
+    'hi from one',
+    'hi from two',
+  ])
+})


### PR DESCRIPTION
## Changes

We have a bug that a new runtime doesn't really know about any other runtimes. It only keeps itself in the list of clients and notifies _other_ runtimes about itself. That's not right.

BroadcastChannel is not a good API to introduce a shared state because one has to constantly keep that state in-sync. Instead, I propose we use `localStorage` to keep the serialized list of all the WebSocket clients for the app. 

- Fixes the failing test from https://github.com/mswjs/examples/pull/111

## Roadmap

- [x] Rewrite `src/core/ws/WebSocketClientManager.test.ts` tests, the constructor signature and the behavior of `WebSocketClientManager` have changed. 
- [x] Clear the localStorage key at some point. 