### PR TITLE
fix: purge persisted clients on page reload

### DIFF
--- a/src/browser/setupWorker/start/createStartHandler.ts
+++ b/src/browser/setupWorker/start/createStartHandler.ts
@@ -1,4 +1,5 @@
 import { devUtils } from '~/core/utils/internal/devUtils'
+import { MSW_WEBSOCKET_CLIENTS_KEY } from '~/core/ws/WebSocketClientManager'
 import { getWorkerInstance } from './utils/getWorkerInstance'
 import { enableMocking } from './utils/enableMocking'
 import { SetupWorkerInternalContext, StartHandler } from '../glossary'
@@ -71,6 +72,11 @@ Please consider using a custom "serviceWorker.url" option to point to the actual
         // Make sure we're always clearing the interval - there are reports that not doing this can
         // cause memory leaks in headless browser environments.
         window.clearInterval(context.keepAliveInterval)
+
+        // Purge persisted clients on page reload.
+        // WebSocket clients will get new IDs on reload so persisting them
+        // makes little sense.
+        localStorage.removeItem(MSW_WEBSOCKET_CLIENTS_KEY)
       })
 
       // Check if the active Service Worker has been generated

--- a/src/core/ws/WebSocketClientManager.ts
+++ b/src/core/ws/WebSocketClientManager.ts
@@ -43,9 +43,8 @@ export class WebSocketClientManager {
   ) {
     this.inMemoryClients = new Set()
 
+    // Purge in-memory clients when the worker stops.
     if (typeof localStorage !== 'undefined') {
-      // When the worker clears the local storage key in "worker.stop()",
-      // also clear the in-memory clients map.
       localStorage.removeItem = new Proxy(localStorage.removeItem, {
         apply: (target, thisArg, args) => {
           const [key] = args


### PR DESCRIPTION
When the page reloads, purge the localStorage entry keeping the WebSocket clients because upon reload each client will have a different ID anyway. 