### PR TITLE
fix: give `node` export condition higher priority

### DIFF
--- a/config/scripts/validate-esm.js
+++ b/config/scripts/validate-esm.js
@@ -90,7 +90,7 @@ function validatePackageExports() {
   console.log('✅ Validated package.json exports')
 }
 
-function validateExportConditions(pointer, conditions) {
+function validateExportConditions(pointer, conditions, level = 0) {
   if (typeof conditions === 'string') {
     invariant(
       fs.existsSync(conditions),
@@ -103,7 +103,7 @@ function validateExportConditions(pointer, conditions) {
 
   const keys = Object.keys(conditions)
 
-  if (conditions[keys[0]] !== null) {
+  if (level == 0 && conditions[keys[0]] !== null) {
     invariant(keys[0] === 'types', 'FS')
   }
 
@@ -112,6 +112,15 @@ function validateExportConditions(pointer, conditions) {
     const relativeExportPath = conditions[key]
 
     if (relativeExportPath === null) {
+      return
+    }
+
+    if (typeof relativeExportPath === 'object') {
+      validateExportConditions(
+        `${pointer}.${key}`,
+        relativeExportPath,
+        level + 1,
+      )
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
       "default": "./lib/core/index.js"
     },
     "./browser": {
-      "node": null,
       "types": "./lib/browser/index.d.ts",
+      "browser": {
+        "require": "./lib/browser/index.js",
+        "import": "./lib/browser/index.mjs"
+      },
+      "node": null,
       "require": "./lib/browser/index.js",
       "import": "./lib/browser/index.mjs",
       "default": "./lib/browser/index.js"
@@ -32,8 +36,12 @@
       "default": "./lib/node/index.mjs"
     },
     "./native": {
-      "browser": null,
       "types": "./lib/native/index.d.ts",
+      "react-native": {
+        "require": "./lib/native/index.js",
+        "import": "./lib/native/index.mjs"
+      },
+      "browser": null,
       "require": "./lib/native/index.js",
       "import": "./lib/native/index.mjs",
       "default": "./lib/native/index.js"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,12 @@
       "default": "./lib/browser/index.js"
     },
     "./node": {
-      "browser": null,
       "types": "./lib/node/index.d.ts",
+      "node": {
+        "require": "./lib/node/index.js",
+        "import": "./lib/node/index.mjs"
+      },
+      "browser": null,
       "require": "./lib/node/index.js",
       "import": "./lib/node/index.mjs",
       "default": "./lib/node/index.mjs"


### PR DESCRIPTION
in case of mixed environments that look for both
"node" and "browser" export conditions