### PR TITLE
fix: prevent error when request not present

### DIFF
--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -53,7 +53,7 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
      * @see https://github.com/mswjs/msw/issues/2030
      * @see https://developer.mozilla.org/en-US/docs/Web/API/Response/url
      */
-    if (!response.url) {
+    if (!response.url && request && request.url) {
       Object.defineProperty(response, 'url', {
         value: request.url,
         enumerable: true,

--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -53,7 +53,7 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
      * @see https://github.com/mswjs/msw/issues/2030
      * @see https://developer.mozilla.org/en-US/docs/Web/API/Response/url
      */
-    if (!response.url) {
+    if (!response.url && request.url) {
       Object.defineProperty(response, 'url', {
         value: request.url,
         enumerable: true,


### PR DESCRIPTION
I get the the following error all the time in the console
```
createResponseListener.ts:58 Uncaught TypeError: Cannot read properties of undefined (reading 'url')
    at createResponseListener.ts:58:24
    at ServiceWorkerContainer.<anonymous> (setupWorker.ts:84:15)
```
This is because the request object maybe undefined in some cases

![image](https://github.com/mswjs/msw/assets/1392720/949ee640-51bc-4ac6-bb47-80d89faba0f0)

This PR is a simple fix for that.