### PR TITLE
fix(Disposable): make the ".dispose()" method synchronous

### DIFF
--- a/src/core/utils/internal/Disposable.ts
+++ b/src/core/utils/internal/Disposable.ts
@@ -1,9 +1,12 @@
-export type DisposableSubscription = () => Promise<void> | void
+export type DisposableSubscription = () => void
 
 export class Disposable {
   protected subscriptions: Array<DisposableSubscription> = []
 
-  public async dispose() {
-    await Promise.all(this.subscriptions.map((subscription) => subscription()))
+  public dispose() {
+    let subscription: DisposableSubscription | undefined
+    while ((subscription = this.subscriptions.shift())) {
+      subscription()
+    }
   }
 }


### PR DESCRIPTION
Fixing an oversight. The `.dispose()` method of `Disposable` is not meant to be async. In fact, we aren't using it that way anywhere in MSW. Looks like a leftover from 1.x -> 2.x migration. 

To prevent confusion, rewriting that method to do the following:

1. Be sync.
2. Actually shift the subscription functions so you cannot fire them multiple times. 