### PR TITLE
fix: update `@mswjs/interceptors` to 0.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@bundled-es-modules/statuses": "^1.0.1",
     "@inquirer/confirm": "^3.0.0",
     "@mswjs/cookies": "^1.1.0",
-    "@mswjs/interceptors": "^0.29.0",
+    "@mswjs/interceptors": "^0.30.0",
     "@open-draft/until": "^2.1.0",
     "@types/cookie": "^0.6.0",
     "@types/statuses": "^2.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^1.1.0
     version: 1.1.0
   '@mswjs/interceptors':
-    specifier: ^0.29.0
-    version: 0.29.0
+    specifier: ^0.30.0
+    version: 0.30.0
   '@open-draft/until':
     specifier: ^2.1.0
     version: 2.1.0
@@ -1453,8 +1453,8 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /@mswjs/interceptors@0.29.0:
-    resolution: {integrity: sha512-eppU9TxaRS2t5IcR00nuh+36zMHcK09pyhUvWJLO1ae5+U8KL7iatUGKlLUlbxXaq3BvDjlcF0Q8Xhzyosk/xA==}
+  /@mswjs/interceptors@0.30.0:
+    resolution: {integrity: sha512-wOsatc3+3LALw7JuvBZGvx8rg2Qz2nGNJrGvcH0qnBpDNNOCS7wHPPK90UIUwp7fB/eRPLPSawdzMBaxSifU1Q==}
     engines: {node: '>=18'}
     dependencies:
       '@open-draft/deferred-promise': 2.2.0

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -59,8 +59,7 @@ export class WebSocketHandler {
     const connection = event.data
 
     const resolvedConnection: WebSocketHandlerConnection = {
-      client: connection.client,
-      server: connection.server,
+      ...connection,
       params: parsedResult.match.params || {},
     }
 


### PR DESCRIPTION
Update `@mswjs/interceptors` to v0.30.0 to improve WebSocket handling (https://github.com/mswjs/interceptors/pull/577).