### PR TITLE
fix(ws): call BroadcastChannel.unref in Node.js environment

### DIFF
--- a/src/core/ws.ts
+++ b/src/core/ws.ts
@@ -11,7 +11,19 @@ import {
 import { Path, isPath } from './utils/matching/matchRequestUrl'
 import { WebSocketClientManager } from './ws/WebSocketClientManager'
 
+function isBroadcastChannelWithUnref(
+  channel: BroadcastChannel,
+): channel is BroadcastChannel & NodeJS.RefCounted {
+  return typeof Reflect.get(channel, 'unref') !== 'undefined'
+}
+
 const wsBroadcastChannel = new BroadcastChannel('msw:ws-client-manager')
+
+if (isBroadcastChannelWithUnref(wsBroadcastChannel)) {
+  // Allows the Node.js thread to exit if it is the only active handle in the event system.
+  // https://nodejs.org/api/worker_threads.html#broadcastchannelunref
+  wsBroadcastChannel.unref()
+}
 
 export type WebSocketLink = {
   /**


### PR DESCRIPTION
When using the WebSocket preview, the Node.js process doesn't exit properly. It does not matter if you actually create WebSocket links. This is a minimal reproduction:

```js
import { http, passthrough } from "msw";

http.get("/", () => passthrough());
```

I added `why-is-node-running` to the script:
```js
import why from "why-is-node-running";
import { http, passthrough } from "msw";

http.get("/", () => passthrough());

setTimeout(why, 1000);
```

This shows there is a `MessagePort` keeping the process running:
```
# MESSAGEPORT
node:internal/async_hooks:202                                                              
node:internal/worker/io:341                                                                
file://./node_modules/msw/lib/core/ws.mjs:8
node:internal/modules/esm/module_job:262                                                   
node:internal/modules/esm/loader:474                                                       
node:internal/modules/run_main:109 
```

It traces back to [this line](https://github.com/mswjs/msw/blob/feat/ws/src/core/ws.ts#L14):
```js
const wsBroadcastChannel = new BroadcastChannel("msw:ws-client-manager");
```

This PR fixes the problem by calling `.unref()` in Node.js environments ([docs](https://nodejs.org/api/worker_threads.html#broadcastchannelunref)). The typing is a bit ugly, but `unref` is only available in the type when importing from `node:working_threads` and not when using the global variable. The browser version of `BroadcastChannel` does not have an `unref` function, so the call has to be conditional.