### PR TITLE
fix(types): add generic type to MockedRequest.passthrough

### DIFF
--- a/src/utils/request/MockedRequest.ts
+++ b/src/utils/request/MockedRequest.ts
@@ -129,14 +129,16 @@ export class MockedRequest<
    * Bypass the intercepted request.
    * This will make a call to the actual endpoint requested.
    */
-  public passthrough(): MockedResponse<null> {
+  public passthrough<
+    BodyType extends DefaultBodyType = null,
+  >(): MockedResponse<BodyType> {
     return {
       // Constructing a dummy "101 Continue" mocked response
       // to keep the return type of the resolver consistent.
       status: 101,
       statusText: 'Continue',
       headers: new Headers(),
-      body: null,
+      body: null as BodyType,
       // Setting "passthrough" to true will signal the response pipeline
       // to perform this intercepted request as-is.
       passthrough: true,


### PR DESCRIPTION
This allows using request.passthrough() in a handler that also returns data.

Closes #2195

I was not able to run the test suite without errors even in the `backport/v1` branch. There were no type errors though.