### PR TITLE
chore: update pnpm/action-setup to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8.15
+          version: 8.15.6
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -20,9 +20,9 @@ jobs:
           node-version: 18
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8.15
+          version: 8.15.6
 
       - name: Install dependencies
         run: pnpm install
@@ -62,9 +62,9 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8.15
+          version: 8.15.6
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
           always-auth: true
           registry-url: https://registry.npmjs.org
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8.15
+          version: 8.15.6
 
       - name: Setup Git
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -23,9 +23,9 @@ jobs:
           node-version: 18
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8.15
+          version: 8.15.6
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/typescript-nightly.yml
+++ b/.github/workflows/typescript-nightly.yml
@@ -45,9 +45,9 @@ jobs:
           node-version: 18
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8.15
+          version: 8.15.6
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
GitHub Actions builds of this project appear to be broken ([example 1](https://github.com/mswjs/msw/actions/runs/9806289707/job/27077683587), [example 2](https://github.com/mswjs/msw/actions/runs/9798674386/job/27057508032)). Updating to `pnpm/action-setup@v4` appears to resolve the issue.

The hard coded versions are removed, because `package.json` specifies a `packageManager`. Quote from the [v4 release](https://github.com/pnpm/action-setup/releases/tag/v4.0.0):

> An error is thrown if one version of pnpm is specified in the `packageManager` field of `package.json` and a different version is specified in the action's settings.