### PR TITLE
fix: use iterables instead of generators

### DIFF
--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -1,5 +1,9 @@
 import { getCallFrame } from '../utils/internal/getCallFrame'
-import { isIterable } from '../utils/internal/isIterable'
+import {
+  AsyncIterable,
+  Iterable,
+  isIterable,
+} from '../utils/internal/isIterable'
 import type { ResponseResolutionContext } from '../utils/executeHandlers'
 import type { MaybePromise } from '../typeUtils'
 import { StrictRequest, StrictResponse } from '..//HttpResponse'
@@ -51,12 +55,12 @@ export type AsyncResponseResolverReturnType<
   ResponseBodyType extends DefaultBodyType,
 > = MaybePromise<
   | ResponseResolverReturnType<ResponseBodyType>
-  | Generator<
+  | Iterable<
       MaybeAsyncResponseResolverReturnType<ResponseBodyType>,
       MaybeAsyncResponseResolverReturnType<ResponseBodyType>,
       MaybeAsyncResponseResolverReturnType<ResponseBodyType>
     >
-  | AsyncGenerator<
+  | AsyncIterable<
       MaybeAsyncResponseResolverReturnType<ResponseBodyType>,
       MaybeAsyncResponseResolverReturnType<ResponseBodyType>,
       MaybeAsyncResponseResolverReturnType<ResponseBodyType>
@@ -122,12 +126,12 @@ export abstract class RequestHandler<
 
   protected resolver: ResponseResolver<ResolverExtras, any, any>
   private resolverGenerator?:
-    | Generator<
+    | Iterator<
         MaybeAsyncResponseResolverReturnType<any>,
         MaybeAsyncResponseResolverReturnType<any>,
         MaybeAsyncResponseResolverReturnType<any>
       >
-    | AsyncGenerator<
+    | AsyncIterator<
         MaybeAsyncResponseResolverReturnType<any>,
         MaybeAsyncResponseResolverReturnType<any>,
         MaybeAsyncResponseResolverReturnType<any>
@@ -314,37 +318,38 @@ export abstract class RequestHandler<
     resolver: ResponseResolver<ResolverExtras>,
   ): ResponseResolver<ResolverExtras> {
     return async (info): Promise<ResponseResolverReturnType<any>> => {
-      const result = this.resolverGenerator || (await resolver(info))
-
-      if (isIterable<AsyncResponseResolverReturnType<any>>(result)) {
-        // Opt-out from marking this handler as used.
-        this.isUsed = false
-
-        if (!this.resolverGenerator) {
-          this.resolverGenerator = result
+      if (!this.resolverGenerator) {
+        const result = await resolver(info)
+        if (!isIterable(result)) {
+          return result
         }
-
-        const { done, value } = await this.resolverGenerator.next()
-        const nextResponse = await value
-
-        if (nextResponse) {
-          this.resolverGeneratorResult = nextResponse.clone()
-        }
-
-        if (done) {
-          // A one-time generator resolver stops affecting the network
-          // only after it's been completely exhausted.
-          this.isUsed = true
-
-          // Clone the previously stored response so it can be read
-          // when receiving it repeatedly from the "done" generator.
-          return this.resolverGeneratorResult?.clone()
-        }
-
-        return nextResponse
+        this.resolverGenerator =
+          Symbol.iterator in result
+            ? result[Symbol.iterator]()
+            : result[Symbol.asyncIterator]()
       }
 
-      return result
+      // Opt-out from marking this handler as used.
+      this.isUsed = false
+
+      const { done, value } = await this.resolverGenerator.next()
+      const nextResponse = await value
+
+      if (nextResponse) {
+        this.resolverGeneratorResult = nextResponse.clone()
+      }
+
+      if (done) {
+        // A one-time generator resolver stops affecting the network
+        // only after it's been completely exhausted.
+        this.isUsed = true
+
+        // Clone the previously stored response so it can be read
+        // when receiving it repeatedly from the "done" generator.
+        return this.resolverGeneratorResult?.clone()
+      }
+
+      return nextResponse
     }
   }
 

--- a/src/core/utils/internal/isIterable.ts
+++ b/src/core/utils/internal/isIterable.ts
@@ -1,11 +1,20 @@
+// Redefine these types; the three-parameter forms are only available in TypeScript 5.6 or later.
+export interface Iterable<T, TReturn, TNext> {
+  [Symbol.iterator](): Iterator<T, TReturn, TNext>
+}
+
+export interface AsyncIterable<T, TReturn, TNext> {
+  [Symbol.asyncIterator](): AsyncIterator<T, TReturn, TNext>
+}
+
 /**
  * Determines if the given function is an iterator.
  */
 export function isIterable<IteratorType>(
   fn: any,
 ): fn is
-  | Generator<IteratorType, IteratorType, IteratorType>
-  | AsyncGenerator<IteratorType, IteratorType, IteratorType> {
+  | Iterable<IteratorType, IteratorType, IteratorType>
+  | AsyncIterable<IteratorType, IteratorType, IteratorType> {
   if (!fn) {
     return false
   }

--- a/src/core/utils/internal/isIterable.ts
+++ b/src/core/utils/internal/isIterable.ts
@@ -1,8 +1,15 @@
-// Redefine these types; the three-parameter forms are only available in TypeScript 5.6 or later.
+/**
+ * This is the same as TypeScript's `Iterable`, but with all three type parameters.
+ * @todo Remove once TypeScript 5.6 is the minimum.
+ */
 export interface Iterable<T, TReturn, TNext> {
   [Symbol.iterator](): Iterator<T, TReturn, TNext>
 }
 
+/**
+ * This is the same as TypeScript's `AsyncIterable`, but with all three type parameters.
+ * @todo Remove once TypeScript 5.6 is the minimum.
+ */
 export interface AsyncIterable<T, TReturn, TNext> {
   [Symbol.asyncIterator](): AsyncIterator<T, TReturn, TNext>
 }


### PR DESCRIPTION
This applies https://github.com/mswjs/msw/pull/2108#discussion_r1685551423 to the `fix/generator-resolver` branch.

Best viewed without whitespace: https://github.com/mswjs/msw/pull/2213/files?w=1