### PR TITLE
feat: print request body in `onUnhandledRequest` message

### DIFF
--- a/src/core/utils/request/onUnhandledRequest.test.ts
+++ b/src/core/utils/request/onUnhandledRequest.test.ts
@@ -64,11 +64,9 @@ test('supports the "warn" request strategy with request body', async () => {
   await onUnhandledRequest(
     new Request(new URL('http://localhost/api'), {
       method: 'POST',
-      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
-      cache: 'no-store',
       body: JSON.stringify({
         variables: {
           id: 'abc-123',

--- a/src/core/utils/request/onUnhandledRequest.test.ts
+++ b/src/core/utils/request/onUnhandledRequest.test.ts
@@ -14,7 +14,7 @@ const fixtures = {
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
 Read more: https://mswjs.io/docs/getting-started/mocks`,
-  warningWithResonseBody: (url = `/api`) => `\
+  warningWithResponseBody: (url = `/api`) => `\
 [MSW] Warning: intercepted a request without a matching request handler:
 
   • POST ${url}
@@ -78,7 +78,7 @@ test('supports the "warn" request strategy with request body', async () => {
     }),
   )
 
-  expect(console.warn).toHaveBeenCalledWith(fixtures.warningWithResonseBody())
+  expect(console.warn).toHaveBeenCalledWith(fixtures.warningWithResponseBody())
 })
 
 test('supports the "error" request strategy', async () => {

--- a/src/core/utils/request/onUnhandledRequest.test.ts
+++ b/src/core/utils/request/onUnhandledRequest.test.ts
@@ -19,7 +19,7 @@ Read more: https://mswjs.io/docs/getting-started/mocks`,
 
   • POST ${url}
 
-  • Request body: {\"variables\":{\"id\":\"abc-123\"},\"query\":\"query UserName($id: String!) { user(id: $id) { name } } }\"}
+  • Request body: {\"variables\":{\"id\":\"abc-123\"},\"query\":\"query UserName($id: String!) { user(id: $id) { name } }\"}
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
 Read more: https://mswjs.io/docs/getting-started/mocks`,
@@ -73,7 +73,7 @@ test('supports the "warn" request strategy with request body', async () => {
         variables: {
           id: 'abc-123',
         },
-        query: 'query UserName($id: String!) { user(id: $id) { name } } }',
+        query: 'query UserName($id: String!) { user(id: $id) { name } }',
       }),
     }),
   )

--- a/src/core/utils/request/onUnhandledRequest.test.ts
+++ b/src/core/utils/request/onUnhandledRequest.test.ts
@@ -14,6 +14,15 @@ const fixtures = {
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
 Read more: https://mswjs.io/docs/getting-started/mocks`,
+  warningWithResonseBody: (url = `/api`) => `\
+[MSW] Warning: intercepted a request without a matching request handler:
+
+  • POST ${url}
+
+  • Request body: {\"variables\":{\"id\":\"abc-123\"},\"query\":\"query UserName($id: String!) { user(id: $id) { name } } }\"}
+
+If you still wish to intercept this unhandled request, please create a request handler for it.
+Read more: https://mswjs.io/docs/getting-started/mocks`,
 
   errorWithoutSuggestions: `\
 [MSW] Error: intercepted a request without a matching request handler:
@@ -49,6 +58,27 @@ test('supports the "warn" request strategy', async () => {
   expect(console.warn).toHaveBeenCalledWith(
     fixtures.warningWithoutSuggestions(),
   )
+})
+
+test('supports the "warn" request strategy with request body', async () => {
+  await onUnhandledRequest(
+    new Request(new URL('http://localhost/api'), {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      cache: 'no-store',
+      body: JSON.stringify({
+        variables: {
+          id: 'abc-123',
+        },
+        query: 'query UserName($id: String!) { user(id: $id) { name } } }',
+      }),
+    }),
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(fixtures.warningWithResonseBody())
 })
 
 test('supports the "error" request strategy', async () => {

--- a/src/core/utils/request/onUnhandledRequest.ts
+++ b/src/core/utils/request/onUnhandledRequest.ts
@@ -24,7 +24,9 @@ export async function onUnhandledRequest(
   const url = new URL(request.url)
   const publicUrl = toPublicUrl(url) + url.search
 
-  const unhandledRequestMessage = `intercepted a request without a matching request handler:\n\n  \u2022 ${request.method} ${publicUrl}\n\nIf you still wish to intercept this unhandled request, please create a request handler for it.\nRead more: https://mswjs.io/docs/getting-started/mocks`
+  const requestBody = await request.clone().text()
+  const messageDetails = `\n\n  \u2022 ${request.method} ${publicUrl}\n\n${requestBody ? `  \u2022 Request body: ${await request.text()}\n\n` : ''}`
+  const unhandledRequestMessage = `intercepted a request without a matching request handler:${messageDetails}If you still wish to intercept this unhandled request, please create a request handler for it.\nRead more: https://mswjs.io/docs/getting-started/mocks`
 
   function applyStrategy(strategy: UnhandledRequestStrategy) {
     switch (strategy) {

--- a/src/core/utils/request/onUnhandledRequest.ts
+++ b/src/core/utils/request/onUnhandledRequest.ts
@@ -24,7 +24,7 @@ export async function onUnhandledRequest(
   const url = new URL(request.url)
   const publicUrl = toPublicUrl(url) + url.search
 
-  const requestBody = await request.text()
+  const requestBody = await request.clone().text()
   const messageDetails = `\n\n  \u2022 ${request.method} ${publicUrl}\n\n${requestBody ? `  \u2022 Request body: ${requestBody}\n\n` : ''}`
   const unhandledRequestMessage = `intercepted a request without a matching request handler:${messageDetails}If you still wish to intercept this unhandled request, please create a request handler for it.\nRead more: https://mswjs.io/docs/getting-started/mocks`
 

--- a/src/core/utils/request/onUnhandledRequest.ts
+++ b/src/core/utils/request/onUnhandledRequest.ts
@@ -24,7 +24,10 @@ export async function onUnhandledRequest(
   const url = new URL(request.url)
   const publicUrl = toPublicUrl(url) + url.search
 
-  const requestBody = await request.clone().text()
+  const requestBody =
+    request.method === 'HEAD' || request.method === 'GET'
+      ? null
+      : await request.clone().text()
   const messageDetails = `\n\n  \u2022 ${request.method} ${publicUrl}\n\n${requestBody ? `  \u2022 Request body: ${requestBody}\n\n` : ''}`
   const unhandledRequestMessage = `intercepted a request without a matching request handler:${messageDetails}If you still wish to intercept this unhandled request, please create a request handler for it.\nRead more: https://mswjs.io/docs/getting-started/mocks`
 

--- a/src/core/utils/request/onUnhandledRequest.ts
+++ b/src/core/utils/request/onUnhandledRequest.ts
@@ -24,8 +24,8 @@ export async function onUnhandledRequest(
   const url = new URL(request.url)
   const publicUrl = toPublicUrl(url) + url.search
 
-  const requestBody = await request.clone().text()
-  const messageDetails = `\n\n  \u2022 ${request.method} ${publicUrl}\n\n${requestBody ? `  \u2022 Request body: ${await request.text()}\n\n` : ''}`
+  const requestBody = await request.text()
+  const messageDetails = `\n\n  \u2022 ${request.method} ${publicUrl}\n\n${requestBody ? `  \u2022 Request body: ${requestBody}\n\n` : ''}`
   const unhandledRequestMessage = `intercepted a request without a matching request handler:${messageDetails}If you still wish to intercept this unhandled request, please create a request handler for it.\nRead more: https://mswjs.io/docs/getting-started/mocks`
 
   function applyStrategy(strategy: UnhandledRequestStrategy) {

--- a/test/browser/graphql-api/anonymous-operation.test.ts
+++ b/test/browser/graphql-api/anonymous-operation.test.ts
@@ -41,8 +41,8 @@ test('does not warn on anonymous GraphQL operation when no GraphQL handlers are 
 
   const endpointUrl = httpServer.http.url('/graphql')
   const response = await query(endpointUrl, {
+    // Intentionally anonymous query.
     query: gql`
-      # Intentionally anonymous query.
       query {
         user {
           id
@@ -70,6 +70,8 @@ test('does not warn on anonymous GraphQL operation when no GraphQL handlers are 
 [MSW] Warning: intercepted a request without a matching request handler:
 
   • POST ${endpointUrl}
+
+  • Request body: {\"query\":\"\\n      query {\\n        user {\\n          id\\n        }\\n      }\\n    \"}
 
 If you still wish to intercept this unhandled request, please create a request handler for it.
 Read more: https://mswjs.io/docs/getting-started/mocks`,
@@ -105,9 +107,9 @@ test('warns on handled anonymous GraphQL operation', async ({
 
   const endpointUrl = httpServer.http.url('/graphql')
   const response = await query(endpointUrl, {
+    // Intentionally anonymous query.
+    // It will be handled in the "graphql.operation()" handler above.
     query: gql`
-      # Intentionally anonymous query.
-      # It will be handled in the "graphql.operation()" handler above.
       query {
         user {
           id
@@ -170,9 +172,9 @@ test('does not print a warning on anonymous GraphQL operation handled by "graphq
 
   const endpointUrl = httpServer.http.url('/graphql')
   const response = await query(endpointUrl, {
+    // Intentionally anonymous query.
+    // It will be handled in the "graphql.operation()" handler above.
     query: gql`
-      # Intentionally anonymous query.
-      # It will be handled in the "graphql.operation()" handler above.
       query {
         user {
           id

--- a/test/node/regressions/many-request-handlers-jsdom.test.ts
+++ b/test/node/regressions/many-request-handlers-jsdom.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 import { HttpServer } from '@open-draft/test-server/http'
 import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -74,8 +72,9 @@ describe('http handlers', () => {
         body: 'request-body-',
       },
     )
-    // Each clone is a new AbortSignal listener which needs to be registered
-    expect(requestCloneSpy).toHaveBeenCalledTimes(1)
+    // Each clone is a new AbortSignal listener which needs to be registered.
+    // One clone is `onUnhandledRequest` reading the request body to print.
+    expect(requestCloneSpy).toHaveBeenCalledTimes(2)
     expect(httpResponse.status).toBe(500)
     expect(processErrorSpy).not.toHaveBeenCalled()
   })
@@ -122,7 +121,7 @@ describe('graphql handlers', () => {
     })
 
     expect(unhandledResponse.status).toEqual(500)
-    expect(requestCloneSpy).toHaveBeenCalledTimes(2)
+    expect(requestCloneSpy).toHaveBeenCalledTimes(3)
     // Must not print any memory leak warnings.
     expect(processErrorSpy).not.toHaveBeenCalled()
   })

--- a/test/node/regressions/many-request-handlers.test.ts
+++ b/test/node/regressions/many-request-handlers.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment node
- */
+// @vitest-environment node
 import { HttpServer } from '@open-draft/test-server/http'
 import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -75,8 +73,9 @@ describe('http handlers', () => {
         body: 'request-body-',
       },
     )
-    // Each clone is a new AbortSignal listener which needs to be registered
-    expect(requestCloneSpy).toHaveBeenCalledTimes(1)
+    // Each clone is a new AbortSignal listener which needs to be registered.
+    // One clone is `onUnhandledRequest` reading the request body to print.
+    expect(requestCloneSpy).toHaveBeenCalledTimes(2)
     expect(httpResponse.status).toBe(500)
     expect(stdErrSpy).not.toHaveBeenCalled()
   })
@@ -124,7 +123,7 @@ describe('graphql handlers', () => {
     })
 
     expect(unhandledResponse.status).toEqual(500)
-    expect(requestCloneSpy).toHaveBeenCalledTimes(2)
+    expect(requestCloneSpy).toHaveBeenCalledTimes(3)
     // Must not print any memory leak warnings.
     expect(stdErrSpy).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
- Closes #2161

I came to file a feature request very similar https://github.com/mswjs/msw/issues/2161 and thought I'd open a PR.

This will hopefully change this message:

```sh
[MSW] Warning: intercepted a request without a matching request handler:

  • POST https://graphql.staging.int.creativefabrica.com/query

If you still wish to intercept this unhandled request, please create a request handler for it.
Read more: https://mswjs.io/docs/getting-started/mocks
```

into

```sh
[MSW] Warning: intercepted a request without a matching request handler:

  • POST https://graphql.staging.int.creativefabrica.com/query

  • Request body: { "query": "{ user { id name } }" }

If you still wish to intercept this unhandled request, please create a request handler for it.
Read more: https://mswjs.io/docs/getting-started/mocks
```