### PR TITLE
fix(HttpResponse): skip setting "Content-Length" if it is already set

### DIFF
--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -137,7 +137,7 @@ export class HttpResponse extends Response {
   static arrayBuffer(body?: ArrayBuffer, init?: HttpResponseInit): Response {
     const responseInit = normalizeResponseInit(init)
 
-    if (body) {
+    if (body && !responseInit.headers.has('Content-Length')) {
       responseInit.headers.set('Content-Length', body.byteLength.toString())
     }
 

--- a/test/node/rest-api/response/body-binary.node.test.ts
+++ b/test/node/rest-api/response/body-binary.node.test.ts
@@ -28,12 +28,11 @@ afterAll(() => server.close())
 
 test('returns given buffer in the mocked response', async () => {
   const response = await fetch('http://test.mswjs.io/image')
-  const { status, headers } = response
   const actualImageBuffer = await response.arrayBuffer()
   const expectedImageBuffer = getImageBuffer()
 
-  expect(status).toBe(200)
-  expect(headers.get('content-length')).toBe(
+  expect(response.status).toBe(200)
+  expect(response.headers.get('content-length')).toBe(
     actualImageBuffer.byteLength.toString(),
   )
   expect(
@@ -43,13 +42,12 @@ test('returns given buffer in the mocked response', async () => {
 
 test('returns given blob in the mocked response', async () => {
   const response = await fetch('http://test.mswjs.io/image')
-  const { status, headers } = response
   const blob = await response.blob()
   const expectedImageBuffer = getImageBuffer()
 
-  expect(status).toBe(200)
+  expect(response.status).toBe(200)
   expect(blob.type).toBe('image/jpeg')
-  expect(blob.size).toBe(Number(headers.get('content-length')))
+  expect(blob.size).toBe(Number(response.headers.get('content-length')))
   expect(
     Buffer.compare(Buffer.from(await blob.arrayBuffer()), expectedImageBuffer),
   ).toBe(0)


### PR DESCRIPTION
When upgrading @mswjs/interceptors to 0.33 (in https://github.com/mswjs/msw/pull/2011), I've noticed a failing mocked binary response test: it was listing the `Content-Length` header value _twice_

```
Content-Length: 1044, 1044
```

> [!WARNING]
> This indicates a deeper issue, as `.set()` on `Headers` instance must not join values. Something goes off here. Raw `Headers` from Undici behaved correctly on that branch. 

We don't have any check if the `Content-Length` response header has already been set on `HttpResponse.arrayBuffer()`, which means MSW will disregard your custom `Content-Length`, which is a bug. 