### PR TITLE
test(response-cookies): fix "msw/browser" import

### DIFF
--- a/test/browser/rest-api/response/response-cookies.mocks.ts
+++ b/test/browser/rest-api/response/response-cookies.mocks.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw'
-import { setupWorker } from 'msw/lib/browser'
+import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker(
   http.get('/single-cookie', () => {


### PR DESCRIPTION
This is an incorrect way to import MSW:

https://github.com/mswjs/msw/blob/52d0a13b5c22065a56748d266fd200fcf786d217/test/browser/rest-api/response/response-cookies.mocks.ts#L2

This fails some of the e2e tests on the WebSocket branch. Not sure why it doesn't fail on main either. 