### PR TITLE
feat(ws): support `handleMessage` option on `ws.link`

### DIFF
--- a/src/core/ws/WebSocketClientManager.test.ts
+++ b/src/core/ws/WebSocketClientManager.test.ts
@@ -26,7 +26,7 @@ afterEach(() => {
 })
 
 it('adds a client from this runtime to the list of clients', () => {
-  const manager = new WebSocketClientManager(channel, '*')
+  const manager = new WebSocketClientManager({ url: '*', channel })
   const connection = new WebSocketClientConnection(
     socket,
     new TestWebSocketTransport(),
@@ -39,7 +39,7 @@ it('adds a client from this runtime to the list of clients', () => {
 })
 
 it('adds multiple clients from this runtime to the list of clients', () => {
-  const manager = new WebSocketClientManager(channel, '*')
+  const manager = new WebSocketClientManager({ url: '*', channel })
   const connectionOne = new WebSocketClientConnection(
     socket,
     new TestWebSocketTransport(),
@@ -63,7 +63,7 @@ it('adds multiple clients from this runtime to the list of clients', () => {
 })
 
 it('replays a "send" event coming from another runtime', async () => {
-  const manager = new WebSocketClientManager(channel, '*')
+  const manager = new WebSocketClientManager({ url: '*', channel })
   const connection = new WebSocketClientConnection(
     socket,
     new TestWebSocketTransport(),
@@ -92,7 +92,7 @@ it('replays a "send" event coming from another runtime', async () => {
 })
 
 it('replays a "close" event coming from another runtime', async () => {
-  const manager = new WebSocketClientManager(channel, '*')
+  const manager = new WebSocketClientManager({ url: '*', channel })
   const connection = new WebSocketClientConnection(
     socket,
     new TestWebSocketTransport(),
@@ -122,7 +122,7 @@ it('replays a "close" event coming from another runtime', async () => {
 })
 
 it('removes the extraneous message listener when the connection closes', async () => {
-  const manager = new WebSocketClientManager(channel, '*')
+  const manager = new WebSocketClientManager({ url: '*', channel })
   const transport = new TestWebSocketTransport()
   const connection = new WebSocketClientConnection(socket, transport)
   vi.spyOn(connection, 'close').mockImplementationOnce(() => {

--- a/src/core/ws/WebSocketClientManager.ts
+++ b/src/core/ws/WebSocketClientManager.ts
@@ -38,8 +38,10 @@ export class WebSocketClientManager {
   private inMemoryClients: Set<WebSocketClientConnectionProtocol>
 
   constructor(
-    private channel: BroadcastChannel,
-    private url: Path,
+    private options: {
+      url: Path
+      channel: BroadcastChannel
+    },
   ) {
     this.inMemoryClients = new Set()
 
@@ -88,7 +90,7 @@ export class WebSocketClientManager {
               return new WebSocketRemoteClientConnection(
                 serializedClient.clientId,
                 new URL(serializedClient.url),
-                this.channel,
+                this.options.channel,
               )
             }),
         ),
@@ -114,7 +116,7 @@ export class WebSocketClientManager {
 
     const allClients = JSON.parse(clientsJson) as Array<SerializedClient>
     const matchingClients = allClients.filter((client) => {
-      return matchRequestUrl(new URL(client.url), this.url).matches
+      return matchRequestUrl(new URL(client.url), this.options.url).matches
     })
 
     return matchingClients
@@ -156,7 +158,7 @@ export class WebSocketClientManager {
     ) => {
       const { type, payload } = message.data
 
-      // Ignore broadcasted messages for other clients.
+      // Ignore messages broadcasted to other clients.
       if (
         typeof payload === 'object' &&
         'clientId' in payload &&
@@ -180,7 +182,7 @@ export class WebSocketClientManager {
 
     const abortController = new AbortController()
 
-    this.channel.addEventListener('message', handleExtraneousMessage, {
+    this.options.channel.addEventListener('message', handleExtraneousMessage, {
       signal: abortController.signal,
     })
 

--- a/test/node/ws-api/ws.handle-message.test.ts
+++ b/test/node/ws-api/ws.handle-message.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment node-websocket
+import { ws } from 'msw'
+import { setupServer } from 'msw/node'
+import { WebSocketServer } from '../../support/WebSocketServer'
+
+const server = setupServer()
+const wsServer = new WebSocketServer()
+
+beforeAll(async () => {
+  server.listen()
+  await wsServer.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  wsServer.resetState()
+})
+
+afterAll(async () => {
+  server.close()
+  await wsServer.close()
+})
+
+it('encodes data sent from the interceptor', async () => {
+  const api = ws.link('ws://localhost', {
+    handleMessage(type, data) {
+      if (type === 'incoming') {
+        return decodeURI(data.toString())
+      }
+      return encodeURI(data.toString())
+    },
+  })
+
+  server.use(
+    api.on('connection', ({ client }) => {
+      // Send raw data from the interceptor.
+      // We don't expect the user to do the encoding.
+      // That's the entire purpose of the `handleMessage` option.
+      client.send('hello world')
+    }),
+  )
+
+  const client = new WebSocket('ws://localhost')
+  const messageListener = vi.fn()
+  client.onmessage = messageListener
+
+  await vi.waitFor(() => {
+    expect(messageListener).toHaveBeenCalledOnce()
+  })
+
+  const [messageEvent] = messageListener.mock.calls[0]
+  expect(messageEvent).toHaveProperty('type', 'message')
+  // Must receive encoded data in the client.
+  // This is equivalent to the client receiving an encoded
+  // packate from a third-party WebSocket server.
+  expect(messageEvent).toHaveProperty('data', 'hello%20world')
+})
+
+it('decodes data sent from the client', async () => {
+  const api = ws.link('ws://localhost', {
+    handleMessage(type, data) {
+      if (type === 'incoming') {
+        return decodeURI(data.toString())
+      }
+      return encodeURI(data.toString())
+    },
+  })
+
+  const mockMessageListener = vi.fn()
+  server.use(
+    api.on('connection', ({ client }) => {
+      client.addEventListener('message', mockMessageListener)
+    }),
+  )
+
+  const client = new WebSocket('ws://localhost')
+
+  // Send encoded message to the "server" (interceptor).
+  // This is equivalent to a third-party encoding its payload
+  // before sending it over WebSocket.
+  client.onopen = () => client.send(encodeURI('from client'))
+
+  await vi.waitFor(() => {
+    expect(mockMessageListener).toHaveBeenCalledOnce()
+  })
+
+  // Must receive a decoded data in the interceptor.
+  const [mockMessageEvent] = mockMessageListener.mock.calls[0]
+  expect(mockMessageEvent).toHaveProperty('type', 'message')
+  expect(mockMessageEvent).toHaveProperty('data', 'from client')
+})
+
+it('encodes data sent to the original server from the mock', async () => {
+  const originalServerMessageListener = vi.fn()
+  wsServer.on('connection', (ws) => {
+    ws.addEventListener('message', originalServerMessageListener)
+  })
+
+  const api = ws.link(wsServer.url, {
+    handleMessage(type, data) {
+      if (type === 'incoming') {
+        return decodeURI(data.toString())
+      }
+      return encodeURI(data.toString())
+    },
+  })
+
+  server.use(
+    api.on('connection', ({ server }) => {
+      server.connect()
+      server.send('hello world')
+    }),
+  )
+
+  new WebSocket(wsServer.url)
+
+  await vi.waitFor(() => {
+    expect(originalServerMessageListener).toHaveBeenCalledOnce()
+  })
+
+  const [mockMessageEvent] = originalServerMessageListener.mock.calls[0]
+  expect(mockMessageEvent).toHaveProperty('type', 'message')
+  // Must send encoded data from `server.send()` in the mock.
+  expect(mockMessageEvent).toHaveProperty('data', 'hello%20world')
+})
+
+it('preserves decoding when forwarding data from the client to the original server', async () => {
+  const originalServerMessageListener = vi.fn()
+  wsServer.on('connection', (ws) => {
+    ws.addEventListener('message', originalServerMessageListener)
+  })
+
+  const api = ws.link(wsServer.url, {
+    handleMessage(type, data) {
+      if (type === 'incoming') {
+        return decodeURI(data.toString())
+      }
+      return encodeURI(data.toString())
+    },
+  })
+
+  server.use(
+    api.on('connection', ({ server }) => {
+      server.connect()
+    }),
+  )
+
+  const client = new WebSocket(wsServer.url)
+  client.onopen = () => client.send(encodeURI('hello world'))
+
+  await vi.waitFor(() => {
+    expect(originalServerMessageListener).toHaveBeenCalledOnce()
+  })
+
+  const [mockMessageEvent] = originalServerMessageListener.mock.calls[0]
+  expect(mockMessageEvent).toHaveProperty('type', 'message')
+  // Must send encoded data from `server.send()` in the mock.
+  expect(mockMessageEvent).toHaveProperty('data', 'hello%20world')
+})
+
+it('decodes data received from the original server', async () => {
+  wsServer.on('connection', (ws) => {
+    ws.send(encodeURI('hello world'))
+  })
+
+  const api = ws.link(wsServer.url, {
+    handleMessage(type, data) {
+      if (type === 'incoming') {
+        return decodeURI(data.toString())
+      }
+      return encodeURI(data.toString())
+    },
+  })
+
+  const mockServerMessageListener = vi.fn()
+  server.use(
+    api.on('connection', ({ server }) => {
+      server.connect()
+      server.addEventListener('message', mockServerMessageListener)
+    }),
+  )
+
+  const client = new WebSocket(wsServer.url)
+  const clientMessageListener = vi.fn()
+  client.onmessage = clientMessageListener
+
+  await vi.waitFor(() => {
+    expect(mockServerMessageListener).toHaveBeenCalledOnce()
+  })
+
+  const [mockMessageEvent] = mockServerMessageListener.mock.calls[0]
+  expect(mockMessageEvent).toHaveProperty('type', 'message')
+  // Must receive decoded data from the original server.
+  expect(mockMessageEvent).toHaveProperty('data', 'hello world')
+})


### PR DESCRIPTION
- Related to https://github.com/mswjs/msw/discussions/2010, https://github.com/mswjs/msw/pull/2011
- Implements https://github.com/mswjs/msw/discussions/2010#discussioncomment-10297390

This pull request aims to accomplish a few things:

1. Give the developer a clear API to modify the incoming/outgoing data in the WebSocket connection.
2. Make the support for third-party bindings apply to the entire `ws.link()`, not individual connections (i.e. consistency).

## Roadmap 

- [ ] Document the `ws.link` options.
- [ ] Check if this API is sufficient for https://github.com/mswjs/socket.io-binding to be rewritten as a custom `handleMessage` function. 
  - [ ] Needs `binaryType` (https://github.com/mswjs/socket.io-binding/blob/0db8a6193f06c2196cfd1880d07e153fa702e591/src/index.ts#L36)
  - [ ] This pull request doesn't provide any means to create custom methods on `connection`, like `.emit()` (https://github.com/mswjs/socket.io-binding/blob/0db8a6193f06c2196cfd1880d07e153fa702e591/src/index.ts#L81)
  - [ ] This API provides no access to the actual server connection (https://github.com/mswjs/socket.io-binding/blob/0db8a6193f06c2196cfd1880d07e153fa702e591/src/index.ts#L137)
  - [ ] Some clients may represent a single message as _multiple_ messages (e.g. how `socket.io` handles Blobs) (https://github.com/mswjs/socket.io-binding/blob/0db8a6193f06c2196cfd1880d07e153fa702e591/src/index.ts#L107)

> Given that the binding requires more functionality (to return more functionality), perhaps a binding can ship multiple things: a custom `handlMessage` function to encoding/decoding, and something like `extend()` to provide new methods on the connection (or create new properties on the connection). 

With this brief analysis, it looks like a single `handleMessage` option won't be enough to hook in a custom binding to your WebSocket connection. I may need to explore other means to provide a consistent, connection-wide API to augment the connection. 