### PR TITLE
fix: cannot read properties of undefined (reading 'url')

### DIFF
--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -18,7 +18,12 @@ export function createResponseListener(context: SetupWorkerInternalContext) {
     // Get the Request instance reference stored in the
     // request listener.
     const { requestId } = responseJson
-    const request = context.requests.get(requestId)!
+    const request = context.requests.get(requestId)
+
+    if (!request) {
+      return
+    }
+
     context.requests.delete(requestId)
 
     /**


### PR DESCRIPTION
fix error `cannot read properties of undefined (reading 'url')` (ref. https://github.com/mswjs/msw/issues/2193)
![image](https://github.com/user-attachments/assets/66078e94-98a5-47f0-b2fe-603447bac14f)
This bug is said to be fixed in the latest version, but it's still an issue for some users, including myself (I'm currently using version 2.3.5).

In the `createResponseListener` function, sometimes `const request = context.requests.get(requestId)` is possible `undefined`. so reference error in `request.url` in the code below.
```
if (!response.url) {
  Object.defineProperty(response, 'url', {
    value: request.url,
    enumerable: true,
    writable: false,
  })
}
```
The same issue does not occur when using the changed version with this code.