### PR TITLE
fix: import `graphql` lazily

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "webpack-http-server": "^0.5.0"
   },
   "peerDependencies": {
+    "graphql": ">=16.8.0",
     "typescript": ">= 4.7.x"
   },
   "peerDependenciesMeta": {

--- a/src/core/utils/internal/parseGraphQLRequest.ts
+++ b/src/core/utils/internal/parseGraphQLRequest.ts
@@ -3,7 +3,6 @@ import type {
   OperationDefinitionNode,
   OperationTypeNode,
 } from 'graphql'
-import { parse } from 'graphql'
 import type { GraphQLVariables } from '../../handlers/GraphQLHandler'
 import { toPublicUrl } from '../request/toPublicUrl'
 import { devUtils } from './devUtils'
@@ -40,7 +39,9 @@ export function parseDocumentNode(node: DocumentNode): ParsedGraphQLQuery {
   }
 }
 
-function parseQuery(query: string): ParsedGraphQLQuery | Error {
+async function parseQuery(query: string): Promise<ParsedGraphQLQuery | Error> {
+  const { parse } = await import('graphql')
+
   try {
     const ast = parse(query)
     return parseDocumentNode(ast)
@@ -181,7 +182,7 @@ export async function parseGraphQLRequest(
   }
 
   const { query, variables } = input
-  const parsedResult = parseQuery(query)
+  const parsedResult = await parseQuery(query)
 
   if (parsedResult instanceof Error) {
     const requestPublicUrl = toPublicUrl(request.url)

--- a/src/core/utils/internal/parseGraphQLRequest.ts
+++ b/src/core/utils/internal/parseGraphQLRequest.ts
@@ -40,7 +40,12 @@ export function parseDocumentNode(node: DocumentNode): ParsedGraphQLQuery {
 }
 
 async function parseQuery(query: string): Promise<ParsedGraphQLQuery | Error> {
-  const { parse } = await import('graphql')
+  const { parse } = await import('graphql').catch((error) => {
+    devUtils.error(
+      'Failed to parse a GraphQL query: cannot import the "graphql" module. Please make sure you install it if you wish to intercept GraphQL requests. See the original import error below.',
+    )
+    throw error
+  })
 
   try {
     const ast = parse(query)


### PR DESCRIPTION
- Fixes #2247 
- Fixes #2248 

## Changes

MSW depends on `graphql` only when using the `graphql` request handlers, and only to import its `parse()` method (other imports are type imports and are not present on runtime, neither can they affect it). 

- This change makes `graphql` a _dynamic import_ where it's needed. This way, even though MSW exports `{ graphql } from './graphql'` in the root, it will never result in `import X from 'graphql'` unless you `import { graphql } from 'msw'` on runtime. 

In a long term, we should drop http/graphql handlers from the root entry and keep them only in `msw/core/http` and `msw/core/graphql`. 

- Also adds a custom error message if importing `graphql` fails for any reason. This will remind the developer that they have to install `graphql` if they want to intercept GraphQL requests. 