### PR TITLE
fix: use typescript@4.8 as the minimal supported version

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
   },
   "peerDependencies": {
     "graphql": ">= 16.8.x",
-    "typescript": ">= 5.5.x"
+    "typescript": ">= 4.8.x"
   },
   "peerDependenciesMeta": {
     "graphql": {

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
   },
   "peerDependencies": {
     "graphql": ">= 16.8.x",
-    "typescript": ">= 4.7.x"
+    "typescript": ">= 5.5.x"
   },
   "peerDependenciesMeta": {
     "graphql": {


### PR DESCRIPTION
To fix the discrepancy between the dev dependency and the version installed by end users