### PR TITLE
fix: revert "graphql" as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@types/cookie": "^0.6.0",
     "@types/statuses": "^2.0.4",
     "chalk": "^4.1.2",
+    "graphql": "^16.8.1",
     "headers-polyfill": "^4.0.2",
     "is-node-process": "^1.2.0",
     "outvariant": "^1.4.2",
@@ -180,7 +181,6 @@
     "fs-extra": "^11.2.0",
     "fs-teardown": "^0.3.0",
     "glob": "^10.3.10",
-    "graphql": "^16.8.1",
     "jsdom": "^23.2.0",
     "json-bigint": "^1.0.0",
     "lint-staged": "^15.2.0",
@@ -200,13 +200,9 @@
     "webpack-http-server": "^0.5.0"
   },
   "peerDependencies": {
-    "graphql": ">= 16.8.x",
     "typescript": ">= 4.8.x"
   },
   "peerDependenciesMeta": {
-    "graphql": {
-      "optional": true
-    },
     "typescript": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   chalk:
     specifier: ^4.1.2
     version: 4.1.2
+  graphql:
+    specifier: ^16.8.1
+    version: 16.9.0
   headers-polyfill:
     specifier: ^4.0.2
     version: 4.0.3
@@ -142,9 +145,6 @@ devDependencies:
   glob:
     specifier: ^10.3.10
     version: 10.3.12
-  graphql:
-    specifier: ^16.8.1
-    version: 16.8.2
   jsdom:
     specifier: ^23.2.0
     version: 23.2.0
@@ -4850,10 +4850,10 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
-  /graphql@16.8.2:
-    resolution: {integrity: sha512-cvVIBILwuoSyD54U4cF/UXDh5yAobhNV/tPygI4lZhgOIJQE/WLWC4waBRb4I6bDVYb3OVx3lfHbaQOEoUD5sg==}
+  /graphql@16.9.0:
+    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: true
+    dev: false
 
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}


### PR DESCRIPTION
- Fixes #2264
- Fixes #2248
- Related to #2187 
- Closes #2265 

## Motivation

ESM imports of optional peer dependencies are virtually impossible. You have to opt-out from your bundler treating them as code splitting points because the dependency may not exist, and then as a result, _you_ become in charge of serving that dependency over HTTP + providing an `importmap` for the browser to understand where to look it up. 

This is an insane ask from a developer, and I'm not willing to make it. I was prematurely optimistic about the state of optional peer dependencies, causing the recent release to be a failure. Lessons learned. 

## Resolving the original issue

The original issue reported in #2185 states that the `graphql` dependency _has_ to be a peer dependency to prevent duplicate GraphQL versions installed in a single app (MSW installs v16.1, your app has v16.8, and that potentially causes issues). 