### PR TITLE
fix: remove cookies with `max-age=0` from cookie store

### DIFF
--- a/src/core/utils/cookieStore.ts
+++ b/src/core/utils/cookieStore.ts
@@ -75,6 +75,11 @@ class WebStorageCookieStore extends Store {
     callback: (error: Error | null) => void,
   ): void {
     try {
+      // Never set cookies with `maxAge` of `0`.
+      if (cookie.maxAge === 0) {
+        return
+      }
+
       const store = this.getStore()
       store.push(cookie)
       this.updateStore(store)
@@ -90,6 +95,21 @@ class WebStorageCookieStore extends Store {
     newCookie: CookieInstance,
     callback: (error: Error | null) => void,
   ): void {
+    /**
+     * If updating a cookie with `maxAge` of `0`, remove it from the store.
+     * Otherwise, two cookie entries will be created.
+     * @see https://github.com/mswjs/msw/issues/2272
+     */
+    if (newCookie.maxAge === 0) {
+      this.removeCookie(
+        newCookie.domain || '',
+        newCookie.path || '',
+        newCookie.key,
+        callback,
+      )
+      return
+    }
+
     this.putCookie(newCookie, callback)
   }
 

--- a/test/browser/rest-api/request/request-cookies.test.ts
+++ b/test/browser/rest-api/request/request-cookies.test.ts
@@ -203,7 +203,7 @@ test('respects cookie "Path" when exposing cookies', async ({
   })
 })
 
-test('deletes a cookie when received "max-age=0" in a mocked response', async ({
+test('deletes a cookie when sending "max-age=0" in a mocked response', async ({
   loadExample,
   fetch,
 }) => {


### PR DESCRIPTION
- Fixes #2272 

## Changes

- Cookies with `max-age=0` can never be set in the store.
- Updating an existing cookie to `max-age=0` (i.e. removing the cookie) now deletes that cookie instead of storing two entries of it (the root cause of the issue). 