### PR TITLE
fix(setupWorker): prevent the `mockServiceWorker.js` script to be picked up by v8 coverage (e.g. Vitest)

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -1,3 +1,4 @@
+/* v8 ignore start */
 /* eslint-disable */
 /* tslint:disable */
 
@@ -282,3 +283,4 @@ async function respondWithMock(response) {
 
   return mockedResponse
 }
+/* v8 ignore stop */


### PR DESCRIPTION
This ensures that projects setting up `msw` do not accidentally drop their coverage metrics for the auto-generated script.

This can of course be configured at consumer level but I figured it makes more sense to do so in the script itself like it is currently done for ESLint and TSLint.

References:
- https://vitest.dev/guide/coverage#ignoring-code
- https://github.com/istanbuljs/v8-to-istanbul?tab=readme-ov-file#ignoring-all-lines-until-told

Let me know what you think! :)