### PR TITLE
chore(upgrade): upgrade `path-to-regexp`

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "headers-polyfill": "^4.0.2",
     "is-node-process": "^1.2.0",
     "outvariant": "^1.4.2",
-    "path-to-regexp": "^6.3.0",
+    "path-to-regexp": "^8.1.0",
     "strict-event-emitter": "^0.5.1",
     "type-fest": "^4.9.0",
     "yargs": "^17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ dependencies:
     specifier: ^1.4.2
     version: 1.4.2
   path-to-regexp:
-    specifier: ^6.3.0
-    version: 6.3.0
+    specifier: ^8.1.0
+    version: 8.1.0
   strict-event-emitter:
     specifier: ^0.5.1
     version: 0.5.1
@@ -6620,14 +6620,9 @@ packages:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
     dev: true
 
-  /path-to-regexp@6.3.0:
-    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-    dev: false
-
   /path-to-regexp@8.1.0:
     resolution: {integrity: sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==}
     engines: {node: '>=16'}
-    dev: true
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}

--- a/src/core/handlers/GraphQLHandler.test.ts
+++ b/src/core/handlers/GraphQLHandler.test.ts
@@ -164,7 +164,7 @@ describe('parse', () => {
         match: {
           matches: true,
           params: {
-            '0': 'https://example.com/',
+            wildcard: ['https:', '', 'example.com', ''],
           },
         },
         operationType: 'query',
@@ -193,7 +193,7 @@ describe('parse', () => {
         match: {
           matches: true,
           params: {
-            '0': 'https://example.com/',
+            wildcard: ['https:', '', 'example.com', ''],
           },
         },
         operationType: 'query',
@@ -221,7 +221,7 @@ describe('parse', () => {
         match: {
           matches: true,
           params: {
-            '0': 'https://example.com/',
+            wildcard: ['https:', '', 'example.com', ''],
           },
         },
         operationType: 'query',
@@ -250,7 +250,7 @@ describe('parse', () => {
         match: {
           matches: true,
           params: {
-            '0': 'https://example.com/',
+            wildcard: ['https:', '', 'example.com', ''],
           },
         },
         operationType: 'query',
@@ -280,7 +280,7 @@ describe('parse', () => {
         match: {
           matches: true,
           params: {
-            '0': 'https://example.com/',
+            wildcard: ['https:', '', 'example.com', ''],
           },
         },
         operationType: 'mutation',
@@ -309,7 +309,7 @@ describe('parse', () => {
         match: {
           matches: true,
           params: {
-            '0': 'https://example.com/',
+            wildcard: ['https:', '', 'example.com', ''],
           },
         },
         operationType: 'mutation',
@@ -337,7 +337,7 @@ describe('parse', () => {
         match: {
           matches: true,
           params: {
-            '0': 'https://example.com/',
+            wildcard: ['https:', '', 'example.com', ''],
           },
         },
         operationType: 'mutation',
@@ -366,7 +366,7 @@ describe('parse', () => {
         match: {
           matches: true,
           params: {
-            '0': 'https://example.com/',
+            wildcard: ['https:', '', 'example.com', ''],
           },
         },
         operationType: 'mutation',
@@ -745,7 +745,7 @@ describe('run', () => {
       match: {
         matches: true,
         params: {
-          '0': 'https://example.com/',
+          wildcard: ['https:', '', 'example.com', ''],
         },
       },
       operationType: 'query',

--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -17,7 +17,7 @@ describe('matchRequestUrl', () => {
     const match = matchRequestUrl(new URL('https://test.mswjs.io'), '*')
     expect(match).toHaveProperty('matches', true)
     expect(match).toHaveProperty('params', {
-      '0': 'https://test.mswjs.io/',
+      wildcard: ['https:', '', 'test.mswjs.io', ''],
     })
   })
 
@@ -27,7 +27,7 @@ describe('matchRequestUrl', () => {
       /test\.mswjs\.io/,
     )
     expect(match).toHaveProperty('matches', true)
-    expect(match).toHaveProperty('params', {})
+    expect(match).toHaveProperty('params', { wildcard: ['', ''] })
   })
 
   test('returns path parameters when matched', () => {
@@ -101,25 +101,27 @@ describe('coercePath', () => {
   })
 
   test('replaces wildcard with an unnnamed capturing group', () => {
-    expect(coercePath('*')).toEqual('(.*)')
-    expect(coercePath('**')).toEqual('(.*)')
-    expect(coercePath('/us*')).toEqual('/us(.*)')
-    expect(coercePath('/user/*')).toEqual('/user/(.*)')
+    expect(coercePath('*')).toEqual('{*wildcard}')
+    expect(coercePath('**')).toEqual('{*wildcard}')
+    expect(coercePath('/us*')).toEqual('/us{*wildcard}')
+    expect(coercePath('/user/*')).toEqual('/user/{*wildcard}')
     expect(coercePath('https://example.com/user/*')).toEqual(
-      'https\\://example.com/user/(.*)',
+      'https\\://example.com/user/{*wildcard}',
     )
     expect(coercePath('https://example.com/us*')).toEqual(
-      'https\\://example.com/us(.*)',
+      'https\\://example.com/us{*wildcard}',
     )
   })
 
   test('preserves path parameter modifiers', () => {
     expect(coercePath(':name*')).toEqual(':name*')
     expect(coercePath('/foo/:name*')).toEqual('/foo/:name*')
-    expect(coercePath('/foo/**:name*')).toEqual('/foo/(.*):name*')
-    expect(coercePath('**/foo/*/:name*')).toEqual('(.*)/foo/(.*)/:name*')
+    expect(coercePath('/foo/**:name*')).toEqual('/foo/{*wildcard}:name*')
+    expect(coercePath('**/foo/*/:name*')).toEqual(
+      '{*wildcard}/foo/{*wildcard}/:name*',
+    )
     expect(coercePath('/foo/:first/bar/:second*/*')).toEqual(
-      '/foo/:first/bar/:second*/(.*)',
+      '/foo/:first/bar/:second*/{*wildcard}',
     )
   })
 })


### PR DESCRIPTION
Related: https://github.com/mswjs/msw/issues/2270

This PR upgrades `path-to-regexp` to latest version 8.

`path-to-regexp` v8 has breaking changes, see https://github.com/pillarjs/path-to-regexp/releases/tag/v8.0.0.

In this PR, I've attempted to make the change transparent to `msw` users.