### PR TITLE
fix(node): preserve headers instanceof when recording raw headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@bundled-es-modules/statuses": "^1.0.1",
     "@bundled-es-modules/tough-cookie": "^0.1.6",
     "@inquirer/confirm": "^3.0.0",
-    "@mswjs/interceptors": "^0.35.8",
+    "@mswjs/interceptors": "^0.36.5",
     "@open-draft/until": "^2.1.0",
     "@types/cookie": "^0.6.0",
     "@types/statuses": "^2.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^3.0.0
     version: 3.1.1
   '@mswjs/interceptors':
-    specifier: ^0.35.8
-    version: 0.35.8
+    specifier: ^0.36.5
+    version: 0.36.5
   '@open-draft/until':
     specifier: ^2.1.0
     version: 2.1.0
@@ -1835,8 +1835,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@mswjs/interceptors@0.35.8:
-    resolution: {integrity: sha512-PFfqpHplKa7KMdoQdj5td03uG05VK2Ng1dG0sP4pT9h0dGSX2v9txYt/AnrzPb/vAmfyBBC0NQV7VaBEX+efgQ==}
+  /@mswjs/interceptors@0.36.5:
+    resolution: {integrity: sha512-aQ8WF5zQwOdcxLsxSEk9Jd01GgGb80xxqCaiDDlewhtwqpSm8MOvUHslwPydVirasdW09++NxDNNftm1vLY8yA==}
     engines: {node: '>=18'}
     dependencies:
       '@open-draft/deferred-promise': 2.2.0


### PR DESCRIPTION
This updates `@msw/interceptors` to latest since it was "stuck" at `0.35.9` (being <1.0 pnpm resolves `^0.35.4` up to the next patch in the same minor.