### PR TITLE
Exclude SW file from deno-lint: require-await

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file
 /* eslint-disable */
 /* tslint:disable */
 


### PR DESCRIPTION
When the project is using deno lint as a linter, this mock sw file will fall to the deno-lint rule https://lint.deno.land/rules/require-await on lines 132 and 277