### PR TITLE
fix: enable provenance for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: macos-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/release.config.json
+++ b/release.config.json
@@ -2,7 +2,7 @@
   "profiles": [
     {
       "name": "latest",
-      "use": "pnpm publish --no-git-checks"
+      "use": "NPM_CONFIG_PROVENANCE=true pnpm publish --no-git-checks"
     }
   ]
 }


### PR DESCRIPTION
- [Package provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/)
- [Using `provenance` with pnpm](https://github.com/pnpm/pnpm/issues/6435)