### PR TITLE
chore: publish preview versions

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -1,5 +1,7 @@
 name: auto
+
 on: [push]
+
 jobs:
   cancel-previous-workflows:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -1,0 +1,19 @@
+name: locked-closed-issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: macos-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-inactive-days: '14'
+          issue-lock-reason: ''
+          process-only: 'issues'

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   preview:
     # Publish previews only for approved pull requests.
-    if: github.event.review.state == 'APPROVED'
+    # The reviewer must have push persmissions to trigger this job.
+    if: github.event.review.state == 'approved' && github.event.review.user.permissions.push == true
     runs-on: macos-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -40,4 +40,4 @@ jobs:
         run: pnpm test
 
       - name: Publish preview
-        run: pnpm dlx pkg-pr-new@0.0 publish --compact --pnpm
+        run: pnpm dlx pkg-pr-new@0.0 publish --compact --pnpm --comment=update

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,43 @@
+name: release
+
+on:
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+
+jobs:
+  preview:
+    # Publish previews only for approved pull requests.
+    if: github.event.review.state == 'APPROVED'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.6
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Tests
+        run: pnpm test
+
+      - name: Publish preview
+        run: pnpm dlx pkg-pr-new@0.0 publish --compact --pnpm

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -6,10 +6,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  check:
+    # Trigger the permissions check whenever someone approves a pull request.
+    # They must have the write permissions to the repo in order to
+    # trigger preview package publishing.
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    outputs:
+      has-permissions: ${{ steps.checkPermissions.outputs.require-result }}
+    steps:
+      - name: Check permissions
+        id: checkPermissions
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: 'write'
+
   preview:
-    # Publish previews only for approved pull requests.
-    # The reviewer must have push persmissions to trigger this job.
-    if: github.event.review.state == 'approved' && github.event.review.user.permissions.push == true
+    # The approving user must pass the permissions check
+    # to trigger the preview publish.
+    needs: check
+    if: needs.check.outputs.has-permissions == 'true'
     runs-on: macos-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,20 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_ADMIN_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           always-auth: true
           registry-url: https://registry.npmjs.org
 
-      - uses: pnpm/action-setup@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 8.15.6
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
-      - name: Set up PNPM
+      - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 8.15.6

--- a/.github/workflows/typescript-nightly.yml
+++ b/.github/workflows/typescript-nightly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -37,10 +37,10 @@ jobs:
     if: ${{ needs.compare.outputs.latest_version != needs.compare.outputs.rc_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/decisions/releases.md
+++ b/decisions/releases.md
@@ -4,9 +4,13 @@ MSW uses the [Release](https://github.com/ossjs/release) library to automate its
 
 ## Release schedule
 
-The next version of the library releases automatically **every 3 days**.
+The next version of **the library releases automatically every day**.
 
 We do our best to choose the optimal release window to accumulate multiple changes under a single release. We do deviate from the release schedule in emergency cases, like when a critical issue has been fixed and needs an immediate release.
 
 > [!IMPORTANT]
 > Please do not ping the library maintainers to release a new version of MSW. Be patient and wait for the automated release to happen. Subscribe to any issue or pull request you are interested in, and you will be notified whenever it gets released.
+
+## Preview releases
+
+This repository is configured to **release work-in-progress pull requests** using [okg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new). Once the pull request in question is approved, it will automatically be published to a temporary registry. Follow the instructions in the automated comment to install the work-in-progress version of the package.


### PR DESCRIPTION
- Adds a new workflow to publish MSW from approved pull requests using https://github.com/stackblitz-labs/pkg.pr.new.
- Adds a new workflow to automatically lock closed issues.
- Updates actions versions in the workflows.