### PR TITLE
fix(types): support optional path parameters

### DIFF
--- a/src/core/utils/matching/matchRequestUrl.ts
+++ b/src/core/utils/matching/matchRequestUrl.ts
@@ -4,7 +4,7 @@ import { normalizePath } from './normalizePath'
 
 export type Path = string | RegExp
 export type PathParams<KeyType extends keyof any = string> = {
-  [ParamName in KeyType]: string | ReadonlyArray<string>
+  [ParamName in KeyType]?: string | ReadonlyArray<string>
 }
 
 export interface Match {

--- a/test/typings/http.test-d.ts
+++ b/test/typings/http.test-d.ts
@@ -7,6 +7,28 @@ it('supports a single path parameter', () => {
   })
 })
 
+it('supports a repeating path parameter', () => {
+  http.get<{ id?: string }>('/user/id*', ({ params }) => {
+    expectTypeOf(params).toEqualTypeOf<{ id?: string }>()
+  })
+})
+
+it('supports an optional path parameter', () => {
+  http.get<{ id?: string }>('/user/:id?', ({ params }) => {
+    expectTypeOf(params).toEqualTypeOf<{ id?: string }>()
+  })
+})
+
+it('supports optional repeating path parameter', () => {
+  /**
+   * @note This is the newest "path-to-regexp" syntax.
+   * MSW doesn't support this quite yet.
+   */
+  http.get<{ path?: string[] }>('/user{/*path}', ({ params }) => {
+    expectTypeOf(params).toEqualTypeOf<{ path?: string[] }>()
+  })
+})
+
 it('supports multiple path parameters', () => {
   type Params = { a: string; b: string[] }
   http.get<Params>('/user/:a/:b/:b', ({ params }) => {


### PR DESCRIPTION
## Changes

- MSW now allows to describe optional path parameters (previously a type error—all parameters were expected to be non-nullable):

```ts
// Optional path parameter.
http.get<{ id?: string }>('/user/:id?', resolver)
```

> [!WARNING]
> Note that MSW uses `path-to-regexp@6.3.0`, which doesn't support all the modern PTR syntax. 