### PR TITLE
fix(setupServer): reapply interception after calling `server.listen()` after `server.close()`

### DIFF
--- a/src/node/SetupServerCommonApi.ts
+++ b/src/node/SetupServerCommonApi.ts
@@ -48,8 +48,6 @@ export class SetupServerCommonApi
     })
 
     this.resolvedOptions = {} as RequiredDeep<SharedOptions>
-
-    this.init()
   }
 
   /**
@@ -141,7 +139,10 @@ export class SetupServerCommonApi
     ) as RequiredDeep<SharedOptions>
 
     // Apply the interceptor when starting the server.
+    // Attach the event listeners to the interceptor here
+    // so they get re-attached whenever `.listen()` is called.
     this.interceptor.apply()
+    this.init()
     this.subscriptions.push(() => this.interceptor.dispose())
 
     // Apply the WebSocket interception.

--- a/test/node/regressions/2370-listen-after-close.test.ts
+++ b/test/node/regressions/2370-listen-after-close.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @see https://github.com/mswjs/msw/issues/2370
+ */
+// @vitest-environment node
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { HttpServer } from '@open-draft/test-server/http'
+
+const server = setupServer()
+
+const httpServer = new HttpServer((app) => {
+  app.get('/resource', (_req, res) => {
+    res.send('original')
+  })
+})
+
+beforeAll(async () => {
+  server.listen()
+  await httpServer.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(async () => {
+  server.close()
+  await httpServer.close()
+})
+
+it('intercepts a request once `server.listen()` is called after `server.close()`', async () => {
+  const requestUrl = httpServer.http.url('/resource')
+
+  server.use(
+    http.get(requestUrl, () => {
+      return HttpResponse.text('mocked')
+    }),
+  )
+
+  // Must respond with a mocked response while MSW is active.
+  {
+    const response = await fetch(requestUrl)
+    await expect(response.text()).resolves.toBe('mocked')
+  }
+
+  server.close()
+
+  // Must respond with the original response once MSW is closed.
+  {
+    const response = await fetch(requestUrl)
+    await expect(response.text()).resolves.toBe('original')
+  }
+
+  server.listen()
+
+  // Must respond with the mocked response once MSW is active again.
+  {
+    const response = await fetch(requestUrl)
+    await expect(response.text()).resolves.toBe('mocked')
+  }
+})


### PR DESCRIPTION
- Fixes #2370 

## Changes

The `request` event listener of the interceptor is not called in the `.listen()` method (previously, `SetupServerCommonApi` constructor). This ensures that close -> listen scenario re-attaches the interceptor listeners to keep the interception working. 