### PR TITLE
feat: add `baseUrl` option in `getResponse`

### DIFF
--- a/src/core/getResponse.test.ts
+++ b/src/core/getResponse.test.ts
@@ -61,3 +61,39 @@ it('returns the response from the first matching handler if multiple match', asy
   expect(response?.headers.get('Content-Type')).toBe('application/json')
   expect(await response?.json()).toEqual({ name: 'John' })
 })
+
+it('returns the response from a handler that matchs path when set baseUrl', async () => {
+  const response = await getResponse(
+    [http.get('/user', () => Response.json({ name: 'John' }))],
+    new Request('http://localhost/user'),
+    'http://localhost',
+  )
+  expect(response?.status).toBe(200)
+  expect(response?.headers.get('Content-Type')).toBe('application/json')
+  expect(await response?.json()).toEqual({ name: 'John' })
+})
+
+it('returns undefined to not match the host of the request although set baseUrl', async () => {
+  const response = await getResponse(
+    [http.get('/user', () => Response.json({ name: 'John' }))],
+    new Request('http://localhost:8080/user'),
+    'http://localhost',
+  )
+  expect(response).toBeUndefined()
+})
+
+it('returns the response from the second handler although set baseUrl', async () => {
+  const response = await getResponse(
+    [
+      http.get('/user', () => Response.json({ name: 'John' })),
+      http.get('http://localhost:8080/user', () =>
+        Response.json({ name: 'Kate' }),
+      ),
+    ],
+    new Request('http://localhost:8080/user'),
+    'http://localhost',
+  )
+  expect(response?.status).toBe(200)
+  expect(response?.headers.get('Content-Type')).toBe('application/json')
+  expect(await response?.json()).toEqual({ name: 'Kate' })
+})

--- a/src/core/getResponse.ts
+++ b/src/core/getResponse.ts
@@ -7,16 +7,19 @@ import { executeHandlers } from './utils/executeHandlers'
  * in the array of request handlers.
  * @param handlers The array of request handlers.
  * @param request The `Request` instance.
+ * @param baseUrl The baseUrl for each handlers.
  * @returns {Response} A mocked response, if any.
  */
 export const getResponse = async (
   handlers: Array<RequestHandler>,
   request: Request,
+  baseUrl?: string,
 ): Promise<Response | undefined> => {
   const result = await executeHandlers({
     request,
     requestId: createRequestId(),
     handlers,
+    resolutionContext: baseUrl ? { baseUrl } : undefined,
   })
 
   return result?.response


### PR DESCRIPTION
I appreciate the availability of this library. Thanks to all the maintainers.

I have been using the `getResponse` function lately. It is a very useful API, but I thought it would be better if I could also use handlers created with relative paths.

So I would like to add a `baseUrl` argument to `getResponses`. I think this can be adapted without causing side-effects, since it just allows existing implementations to be used.

Usage:

```typescript
const response = await getResponse(
  [http.get('/user', () => Response.json({ name: 'John' }))],
  new Request('http://localhost/user'),
  'http://localhost',
)
```

If this is not a problem, I would love to have it merged. Please review it.

I am not good at English and I don't have much experience in Contribute to OSS, so I am sorry if I am rude.
