### PR TITLE
feat: worker can clear current handlers

### DIFF
--- a/src/core/SetupApi.ts
+++ b/src/core/SetupApi.ts
@@ -13,6 +13,7 @@ export abstract class HandlersController {
     runtimeHandlers: Array<RequestHandler | WebSocketHandler>,
   ): void
   abstract reset(nextHandles: Array<RequestHandler | WebSocketHandler>): void
+  abstract clear(): void
   abstract currentHandlers(): Array<RequestHandler | WebSocketHandler>
 }
 
@@ -34,6 +35,10 @@ export class InMemoryHandlersController implements HandlersController {
   public reset(nextHandlers: Array<RequestHandler | WebSocketHandler>): void {
     this.handlers =
       nextHandlers.length > 0 ? [...nextHandlers] : [...this.initialHandlers]
+  }
+
+  public clear(): void {
+    this.handlers = []
   }
 
   public currentHandlers(): Array<RequestHandler | WebSocketHandler> {
@@ -105,6 +110,10 @@ export abstract class SetupApi<EventsMap extends EventMap> extends Disposable {
     ...nextHandlers: Array<RequestHandler | WebSocketHandler>
   ): void {
     this.handlersController.reset(nextHandlers)
+  }
+
+  public clearHandlers(): void {
+    this.handlersController.clear()
   }
 
   public listHandlers(): ReadonlyArray<RequestHandler | WebSocketHandler> {

--- a/src/node/SetupServerApi.ts
+++ b/src/node/SetupServerApi.ts
@@ -42,6 +42,10 @@ class AsyncHandlersController implements HandlersController {
       nextHandlers.length > 0 ? nextHandlers : context.initialHandlers
   }
 
+  public clear() {
+    this.context.handlers = []
+  }
+
   public currentHandlers(): Array<RequestHandler | WebSocketHandler> {
     const { initialHandlers, handlers } = this.context
     return handlers.concat(initialHandlers)


### PR DESCRIPTION
# summary
- We can empty the handler. There is no need to stop the worker.

# related issue
#2410 

# description
- I add `.clearHandlers()` method. 

# additional context
- Some explanation is needed. This seems to be different logic from the browser.
```typescript
  public reset(nextHandlers: Array<RequestHandler | WebSocketHandler>) {
    const context = this.context
    context.handlers = []
    context.initialHandlers =
      nextHandlers.length > 0 ? nextHandlers : context.initialHandlers
  }
```
-This directly manipulates initialHandler. Isn't it correct to manipulate the handler? First of all, the server was written with the same logic as the browser.
- Does the server need separate logic for handler and initialHandler? I will listen to your explanation and fix `clear()` if necessary.
- I have never used msw other than in a browser environment. 😢 