### PR TITLE
fix(HttpResponse): support non-configurable status codes

### DIFF
--- a/src/core/HttpResponse.test.ts
+++ b/src/core/HttpResponse.test.ts
@@ -13,6 +13,10 @@ it('creates a plain response', async () => {
   expect(Object.fromEntries(response.headers.entries())).toEqual({})
 })
 
+it('supports non-configurable status codes', () => {
+  expect(new HttpResponse(null, { status: 101 })).toHaveProperty('status', 101)
+})
+
 describe('HttpResponse.text()', () => {
   it('creates a text response', async () => {
     const response = HttpResponse.text('hello world', { status: 201 })

--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -1,3 +1,4 @@
+import { FetchResponse } from '@mswjs/interceptors'
 import type { DefaultBodyType, JsonBodyType } from './handlers/RequestHandler'
 import type { NoInfer } from './typeUtils'
 import {
@@ -35,7 +36,7 @@ export interface StrictResponse<BodyType extends DefaultBodyType>
  *
  * @see {@link https://mswjs.io/docs/api/http-response `HttpResponse` API reference}
  */
-export class HttpResponse extends Response {
+export class HttpResponse extends FetchResponse {
   constructor(body?: BodyInit | null, init?: HttpResponseInit) {
     const responseInit = normalizeResponseInit(init)
     super(body, responseInit)
@@ -167,7 +168,7 @@ export class HttpResponse extends Response {
       responseInit.headers.set('Content-Length', body.byteLength.toString())
     }
 
-    return new HttpResponse(body, responseInit)
+    return new HttpResponse(body as ArrayBuffer, responseInit)
   }
 
   /**


### PR DESCRIPTION
- Fixes #2433 

With this fix, you will be able to do this:

```ts
new HttpResponse(null, { status: 101 })
```

> No direct changes necessary in MSW. We should rely on `FetchResponse` from Interceptors, to begin with. It bakes in a bunch of useful, uncommon behaviors that are expected in the context of mocking. 