### PR TITLE
feat(experimental): add `defineStore` API

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@mswjs/interceptors": "^0.37.0",
     "@open-draft/deferred-promise": "^2.2.0",
     "@open-draft/until": "^2.1.0",
+    "@standard-schema/spec": "^1.0.0",
     "@types/cookie": "^0.6.0",
     "@types/statuses": "^2.0.4",
     "graphql": "^16.8.1",
@@ -206,7 +207,8 @@
     "vitest": "^2.1.8",
     "vitest-environment-miniflare": "^2.14.4",
     "webpack": "^5.95.0",
-    "webpack-http-server": "^0.5.0"
+    "webpack-http-server": "^0.5.0",
+    "zod": "^3.24.2"
   },
   "peerDependencies": {
     "typescript": ">= 4.8.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@open-draft/until':
         specifier: ^2.1.0
         version: 2.1.0
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -204,6 +207,9 @@ importers:
       webpack-http-server:
         specifier: ^0.5.0
         version: 0.5.0(@swc/core@1.9.3)(esbuild@0.24.0)
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
 
 packages:
 
@@ -1154,6 +1160,9 @@ packages:
 
   '@socket.io/component-emitter@3.1.0':
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@swc/core-darwin-arm64@1.9.3':
     resolution: {integrity: sha512-hGfl/KTic/QY4tB9DkTbNuxy5cV4IeejpPD4zo+Lzt4iLlDWIeANL4Fkg67FiVceNJboqg48CUX+APhDHO5G1w==}
@@ -5139,6 +5148,9 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
+  zod@3.24.2:
+    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
 snapshots:
 
   '@75lb/deep-merge@1.1.1':
@@ -6055,6 +6067,8 @@ snapshots:
     optional: true
 
   '@socket.io/component-emitter@3.1.0': {}
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@swc/core-darwin-arm64@1.9.3':
     optional: true
@@ -10452,3 +10466,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  zod@3.24.2: {}

--- a/src/core/AsyncCollection.ts
+++ b/src/core/AsyncCollection.ts
@@ -1,0 +1,152 @@
+import { createRequestId } from '@mswjs/interceptors'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+
+export type TransactionCallback<T> = (
+  store: Record<string, T>,
+) => void | Promise<void>
+
+const kTransactionId = Symbol('kTransactionId')
+
+/**
+ * @todo @fixme Unref the broadcast channel because it prevents
+ * Node.js process from exiting normally.
+ */
+
+export class AsyncCollection<T> {
+  private store: Record<string, T>
+  private channel: BroadcastChannel
+  private queue: Set<DeferredPromise<void>>
+
+  constructor(name: string) {
+    this.channel = new BroadcastChannel(name)
+    this.store = {}
+    this.queue = new Set()
+    this.subscribeToQueue()
+    this.hydrate()
+  }
+
+  public forEach(
+    callback: (value: T, key: string, done: () => void) => void,
+  ): void {
+    const controller = new AbortController()
+
+    for (const key in this.store) {
+      if (controller.signal.aborted) {
+        break
+      }
+      callback(this.store[key], key, controller.abort.bind(controller))
+    }
+  }
+
+  public async clear(): Promise<void> {
+    await this.transaction(() => {
+      this.store = {}
+    })
+  }
+
+  public async all(): Promise<Array<T>> {
+    return Object.values(this.store)
+  }
+
+  public async get(key: string): Promise<T | undefined> {
+    await this.exhaustQueue()
+    return this.store[key]
+  }
+
+  public async put(key: string, value: T): Promise<void> {
+    await this.transaction((store) => {
+      store[key] = value
+    })
+  }
+
+  public async delete(key: string): Promise<void> {
+    await this.transaction((store) => {
+      delete store[key]
+    })
+  }
+
+  public async deleteMany(keys: Array<string>): Promise<void> {
+    await this.transaction((store) => {
+      for (const key of keys) {
+        delete store[key]
+      }
+    })
+  }
+
+  public async transaction(callback: TransactionCallback<T>): Promise<void> {
+    const transactionId = createRequestId()
+
+    // Wait for any pending extraneous transactions.
+    await this.exhaustQueue()
+
+    // Lock other collections until this transaction is done.
+    this.lock(transactionId)
+
+    // Execute the transaction.
+    await callback(this.store)
+
+    // Persist the next store.
+    this.persist()
+
+    // Notify other collections to pull the store.
+    this.release(transactionId)
+  }
+
+  private async exhaustQueue(): Promise<void> {
+    await Promise.allSettled(this.queue)
+  }
+
+  private lock(transactionId: string) {
+    this.channel.postMessage({
+      type: 'collection:lock',
+      transactionId,
+    })
+  }
+
+  private release(transactionId: string) {
+    this.channel.postMessage({
+      type: 'collection:release',
+      transactionId,
+    })
+  }
+
+  private subscribeToQueue(): void {
+    this.channel.addEventListener('message', (event) => {
+      switch (event.data?.type) {
+        case 'collection:lock': {
+          const lockPromise = new DeferredPromise<void>()
+          Reflect.set(lockPromise, kTransactionId, event.data.transactionId)
+          lockPromise.then(() => this.hydrate())
+          this.queue.add(lockPromise)
+          break
+        }
+
+        case 'collection:release': {
+          for (const promise of this.queue) {
+            if (
+              Reflect.get(promise, kTransactionId) === event.data.transactionId
+            ) {
+              promise.resolve()
+              this.queue.delete(promise)
+              break
+            }
+          }
+          break
+        }
+      }
+    })
+  }
+
+  private getPersistKey(): string {
+    return `msw:collection:${this.channel.name}`
+  }
+
+  private persist(): void {
+    localStorage.setItem(this.getPersistKey(), JSON.stringify(this.store))
+  }
+
+  private hydrate(): void {
+    const persistedStore = localStorage.getItem(this.getPersistKey())
+    this.store = persistedStore ? JSON.parse(persistedStore) : {}
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -63,6 +63,8 @@ export * from './delay'
 export { bypass } from './bypass'
 export { passthrough } from './passthrough'
 
+export * from './store/store'
+
 // Validate environmental globals before executing any code.
 // This ensures that the library gives user-friendly errors
 // when ran in the environments that require additional polyfills

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -22,9 +22,9 @@ class Store<Collections extends CollectionsDefinition> {
    * Opens a new collection.
    * If the collection already exists, returns its reference.
    */
-  public open<Name extends keyof Collections>(
+  public async open<Name extends keyof Collections>(
     name: Name,
-  ): Collection<StandardSchemaV1.InferInput<Collections[Name]>> {
+  ): Promise<Collection<StandardSchemaV1.InferInput<Collections[Name]>>> {
     const collectionDefinition = this.collectionDefinitions[name]
 
     invariant(

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -75,6 +75,9 @@ class Collection<RecordType> {
     this.collection = new AsyncCollection(this.name)
   }
 
+  /**
+   * Returns all records in this collection.
+   */
   public async all(): Promise<Array<RecordType>> {
     return this.collection.all()
   }

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -208,9 +208,9 @@ Validation error:`,
   }
 
   /**
-   * Clears the entire collection, deleting all its records.
+   * Deletes all records in this collection.
    */
-  public async clear(): Promise<void> {
+  public async deleteAll(): Promise<void> {
     this.records.clear()
   }
 }

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -1,0 +1,113 @@
+import { invariant } from 'outvariant'
+import { StandardSchemaV1 } from '@standard-schema/spec'
+import { InternalError } from '../utils/internal/devUtils'
+
+type CollectionsDefinition = {
+  [collectionName: string]: StandardSchemaV1
+}
+
+class Store<Collections extends CollectionsDefinition> {
+  private collectionDefinitions: Collections
+  private collectionNames: Array<keyof Collections>
+  private collections: Map<keyof Collections, Collection<any>>
+
+  constructor(options: { collections: Collections }) {
+    this.collectionDefinitions = options.collections
+    this.collectionNames = Object.keys(options.collections)
+    this.collections = new Map()
+  }
+
+  /**
+   * Opens a new collection.
+   * If the collection already exists, returns its reference.
+   */
+  public open<Name extends keyof Collections>(
+    name: Name,
+  ): Collection<StandardSchemaV1.InferInput<Collections[Name]>> {
+    const collectionDefinition = this.collectionDefinitions[name]
+
+    invariant(
+      collectionDefinition,
+      'Failed to open a store: expected a known collection (%s) but got "%s"',
+      this.collectionNames.join(', '),
+      name,
+    )
+
+    const existingCollection = this.collections.get(name)
+
+    if (existingCollection) {
+      return existingCollection
+    }
+
+    const newCollection = new Collection<any>({
+      name: name as any,
+      schema: collectionDefinition,
+    })
+    this.collections.set(name, newCollection)
+
+    return newCollection
+  }
+}
+
+class Collection<V> {
+  private name: string
+  private records: Map<string, V>
+  private schema: StandardSchemaV1<V>
+
+  constructor(args: { name: string; schema: StandardSchemaV1<V> }) {
+    this.name = args.name
+    this.schema = args.schema
+    this.records = new Map()
+  }
+
+  public get(key: string): V | undefined {
+    return this.records.get(key)
+  }
+
+  /**
+   * Adds a new record to this collection.
+   */
+  public async put(key: string, record: V): Promise<V> {
+    const validationResult = await this.schema['~standard'].validate(record)
+
+    invariant.as(
+      InternalError,
+      validationResult.issues == null,
+      `\
+Failed to put record with key "%s" to the collection "%s": provided input does not match the schema.
+
+Input: %o
+
+Validation error:`,
+      key,
+      this.name,
+      record,
+      JSON.stringify(validationResult.issues, null, 2),
+    )
+
+    this.records.set(key.toString(), validationResult.value)
+    return validationResult.value
+  }
+
+  /**
+   * Deletes a record with the given key from this collection.
+   */
+  public delete(key: string): void {
+    this.records.delete(key)
+  }
+
+  /**
+   * Clears the entire collection, deleting all its records.
+   */
+  public clear(): void {
+    this.records.clear()
+  }
+}
+
+export function defineStore<C extends CollectionsDefinition>(options: {
+  collections: C
+}) {
+  return new Store({
+    collections: options.collections,
+  })
+}

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -210,7 +210,7 @@ Validation error:`,
   /**
    * Clears the entire collection, deleting all its records.
    */
-  public clear(): void {
+  public async clear(): Promise<void> {
     this.records.clear()
   }
 }

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -50,6 +50,13 @@ class Store<Collections extends CollectionsDefinition> {
   }
 
   public async clear(): Promise<void> {
+    const pendingCollections: Array<Promise<void>> = []
+
+    for (const [, collection] of this.collections) {
+      pendingCollections.push(collection.deleteAll())
+    }
+
+    await Promise.allSettled(pendingCollections)
     this.collections.clear()
   }
 }

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -60,12 +60,16 @@ class Collection<V> {
     this.records = new Map()
   }
 
+  /**
+   * Returns the record with the given key.
+   */
   public get(key: string): V | undefined {
     return this.records.get(key)
   }
 
   /**
    * Adds a new record to this collection.
+   * If the record by this key already exists, overrides the record.
    */
   public async put(key: string, record: V): Promise<V> {
     const validationResult = await this.schema['~standard'].validate(record)
@@ -87,6 +91,34 @@ Validation error:`,
 
     this.records.set(key.toString(), validationResult.value)
     return validationResult.value
+  }
+
+  /**
+   * Returns the first record matching the given predicate.
+   */
+  public findFirst(
+    predicate: (value: V, key: string) => boolean,
+  ): V | undefined {
+    for (const [key, value] of this.records) {
+      if (predicate(value, key)) {
+        return value
+      }
+    }
+  }
+
+  /**
+   * Returns all records matching the given predicate.
+   */
+  public findMany(predicate: (value: V, key: string) => boolean): Array<V> {
+    const results: Array<V> = []
+
+    for (const [key, value] of this.records) {
+      if (predicate(value, key)) {
+        results.push(value)
+      }
+    }
+
+    return results
   }
 
   /**

--- a/test/browser/msw-api/store/store-persist.test.ts
+++ b/test/browser/msw-api/store/store-persist.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '../../playwright.extend'
+
+test('persists store records between page reloads', async ({
+  loadExample,
+  fetch,
+  page,
+}) => {
+  await loadExample(require.resolve('./store.mocks.ts'))
+
+  // Create a new post.
+  const createdRecord = await fetch('/posts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: 'abc-123',
+      title: 'Hello world',
+    }),
+  }).then((response) => response.json())
+
+  expect(createdRecord).toEqual({
+    id: 'abc-123',
+    title: 'Hello world',
+  })
+
+  await page.reload()
+
+  // Must persist the created post between page reloads.
+  const allPosts = await fetch('/posts').then((response) => response.json())
+  expect(allPosts).toEqual([
+    {
+      id: 'abc-123',
+      title: 'Hello world',
+    },
+  ])
+})

--- a/test/browser/msw-api/store/store.mocks.ts
+++ b/test/browser/msw-api/store/store.mocks.ts
@@ -1,0 +1,70 @@
+import { http, defineStore, HttpResponse } from 'msw'
+import { setupWorker } from 'msw/browser'
+import { z } from 'zod'
+
+const store = defineStore({
+  collections: {
+    posts: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+})
+
+const worker = setupWorker(
+  http.get('/posts', async () => {
+    const posts = await store.open('posts')
+    return HttpResponse.json(await posts.all())
+  }),
+  http.get<{ id: string }>('/posts/:id', async ({ params }) => {
+    const posts = await store.open('posts')
+    const post = await posts.get(params.id)
+
+    if (!post) {
+      return new HttpResponse(null, { status: 404 })
+    }
+
+    return HttpResponse.json(post)
+  }),
+  http.post<never, { id: string; title: string }>(
+    '/posts',
+    async ({ request }) => {
+      const data = await request.json()
+      const posts = await store.open('posts')
+      await posts.put(data.id, data)
+      return HttpResponse.json(data, { status: 201 })
+    },
+  ),
+  http.put<{ id: string }, { id: string; title: string }>(
+    '/posts/:id',
+    async ({ request, params }) => {
+      const data = await request.json()
+      const posts = await store.open('posts')
+      const updatedPost = await posts.update(
+        (post) => {
+          return post.id === params.id
+        },
+        (post) => {
+          return {
+            ...post,
+            ...data,
+          }
+        },
+      )
+
+      return HttpResponse.json(updatedPost)
+    },
+  ),
+  http.delete<{ id: string }>('/posts/:id', async ({ params }) => {
+    const posts = await store.open('posts')
+    const deletedPost = await posts.delete(params.id)
+
+    if (!deletedPost) {
+      return new HttpResponse(null, { status: 404 })
+    }
+
+    return HttpResponse.json(deletedPost)
+  }),
+)
+
+worker.start()

--- a/test/node/msw-api/store/store.test.ts
+++ b/test/node/msw-api/store/store.test.ts
@@ -1,0 +1,81 @@
+import { http, HttpResponse, defineStore } from 'msw'
+import { setupServer } from 'msw/node'
+import { z } from 'zod'
+
+const store = defineStore({
+  collections: {
+    posts: z.object({
+      id: z.string(),
+      title: z.string(),
+    }),
+  },
+})
+
+const server = setupServer({
+  context: {
+    store,
+  },
+})
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface Post {
+  id: string
+  title: string
+}
+
+test('persists data between handlers', async () => {
+  server.use(
+    http.post<never, Post, Post>(
+      'https://api.example.com/posts',
+      async ({ request }) => {
+        const data = await request.json()
+
+        const posts = store.open('posts')
+        await posts.put(data.id, data)
+
+        return HttpResponse.json(data, { status: 201 })
+      },
+    ),
+    http.get<{ id: string }, never, Post>(
+      'https://api.example.com/posts/:id',
+      async ({ params }) => {
+        const posts = store.open('posts')
+        const post = posts.get(params.id)
+
+        if (!post) {
+          return new HttpResponse(null, { status: 404 })
+        }
+
+        return HttpResponse.json(post)
+      },
+    ),
+  )
+
+  // Create a new post.
+  await fetch('https://api.example.com/posts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: 'abc-123', title: 'Hello world' }),
+  })
+
+  // Retrieve the created post.
+  const post = await fetch('https://api.example.com/posts/abc-123').then(
+    (response) => response.json(),
+  )
+  expect(post).toEqual({ id: 'abc-123', title: 'Hello world' })
+
+  await expect(
+    fetch('https://api.example.com/posts/123'),
+  ).resolves.toMatchObject({ status: 404 })
+})

--- a/test/node/msw-api/store/store.test.ts
+++ b/test/node/msw-api/store/store.test.ts
@@ -27,7 +27,7 @@ const server = setupServer(
     'https://api.example.com/posts/:id',
     async ({ params }) => {
       const posts = store.open('posts')
-      const post = posts.get(params.id)
+      const post = await posts.get(params.id)
 
       if (!post) {
         return new HttpResponse(null, { status: 404 })
@@ -87,7 +87,7 @@ test('updates an in-memory record', async () => {
         const posts = store.open('posts')
         const data = await request.json()
 
-        const nextPost = posts.update(
+        const nextPost = await posts.update(
           (post) => {
             return post.id === params.id
           },

--- a/test/node/msw-api/store/store.test.ts
+++ b/test/node/msw-api/store/store.test.ts
@@ -11,14 +11,40 @@ const store = defineStore({
   },
 })
 
-const server = setupServer({
-  context: {
-    store,
-  },
-})
+const server = setupServer(
+  http.post<never, Post, Post>(
+    'https://api.example.com/posts',
+    async ({ request }) => {
+      const data = await request.json()
+
+      const posts = store.open('posts')
+      await posts.put(data.id, data)
+
+      return HttpResponse.json(data, { status: 201 })
+    },
+  ),
+  http.get<{ id: string }, never, Post>(
+    'https://api.example.com/posts/:id',
+    async ({ params }) => {
+      const posts = store.open('posts')
+      const post = posts.get(params.id)
+
+      if (!post) {
+        return new HttpResponse(null, { status: 404 })
+      }
+
+      return HttpResponse.json(post)
+    },
+  ),
+)
 
 beforeAll(() => {
-  server.listen()
+  server.listen({
+    /** @todo */
+    // context: {
+    // 	store
+    // }
+  })
 })
 
 afterEach(() => {
@@ -35,33 +61,6 @@ interface Post {
 }
 
 test('persists data between handlers', async () => {
-  server.use(
-    http.post<never, Post, Post>(
-      'https://api.example.com/posts',
-      async ({ request }) => {
-        const data = await request.json()
-
-        const posts = store.open('posts')
-        await posts.put(data.id, data)
-
-        return HttpResponse.json(data, { status: 201 })
-      },
-    ),
-    http.get<{ id: string }, never, Post>(
-      'https://api.example.com/posts/:id',
-      async ({ params }) => {
-        const posts = store.open('posts')
-        const post = posts.get(params.id)
-
-        if (!post) {
-          return new HttpResponse(null, { status: 404 })
-        }
-
-        return HttpResponse.json(post)
-      },
-    ),
-  )
-
   // Create a new post.
   await fetch('https://api.example.com/posts', {
     method: 'POST',
@@ -78,4 +77,57 @@ test('persists data between handlers', async () => {
   await expect(
     fetch('https://api.example.com/posts/123'),
   ).resolves.toMatchObject({ status: 404 })
+})
+
+test('updates an in-memory record', async () => {
+  server.use(
+    http.put<{ id: string }, Partial<Post>, Post>(
+      'https://api.example.com/posts/:id',
+      async ({ request, params }) => {
+        const posts = store.open('posts')
+        const data = await request.json()
+
+        const nextPost = posts.update(
+          (post) => {
+            return post.id === params.id
+          },
+          (post) => {
+            return {
+              ...post,
+              ...data,
+            }
+          },
+        )
+
+        return HttpResponse.json(nextPost)
+      },
+    ),
+  )
+
+  await fetch('https://api.example.com/posts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: 'abc-123', title: 'Hello world' }),
+  })
+
+  const updatedPost = await fetch('https://api.example.com/posts/abc-123', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: 'New title' }),
+  }).then((response) => response.json())
+
+  expect(updatedPost).toEqual({
+    id: 'abc-123',
+    title: 'New title',
+  })
+
+  {
+    const post = await fetch('https://api.example.com/posts/abc-123').then(
+      (response) => response.json(),
+    )
+    expect(post).toEqual({
+      id: 'abc-123',
+      title: 'New title',
+    })
+  }
 })

--- a/test/node/msw-api/store/store.test.ts
+++ b/test/node/msw-api/store/store.test.ts
@@ -17,7 +17,7 @@ const server = setupServer(
     async ({ request }) => {
       const data = await request.json()
 
-      const posts = store.open('posts')
+      const posts = await store.open('posts')
       await posts.put(data.id, data)
 
       return HttpResponse.json(data, { status: 201 })
@@ -26,7 +26,7 @@ const server = setupServer(
   http.get<{ id: string }, never, Post>(
     'https://api.example.com/posts/:id',
     async ({ params }) => {
-      const posts = store.open('posts')
+      const posts = await store.open('posts')
       const post = await posts.get(params.id)
 
       if (!post) {
@@ -84,7 +84,7 @@ test('updates an in-memory record', async () => {
     http.put<{ id: string }, Partial<Post>, Post>(
       'https://api.example.com/posts/:id',
       async ({ request, params }) => {
-        const posts = store.open('posts')
+        const posts = await store.open('posts')
         const data = await request.json()
 
         const nextPost = await posts.update(


### PR DESCRIPTION
This is an exploration of a data persistence layer in MSW with input validation on top of [Standard schema](https://standardschema.dev/).

## Proposal

```ts
import { defineStore } from 'msw'

const store = defineStore({
  collections: {
    // Use Standard Schema so users can define
    // their collections using their schema library of choice.
    post: z.object({
      id: z.string(),
      title: z.string()
    })
  }
})

const server = setupServer()
server.listen({ context: { store } })

server.use(
  http.get('/posts/:id', async ({ params, store }) => {
    // Get a record by its ID.
    const posts = await store.open('posts')
    const post = await posts.get(params.id)
    return HttpResponse.json(post)
  })
)
```

- All `store` and `Collection` methods must be asynchronous to accommodate any future changes in regards to how records are created or persisted. 

## What about `@mswjs/data`?

This proposal **has no goal to implement a querying system**. I have found those to be redundant and overly-complex for everyone. Instead, use simple predicates, simple update functions. 

**This is likely to deprecate `@mswjs/data`**. This proposal solves a bunch of long-requested features, such as schema support and type-safety. 

This proposal **will not support relations**. But I suspect you can express relations between objects in schema libraries maybe? 

## Roadmap

- [ ] Persistence. `localStorage` since it exists everywhere (check Node.js 18).
  - Nope, not a thing in Node.js. May be available in more recent releases. 
- [x] Support `context: { store }` extension on `server.listen()` and `worker.listen()`.
  - Consider moving this out and implementing as a separate feature. Store doesn't need this to work. This is purely a quality-of-life thing.
- [ ] Tests. More tests!