### PR TITLE
fix(HttpResponse): set the default `bodyType` to `any`

### DIFF
--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -37,6 +37,8 @@ export interface StrictResponse<BodyType extends DefaultBodyType>
  * @see {@link https://mswjs.io/docs/api/http-response `HttpResponse` API reference}
  */
 export class HttpResponse extends FetchResponse {
+  [bodyType]: any
+
   constructor(body?: BodyInit | null, init?: HttpResponseInit) {
     const responseInit = normalizeResponseInit(init)
     super(body, responseInit)

--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -6,11 +6,11 @@ import {
   normalizeResponseInit,
 } from './utils/HttpResponse/decorators'
 
+const bodyType = Symbol('bodyType')
+
 export interface HttpResponseInit extends ResponseInit {
   type?: ResponseType
 }
-
-declare const bodyType: unique symbol
 
 export interface StrictRequest<BodyType extends DefaultBodyType>
   extends Request {
@@ -37,7 +37,7 @@ export interface StrictResponse<BodyType extends DefaultBodyType>
  * @see {@link https://mswjs.io/docs/api/http-response `HttpResponse` API reference}
  */
 export class HttpResponse extends FetchResponse {
-  [bodyType]: any
+  readonly [bodyType]: any
 
   constructor(body?: BodyInit | null, init?: HttpResponseInit) {
     const responseInit = normalizeResponseInit(init)

--- a/test/typings/http.test-d.ts
+++ b/test/typings/http.test-d.ts
@@ -235,3 +235,15 @@ it('errors when returning non-Response data from resolver', () => {
     () => ({}),
   )
 })
+
+it('treats non-typed HttpResponse body type as matching', () => {
+  http.get<never, never, { id: string }>('/resource', () => {
+    /**
+     * @note When constructing a Response/HttpResponse instance,
+     * its body type must effectively be treated as `any`. You
+     * cannot provide or infer a narrower type because these classes
+     * operate on streams or strings, none of which are type-safe.
+     */
+    return new HttpResponse(null, { status: 500 })
+  })
+})


### PR DESCRIPTION
## Problem

When annotating the response body type of your handlers, MSW doesn't allow raw `HttpResponse` instances to be returned because they are missing the `[bodyType]` symbol in them:

```ts
http.get<never, never, { id: string }>('/resource', () => {
  // This errors. Expected one body type, got no [bodyType] symbol at all.
  return new HttpResponse(null, { status: 500 })
})
```

This is incorrect. You should always be able to tap into a type-unsafe response declaration, especially when returning error responses. 

## Solution

- Add the `[bodyType]` symbol to the `HttpResponse` class and set it to `any` by default. This will make `new HttpResponse()` instances type-compatible with any response body types while preserving stricter type matching when using shorthands like `HttpResponse.json()`. 