### PR TITLE
fix(deps): make graphql an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,16 +147,12 @@
     "@mswjs/interceptors": "^0.37.0",
     "@open-draft/deferred-promise": "^2.2.0",
     "@open-draft/until": "^2.1.0",
-    "@types/cookie": "^0.6.0",
-    "@types/statuses": "^2.0.4",
-    "graphql": "^16.8.1",
     "headers-polyfill": "^4.0.2",
     "is-node-process": "^1.2.0",
     "outvariant": "^1.4.3",
     "path-to-regexp": "^6.3.0",
     "picocolors": "^1.1.1",
     "strict-event-emitter": "^0.5.1",
-    "type-fest": "^4.26.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
@@ -166,11 +162,13 @@
     "@open-draft/test-server": "^0.4.2",
     "@ossjs/release": "^0.8.1",
     "@playwright/test": "^1.48.0",
+    "@types/cookie": "^0.6.0",
     "@types/express": "^4.17.21",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.1.0",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "18.x",
+    "@types/statuses": "^2.0.4",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",
     "@web/dev-server": "^0.4.6",
@@ -201,6 +199,7 @@
     "ts-node": "^10.9.2",
     "tsup": "^8.3.0",
     "typescript": "^5.5.2",
+    "type-fest": "^4.26.1",
     "undici": "^6.20.0",
     "url-loader": "^4.1.1",
     "vitest": "^2.1.8",
@@ -209,10 +208,10 @@
     "webpack-http-server": "^0.5.0"
   },
   "peerDependencies": {
-    "typescript": ">= 4.8.x"
+    "graphql": ">=16.8.1"
   },
   "peerDependenciesMeta": {
-    "typescript": {
+    "graphql": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,14 +29,8 @@ importers:
       '@open-draft/until':
         specifier: ^2.1.0
         version: 2.1.0
-      '@types/cookie':
-        specifier: ^0.6.0
-        version: 0.6.0
-      '@types/statuses':
-        specifier: ^2.0.4
-        version: 2.0.5
       graphql:
-        specifier: ^16.8.1
+        specifier: '>=16.8.1'
         version: 16.8.2
       headers-polyfill:
         specifier: ^4.0.2
@@ -56,9 +50,6 @@ importers:
       strict-event-emitter:
         specifier: ^0.5.1
         version: 0.5.1
-      type-fest:
-        specifier: ^4.26.1
-        version: 4.29.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -81,6 +72,9 @@ importers:
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.49.0
+      '@types/cookie':
+        specifier: ^0.6.0
+        version: 0.6.0
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
@@ -96,6 +90,9 @@ importers:
       '@types/node':
         specifier: 18.x
         version: 18.19.28
+      '@types/statuses':
+        specifier: ^2.0.4
+        version: 2.0.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.8.1
         version: 8.16.0(@typescript-eslint/parser@8.16.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
@@ -183,6 +180,9 @@ importers:
       tsup:
         specifier: ^8.3.0
         version: 8.3.5(@swc/core@1.9.3)(jiti@1.21.0)(postcss@8.4.38)(typescript@5.5.2)(yaml@2.5.1)
+      type-fest:
+        specifier: ^4.26.1
+        version: 4.29.0
       typescript:
         specifier: ^5.5.2
         version: 5.5.2


### PR DESCRIPTION
Working on an application that currently has vulnerabilities due to graphql but the application does not even use graphql, that eventually led us to this repo.

I updated the dependency chain so that graphql is an optional peer dependency which should enable apps to not install additional unwanted dependencies that are unused. Additionally, if you are working on an application with graphql, it probably makes sense to just use the host's graphql version anyways rather than having a duplicate from this library.

Edit: While in there I also moved some dependencies to dev deps that didn't need to be production level dependencies just to clean things up a bit.