### PR TITLE
fix: properly handle concurrent requests while stopping the service worker

### DIFF
--- a/src/browser/setupWorker/glossary.ts
+++ b/src/browser/setupWorker/glossary.ts
@@ -64,6 +64,7 @@ export interface ServiceWorkerIncomingEventsMap {
   KEEPALIVE_RESPONSE: never
   REQUEST: ServiceWorkerIncomingRequest
   RESPONSE: ServiceWorkerIncomingResponse
+  MOCK_DEACTIVATE_RESPONSE: never
 }
 
 /**
@@ -191,7 +192,7 @@ export type StartHandler = (
   options: RequiredDeep<StartOptions>,
   initialOptions: StartOptions,
 ) => StartReturnType
-export type StopHandler = () => void
+export type StopHandler = () => Promise<void>
 
 export interface SetupWorker {
   /**

--- a/src/browser/setupWorker/setupWorker.ts
+++ b/src/browser/setupWorker/setupWorker.ts
@@ -206,11 +206,13 @@ export class SetupWorkerApi
     return await this.startHandler(this.context.startOptions, options)
   }
 
-  public stop(): void {
+  public async stop(): Promise<void> {
+    await this.stopHandler()
+
     super.dispose()
+
     this.context.events.removeAllListeners()
     this.context.emitter.removeAllListeners()
-    this.stopHandler()
   }
 }
 

--- a/src/browser/setupWorker/stop/createStop.ts
+++ b/src/browser/setupWorker/stop/createStop.ts
@@ -5,7 +5,7 @@ import { printStopMessage } from './utils/printStopMessage'
 export const createStop = (
   context: SetupWorkerInternalContext,
 ): StopHandler => {
-  return function stop() {
+  return async function stop() {
     // Warn developers calling "worker.stop()" more times than necessary.
     // This likely indicates a mistake in their code.
     if (!context.isMockingEnabled) {
@@ -21,6 +21,8 @@ export const createStop = (
      * the worker-client relation. Does not affect the worker's lifecycle.
      */
     context.workerChannel.send('MOCK_DEACTIVATE')
+    await context.events.once('MOCK_DEACTIVATE_RESPONSE')
+
     context.isMockingEnabled = false
     window.clearInterval(context.keepAliveInterval)
 

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -12,6 +12,7 @@ const PACKAGE_VERSION = '<PACKAGE_VERSION>'
 const INTEGRITY_CHECKSUM = '<INTEGRITY_CHECKSUM>'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
+const inflightRequests = new Map()
 
 self.addEventListener('install', function () {
   self.skipWaiting()
@@ -88,6 +89,7 @@ self.addEventListener('message', async function (event) {
 
     case 'CLIENT_CLOSED': {
       activeClientIds.delete(clientId)
+      inflightRequests.delete(clientId)
 
       const remainingClients = allClients.filter((client) => {
         return client.id !== clientId
@@ -278,8 +280,6 @@ async function getResponse(event, client, requestId) {
 
   return passthrough()
 }
-
-const inflightRequests = new Map()
 
 function addInflightRequest(clientId, requestId, resolve) {
   let inflightRequestsForClient = inflightRequests.get(clientId)

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -75,14 +75,7 @@ self.addEventListener('message', async function (event) {
 
     case 'MOCK_DEACTIVATE': {
       activeClientIds.delete(clientId)
-
-      // We need to make sure we resolve any in-flight post message requests or they will never resolve 
-      const inflightRequestsForClient = inflightRequests.get(clientId)
-      if (inflightRequestsForClient) {
-        inflightRequestsForClient.forEach((resolve) => resolve())
-        inflightRequestsForClient.delete(clientId)
-      }
-
+      resolveInflightRequests(clientId)
       sendToClient(client, { type: 'MOCK_DEACTIVATE_RESPONSE' })
       break
     }
@@ -301,6 +294,15 @@ function completeInflightRequest(clientId, requestId) {
     if (inflightRequestsForClient.size === 0) {
       inflightRequests.delete(clientId)
     }
+  }
+}
+
+function resolveInflightRequests(clientId) {
+  // We need to make sure we resolve any in-flight post message requests or they will never resolve 
+  const inflightRequestsForClient = inflightRequests.get(clientId)
+  if (inflightRequestsForClient) {
+    inflightRequestsForClient.forEach((resolve) => resolve())
+    inflightRequestsForClient.delete(clientId)
   }
 }
 


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/2323

Not sure how to write tests for this since it requires precise timing you need to have requests in-flight while the `stop` function is called on the service worker and then some how detect that it hanged on those. So need some guidance there.

This change does these things:
1. It changes the `stop` function of the service worker from being sync to async so that you know that after it resolved the service worker is no longer passing requests over to the page handlers. So once `stop` resolved everything should be unmocked and just passthrough.
2. It alters the order of the deactivation so that the the service worker deactivation is ensured before we unregister any event handles on the parent page side.
3. It sends a new `MOCK_DEACTIVATE_RESPONSE` from the service worker to the page so that we can ensure that the message got received. Processing of messages are not instant so sending a `MOCK_DEACTIVATE` call and then assuming that it got it doesn't work.
4. It tracks any in flight HTTP requests that are processed while we are stopping the service worker mocking. If that happens then those in-flight requests just becomes passthrough requests.