### PR TITLE
fix(graphql): add `extensions` property to the `GraphQLResponseBody` type

### DIFF
--- a/src/core/handlers/GraphQLHandler.ts
+++ b/src/core/handlers/GraphQLHandler.ts
@@ -72,6 +72,7 @@ export type GraphQLResponseBody<BodyType extends DefaultBodyType> =
   | {
       data?: BodyType | null
       errors?: readonly Partial<GraphQLError>[] | null
+      extensions?: Record<string, any>
     }
   | null
   | undefined

--- a/test/typings/graphql.test-d.ts
+++ b/test/typings/graphql.test-d.ts
@@ -198,3 +198,15 @@ it('graphql mutation cannot extract variable and reponse types', () => {
     })
   })
 })
+
+it('graphql query allows extensions in the response body', () => {
+  graphql.query<{ id: string }>('GetUser', () => {
+    return HttpResponse.json({
+      data: { id: '2' },
+      extensions: {
+        requestId: '3',
+        runtime: 'foo',
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Description
- Add extensions property type to GraphQLResponseBody

Test cases are already covered in the following files:
- https://github.com/mswjs/msw/blob/main/test/node/graphql-api/extensions.node.test.ts
- https://github.com/mswjs/msw/blob/main/test/browser/graphql-api/extensions.mocks.ts
- https://github.com/mswjs/msw/blob/main/test/browser/graphql-api/extensions.test.ts

resolves: #2461 

