### PR TITLE
feat: do not exhaust one-time handlers with custom predicate in resolver

### DIFF
--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -325,6 +325,7 @@ export abstract class RequestHandler<
       if (!this.resolverIterator) {
         const result = await resolver(info)
         if (!isIterable(result)) {
+          this.isUsed = result instanceof Response
           return result
         }
         this.resolverIterator =
@@ -346,8 +347,7 @@ export abstract class RequestHandler<
       if (done) {
         // A one-time generator resolver stops affecting the network
         // only after it's been completely exhausted.
-        this.isUsed = true
-
+        this.isUsed = nextResponse instanceof Response
         // Clone the previously stored response so it can be read
         // when receiving it repeatedly from the "done" generator.
         return this.resolverIteratorResult?.clone()


### PR DESCRIPTION
## Description
- Mark the request handler as used only after its resolver function has returned a response.

resolves #2399

## Concern

There might be an edge case where a user's internal resolver doesn't return anything but still expects the request to be consumed only once.
I'm not sure how realistic this scenario is, but I thought it was worth mentioning.
Thank you.


