### PR TITLE
fix(ws): ignore `/socket.io/` path prefix during url matching

### DIFF
--- a/src/core/handlers/WebSocketHandler.test.ts
+++ b/src/core/handlers/WebSocketHandler.test.ts
@@ -1,0 +1,160 @@
+import type { WebSocketConnectionData } from '@mswjs/interceptors/WebSocket'
+import { WebSocketHandler } from './WebSocketHandler'
+
+describe('parse', () => {
+  it('matches an exact url', () => {
+    expect(
+      new WebSocketHandler('ws://localhost:3000').parse({
+        event: new MessageEvent('connection', {
+          data: {
+            client: {
+              url: new URL('ws://localhost:3000'),
+            },
+          } as WebSocketConnectionData,
+        }),
+      }),
+    ).toEqual({
+      match: {
+        matches: true,
+        params: {},
+      },
+    })
+  })
+
+  it('ignores trailing slash', () => {
+    expect(
+      new WebSocketHandler('ws://localhost:3000').parse({
+        event: new MessageEvent('connection', {
+          data: {
+            client: {
+              url: new URL('ws://localhost:3000/'),
+            },
+          } as WebSocketConnectionData,
+        }),
+      }),
+    ).toEqual({
+      match: {
+        matches: true,
+        params: {},
+      },
+    })
+
+    expect(
+      new WebSocketHandler('ws://localhost:3000/').parse({
+        event: new MessageEvent('connection', {
+          data: {
+            client: {
+              url: new URL('ws://localhost:3000'),
+            },
+          } as WebSocketConnectionData,
+        }),
+      }),
+    ).toEqual({
+      match: {
+        matches: true,
+        params: {},
+      },
+    })
+  })
+
+  it('supports path parameters', () => {
+    expect(
+      new WebSocketHandler('ws://localhost:3000/:serviceName').parse({
+        event: new MessageEvent('connection', {
+          data: {
+            client: {
+              url: new URL('ws://localhost:3000/auth'),
+            },
+          } as WebSocketConnectionData,
+        }),
+      }),
+    ).toEqual({
+      match: {
+        matches: true,
+        params: {
+          serviceName: 'auth',
+        },
+      },
+    })
+  })
+
+  it('ignores "/socket.io/" prefix in the client url', () => {
+    expect(
+      new WebSocketHandler('ws://localhost:3000').parse({
+        event: new MessageEvent('connection', {
+          data: {
+            client: {
+              url: new URL(
+                'ws://localhost:3000/socket.io/?EIO=4&transport=websocket',
+              ),
+            },
+          } as WebSocketConnectionData,
+        }),
+      }),
+    ).toEqual({
+      match: {
+        matches: true,
+        params: {},
+      },
+    })
+
+    expect(
+      new WebSocketHandler('ws://localhost:3000/non-matching').parse({
+        event: new MessageEvent('connection', {
+          data: {
+            client: {
+              url: new URL(
+                'ws://localhost:3000/socket.io/?EIO=4&transport=websocket',
+              ),
+            },
+          } as WebSocketConnectionData,
+        }),
+      }),
+    ).toEqual({
+      match: {
+        matches: false,
+        params: {},
+      },
+    })
+  })
+
+  it('preserves non-prefix "/socket.io/" path segment', () => {
+    /**
+     * @note It is highly unlikely but we still shouldn't modify the
+     * WebSocket client URL if it contains a user-defined "socket.io" segment.
+     */
+    expect(
+      new WebSocketHandler('ws://localhost:3000/clients/socket.io/123').parse({
+        event: new MessageEvent('connection', {
+          data: {
+            client: {
+              url: new URL('ws://localhost:3000/clients/socket.io/123'),
+            },
+          } as WebSocketConnectionData,
+        }),
+      }),
+    ).toEqual({
+      match: {
+        matches: true,
+        params: {},
+      },
+    })
+
+    expect(
+      new WebSocketHandler('ws://localhost:3000').parse({
+        event: new MessageEvent('connection', {
+          data: {
+            client: {
+              url: new URL('ws://localhost:3000/clients/socket.io/123'),
+            },
+          } as WebSocketConnectionData,
+        }),
+      }),
+    ).toEqual({
+      match: {
+        matches: false,
+        params: {},
+      },
+    })
+  })
+})

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -47,8 +47,17 @@ export class WebSocketHandler {
   public parse(args: {
     event: MessageEvent<WebSocketConnectionData>
   }): WebSocketHandlerParsedResult {
-    const connection = args.event.data
-    const match = matchRequestUrl(connection.client.url, this.url)
+    const { data: connection } = args.event
+    const { url: clientUrl } = connection.client
+
+    /**
+     * @note Remove the Socket.IO path prefix from the WebSocket
+     * client URL. This is an exception to keep the users from
+     * including the implementation details in their handlers.
+     */
+    clientUrl.pathname = clientUrl.pathname.replace(/^\/socket.io\//, '/')
+
+    const match = matchRequestUrl(clientUrl, this.url)
 
     return {
       match,


### PR DESCRIPTION
- Fixes #2477 

## Changes

- The `/socket.io/` suffix of the actual WebSocket client URL will be _ignored_ if present. User-defined `socket.io` part of the pathname will be preserved (if it's not a prefix).
- Adds missing unit tests for the `parse` method of `WebSocketHandler`.

## Motivation

Right now, MSW does a literal path matching between `connection.client.url` and the handlers'` this.url`. That means that it will never match SocketIO connection requests because they include `/socket.io/` in the path while the WebSocket link doesn't.

The users shouldn't leak such implementation details to their handlers so I propose to make an exception and drop the `/socket.io/` path prefix, if any, during the WebSocket handler parsing. 