### PR TITLE
fix: do not append `.mjs` to `.d.ts` core imports

### DIFF
--- a/config/plugins/esbuild/resolveCoreImportsPlugin.ts
+++ b/config/plugins/esbuild/resolveCoreImportsPlugin.ts
@@ -14,7 +14,11 @@ export function resolveCoreImportsPlugin(): Plugin {
         for (const outputFile of result.outputFiles || []) {
           const isEsm = outputFile.path.endsWith(ESM_EXTENSION)
           const fileContents = outputFile.text
-          const nextFileContents = replaceCoreImports(fileContents, isEsm)
+          const nextFileContents = replaceCoreImports(
+            outputFile.path,
+            fileContents,
+            isEsm,
+          )
 
           outputFile.contents = Buffer.from(nextFileContents)
         }

--- a/config/replaceCoreImports.js
+++ b/config/replaceCoreImports.js
@@ -9,15 +9,20 @@ export function hasCoreImports(fileContents, isEsm) {
   return getCoreImportPattern(isEsm).test(fileContents)
 }
 
-export function replaceCoreImports(fileContents, isEsm) {
+export function replaceCoreImports(moduleFilePath, fileContents, isEsm) {
   return fileContents.replace(
     getCoreImportPattern(isEsm),
     (_, __, maybeSubmodulePath, maybeSemicolon) => {
       const submodulePath = maybeSubmodulePath || '/index'
+      /**
+       * @note Although all .d.ts are considered ESM, append different
+       * file extension for d.mts files.
+       */
+      const extension = moduleFilePath.endsWith('.d.mts') ? '.mjs' : ''
       const semicolon = maybeSemicolon || ''
 
       return isEsm
-        ? `from "../core${submodulePath.endsWith('.mjs') ? submodulePath : submodulePath + '.mjs'}"${semicolon}`
+        ? `from "../core${submodulePath}${extension}"${semicolon}`
         : `require("../core${submodulePath}")${semicolon}`
     },
   )

--- a/config/scripts/patch-ts.js
+++ b/config/scripts/patch-ts.js
@@ -18,6 +18,10 @@ async function patchTypeDefs() {
   const typeDefsWithCoreImports = typeDefsPaths
     .map((modulePath) => {
       const fileContents = fs.readFileSync(modulePath, 'utf8')
+      /**
+       * @note Treat all type definition files as ESM because even
+       * CJS .d.ts use `import` statements.
+       */
       if (hasCoreImports(fileContents, true)) {
         return [modulePath, fileContents]
       }
@@ -39,7 +43,11 @@ async function patchTypeDefs() {
   for (const [typeDefsPath, fileContents] of typeDefsWithCoreImports) {
     // Treat ".d.ts" files as ESM to replace "import" statements.
     // Force no extension on the ".d.ts" imports.
-    const nextFileContents = replaceCoreImports(fileContents, true)
+    const nextFileContents = replaceCoreImports(
+      typeDefsPath,
+      fileContents,
+      true,
+    )
     fs.writeFileSync(typeDefsPath, nextFileContents, 'utf8')
     console.log('Successfully patched "%s"!', typeDefsPath)
   }


### PR DESCRIPTION
- Fixes #2495 

## Root cause

The types were broken because CJS .d.ts imports were referencing `.mjs` files, which resulted in them referencing .d.mts type definitions. While we've treated all typedef files like ESM (because they all have `import` statements), we never properly derived the extension to append based on the source typedef file module (d.ts for CJS, d.mts for ESM). 

Unfortunately, this is really tricky to put into a type test. Instead, I'm adding an extra validation after `patch-ts.js` to make sure that no `.d.ts` files are referencing `.mjs` files:

```
Found .d.ts modules referencing ".mjs" files after patching:

  - /lib/browser/index.d.ts
  - /lib/native/index.d.ts
  - /lib/node/index.d.ts
```