### PR TITLE
fix(HttpResponse): export `StrictResponse` type again with added deprecation notice

### DIFF
--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -19,7 +19,7 @@ export interface StrictRequest<BodyType extends JsonBodyType> extends Request {
 /**
  * Opaque `Response` type that supports strict body type.
  *
- * @deprecated Will be removed in v3. Please use {@link HttpResponse} instead.
+ * @deprecated Please use {@link HttpResponse} instead.
  */
 export type StrictResponse<BodyType extends DefaultBodyType> =
   HttpResponse<BodyType>

--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -38,7 +38,7 @@ export type StrictResponse<BodyType extends DefaultBodyType> =
 export class HttpResponse<
   BodyType extends DefaultBodyType,
 > extends FetchResponse {
-  [bodyType]: BodyType = null as any
+  readonly [bodyType]: BodyType = null as any
 
   constructor(body?: NoInfer<BodyType> | null, init?: HttpResponseInit) {
     const responseInit = normalizeResponseInit(init)

--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -18,10 +18,11 @@ export interface StrictRequest<BodyType extends JsonBodyType> extends Request {
 
 /**
  * Opaque `Response` type that supports strict body type.
+ *
+ * @deprecated Will be removed in v3. Please use {@link HttpResponse} instead.
  */
-interface StrictResponse<BodyType extends DefaultBodyType> extends Response {
-  readonly [bodyType]: BodyType
-}
+export type StrictResponse<BodyType extends DefaultBodyType> =
+  HttpResponse<BodyType>
 
 /**
  * A drop-in replacement for the standard `Response` class
@@ -34,10 +35,9 @@ interface StrictResponse<BodyType extends DefaultBodyType> extends Response {
  *
  * @see {@link https://mswjs.io/docs/api/http-response `HttpResponse` API reference}
  */
-export class HttpResponse<BodyType extends DefaultBodyType>
-  extends FetchResponse
-  implements StrictResponse<BodyType>
-{
+export class HttpResponse<
+  BodyType extends DefaultBodyType,
+> extends FetchResponse {
   [bodyType]: BodyType = null as any
 
   constructor(body?: NoInfer<BodyType> | null, init?: HttpResponseInit) {


### PR DESCRIPTION
This PR implements the changes you (@kettanaito) proposed in #2499. I added an additional deprecation notice to the `StrictResponse` type to guide users to `HttpResponse` instead.

closes #2499