### PR TITLE
fix(HttpResponse): strictly annotate all response methods

### DIFF
--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -116,7 +116,7 @@ export class HttpResponse<
   static xml<BodyType extends string>(
     body?: BodyType | null,
     init?: HttpResponseInit,
-  ): Response {
+  ): HttpResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
 
     if (!responseInit.headers.has('Content-Type')) {
@@ -135,7 +135,7 @@ export class HttpResponse<
   static html<BodyType extends string>(
     body?: BodyType | null,
     init?: HttpResponseInit,
-  ): Response {
+  ): HttpResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
 
     if (!responseInit.headers.has('Content-Type')) {
@@ -157,7 +157,7 @@ export class HttpResponse<
   static arrayBuffer(
     body?: ArrayBuffer | SharedArrayBuffer,
     init?: HttpResponseInit,
-  ): Response {
+  ): HttpResponse<ArrayBuffer | SharedArrayBuffer> {
     const responseInit = normalizeResponseInit(init)
 
     if (!responseInit.headers.has('Content-Type')) {
@@ -168,7 +168,7 @@ export class HttpResponse<
       responseInit.headers.set('Content-Length', body.byteLength.toString())
     }
 
-    return new HttpResponse(body as ArrayBuffer, responseInit)
+    return new HttpResponse(body, responseInit)
   }
 
   /**
@@ -179,7 +179,10 @@ export class HttpResponse<
    *
    * HttpResponse.formData(data)
    */
-  static formData(body?: FormData, init?: HttpResponseInit): Response {
+  static formData(
+    body?: FormData,
+    init?: HttpResponseInit,
+  ): HttpResponse<FormData> {
     return new HttpResponse(body, normalizeResponseInit(init))
   }
 }

--- a/test/typings/regressions/default-resolver-type.test-d.ts
+++ b/test/typings/regressions/default-resolver-type.test-d.ts
@@ -1,0 +1,11 @@
+/**
+ * @see https://github.com/mswjs/msw/issues/2506
+ */
+import { http, HttpResponse, HttpResponseResolver } from 'msw'
+
+it('supports a union of the matching explicit and implicit response resolvers', () => {
+  function handle(resolver?: HttpResponseResolver<never, never, string>) {
+    const defaultResolver = () => HttpResponse.html('<div>test</div>')
+    http.get('/path', resolver || defaultResolver)
+  }
+})


### PR DESCRIPTION
- Fixes #2506

## Motivation

Previously, some of the `HttpResponse` class methods returned a plain `Response` instance. It meant that `HttpResponse.html()` returns a plain `Response`, which made it type-incompatible with signatures like `HttpResponseResolver<never, never, string>`. That's incorrect.