### PR TITLE
feat: send `request` reference within the `RESPONSE` event

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "@types/express": "^4.17.21",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "~18.19.28",
+    "@types/serviceworker": "^0.0.136",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",
     "@web/dev-server": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@types/node':
         specifier: ~18.19.28
         version: 18.19.28
+      '@types/serviceworker':
+        specifier: ^0.0.136
+        version: 0.0.136
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.8.1
         version: 8.16.0(@typescript-eslint/parser@8.16.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
@@ -1462,6 +1465,9 @@ packages:
 
   '@types/serve-static@1.15.5':
     resolution: {integrity: sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==}
+
+  '@types/serviceworker@0.0.136':
+    resolution: {integrity: sha512-5lqryjGIegGNpkOcCfVg7j+v+aB128pEUpffB9mqUAX3sFq38mjtKTTRtAq2oLtt5Wg3Ex0G9EB52ha0qJfbsQ==}
 
   '@types/statuses@2.0.5':
     resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
@@ -6431,6 +6437,8 @@ snapshots:
       '@types/http-errors': 2.0.4
       '@types/mime': 4.0.0
       '@types/node': 18.19.28
+
+  '@types/serviceworker@0.0.136': {}
 
   '@types/statuses@2.0.5': {}
 

--- a/src/browser/setupWorker/glossary.ts
+++ b/src/browser/setupWorker/glossary.ts
@@ -36,12 +36,13 @@ export interface ServiceWorkerIncomingRequest extends RequestWithoutMethods {
   body?: ArrayBuffer | null
 }
 
-type ServiceWorkerIncomingResponse = Pick<
-  Response,
-  'type' | 'ok' | 'status' | 'statusText' | 'body' | 'headers' | 'redirected'
-> & {
-  requestId: string
+type ServiceWorkerIncomingResponse = {
   isMockedResponse: boolean
+  request: ServiceWorkerIncomingRequest
+  response: Pick<
+    Response,
+    'type' | 'ok' | 'status' | 'statusText' | 'body' | 'headers' | 'redirected'
+  >
 }
 
 /**
@@ -87,8 +88,7 @@ export interface SetupWorkerInternalContext {
   startOptions: RequiredDeep<StartOptions>
   worker: ServiceWorker | null
   registration: ServiceWorkerRegistration | null
-  getRequestHandlers(): Array<RequestHandler | WebSocketHandler>
-  requests: Map<string, Request>
+  getRequestHandlers: () => Array<RequestHandler | WebSocketHandler>
   emitter: Emitter<LifeCycleEventsMap>
   keepAliveInterval?: number
   workerChannel: {

--- a/src/browser/setupWorker/setupWorker.ts
+++ b/src/browser/setupWorker/setupWorker.ts
@@ -66,7 +66,6 @@ export class SetupWorkerApi
         return this.handlersController.currentHandlers()
       },
       registration: null,
-      requests: new Map(),
       emitter: this.emitter,
       workerChannel: {
         on: (eventType, callback) => {

--- a/src/browser/setupWorker/start/createRequestListener.ts
+++ b/src/browser/setupWorker/start/createRequestListener.ts
@@ -7,7 +7,7 @@ import {
   ServiceWorkerMessage,
   WorkerChannel,
 } from './utils/createMessageChannel'
-import { parseWorkerRequest } from '../../utils/parseWorkerRequest'
+import { deserializeRequest } from '../../utils/deserializeRequest'
 import { RequestHandler } from '~/core/handlers/RequestHandler'
 import { handleRequest } from '~/core/utils/handleRequest'
 import { RequiredDeep } from '~/core/typeUtils'
@@ -29,16 +29,15 @@ export const createRequestListener = (
     const messageChannel = new WorkerChannel(event.ports[0])
 
     const requestId = message.payload.id
-    const request = parseWorkerRequest(message.payload)
+    const request = deserializeRequest(message.payload)
     const requestCloneForLogs = request.clone()
 
-    // Make this the first requets clone before the
+    // Make this the first request clone before the
     // request resolution pipeline even starts.
     // Store the clone in cache so the first matching
     // request handler would skip the cloning phase.
     const requestClone = request.clone()
     RequestHandler.cache.set(request, requestClone)
-    context.requests.set(requestId, requestClone)
 
     try {
       await handleRequest(

--- a/src/browser/utils/deserializeRequest.ts
+++ b/src/browser/utils/deserializeRequest.ts
@@ -5,11 +5,11 @@ import type { ServiceWorkerIncomingRequest } from '../setupWorker/glossary'
  * Converts a given request received from the Service Worker
  * into a Fetch `Request` instance.
  */
-export function parseWorkerRequest(
-  incomingRequest: ServiceWorkerIncomingRequest,
+export function deserializeRequest(
+  serializedRequest: ServiceWorkerIncomingRequest,
 ): Request {
-  return new Request(incomingRequest.url, {
-    ...incomingRequest,
-    body: pruneGetRequestBody(incomingRequest),
+  return new Request(serializedRequest.url, {
+    ...serializedRequest,
+    body: pruneGetRequestBody(serializedRequest),
   })
 }

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -94,10 +94,7 @@ addEventListener('message', async function (event) {
 })
 
 addEventListener('fetch', function (event) {
-  const { clientId, request } = event
-
-  event
-  // ^?
+  const { request } = event
 
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
@@ -117,12 +114,6 @@ addEventListener('fetch', function (event) {
     return
   }
 
-  // Prevent request handling if the issuing client is not registered.
-  if (!activeClientIds.has(clientId)) {
-    return
-  }
-
-  // Generate unique request ID.
   const requestId = crypto.randomUUID()
   event.respondWith(handleRequest(event, requestId))
 })

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -95,7 +95,7 @@ self.addEventListener('message', async function (event) {
 })
 
 self.addEventListener('fetch', function (event) {
-  const { request } = event
+  const { clientId, request } = event
 
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
@@ -112,6 +112,11 @@ self.addEventListener('fetch', function (event) {
   // Prevents the self-unregistered worked from handling requests
   // after it's been deleted (still remains active until the next reload).
   if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Prevent request handling if the issuing client is not registered.
+  if (!activeClientIds.has(clientId)) {
     return
   }
 

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -94,16 +94,17 @@ addEventListener('message', async function (event) {
 })
 
 addEventListener('fetch', function (event) {
-  const { request } = event
-
   // Bypass navigation requests.
-  if (request.mode === 'navigate') {
+  if (event.request.mode === 'navigate') {
     return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
     return
   }
 
@@ -197,11 +198,9 @@ async function resolveMainClient(event) {
  * @returns {Promise<Response>}
  */
 async function getResponse(event, client, requestId) {
-  const { request } = event
-
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = request.clone()
+  const requestClone = event.request.clone()
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
@@ -242,26 +241,26 @@ async function getResponse(event, client, requestId) {
   }
 
   // Notify the client that a request has been intercepted.
-  const requestBuffer = await request.arrayBuffer()
+  const requestBuffer = await event.request.arrayBuffer()
   const clientMessage = await sendToClient(
     client,
     {
       type: 'REQUEST',
       payload: {
         id: requestId,
-        url: request.url,
-        mode: request.mode,
-        method: request.method,
-        headers: Object.fromEntries(request.headers.entries()),
-        cache: request.cache,
-        credentials: request.credentials,
-        destination: request.destination,
-        integrity: request.integrity,
-        redirect: request.redirect,
-        referrer: request.referrer,
-        referrerPolicy: request.referrerPolicy,
+        url: event.request.url,
+        mode: event.request.mode,
+        method: event.request.method,
+        headers: Object.fromEntries(event.request.headers.entries()),
+        cache: event.request.cache,
+        credentials: event.request.credentials,
+        destination: event.request.destination,
+        integrity: event.request.integrity,
+        redirect: event.request.redirect,
+        referrer: event.request.referrer,
+        referrerPolicy: event.request.referrerPolicy,
         body: requestBuffer,
-        keepalive: request.keepalive,
+        keepalive: event.request.keepalive,
       },
     },
     [requestBuffer],

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -131,26 +131,24 @@ async function handleRequest(event, requestId) {
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    ;(async function () {
-      const responseClone = response.clone()
+    const responseClone = response.clone()
 
-      sendToClient(
-        client,
-        {
-          type: 'RESPONSE',
-          payload: {
-            requestId,
-            isMockedResponse: IS_MOCKED_RESPONSE in response,
-            type: responseClone.type,
-            status: responseClone.status,
-            statusText: responseClone.statusText,
-            body: responseClone.body,
-            headers: Object.fromEntries(responseClone.headers.entries()),
-          },
+    await sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          type: responseClone.type,
+          status: responseClone.status,
+          statusText: responseClone.statusText,
+          body: responseClone.body,
+          headers: Object.fromEntries(responseClone.headers.entries()),
         },
-        responseClone.body ? [responseClone.body] : [],
-      )
-    })()
+      },
+      responseClone.body ? [responseClone.body] : [],
+    )
   }
 
   return response

--- a/src/tsconfig.worker.json
+++ b/src/tsconfig.worker.json
@@ -1,0 +1,13 @@
+{
+  "include": ["./mockServiceWorker.js"],
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "types": ["@types/serviceworker"]
+  }
+}

--- a/test/node/msw-api/setup-server/resetHandlers.node.test.ts
+++ b/test/node/msw-api/setup-server/resetHandlers.node.test.ts
@@ -57,8 +57,8 @@ test('replaces all handlers with the explicit next runtime handlers upon reset',
     }),
   )
 
-  // Once reset with explicit next requets handlers,
-  // replaces all present requets handlers with those.
+  // Once reset with explicit next request handlers,
+  // replaces all present request handlers with those.
   server.resetHandlers(
     http.get('https://test.mswjs.io/products', () => {
       return HttpResponse.json([1, 2, 3])

--- a/test/node/msw-api/setup-server/scenarios/on-unhandled-request/error.node.test.ts
+++ b/test/node/msw-api/setup-server/scenarios/on-unhandled-request/error.node.test.ts
@@ -107,8 +107,12 @@ test('does not error on request which handler implicitly returns no mocked respo
   expect(console.error).not.toHaveBeenCalled()
 })
 
-test('ignores common static assets when using the "error" strategy', async () => {
-  await fetch('https://example.com/styles/main.css')
+test(
+  'ignores common static assets when using the "error" strategy',
+  { timeout: 8000 },
+  async () => {
+    await fetch('https://example.com/styles/main.css')
 
-  expect(console.error).not.toHaveBeenCalled()
-})
+    expect(console.error).not.toHaveBeenCalled()
+  },
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,9 @@
     {
       "path": "./src/tsconfig.node.json"
     },
+    {
+      "path": "./src/tsconfig.worker.json"
+    },
 
     // Tests.
     {


### PR DESCRIPTION
> [!WARNING]
> This change will require you to upgrade your worker script via `npm init`. If you've saved the worker script location in the past using the `--save` flag, the worker script will be updated automatically. 

- **Follow up to #2455**
- Related to #2193
- Fixes #2146
- Closes #2240

Test attempt at https://github.com/mswjs/msw/pull/2473. Highly flaky due to how the client registrations are resolved across tabs. I don't believe it's worth it to pursue that test. 