### PR TITLE
fix: update `@mswjs/interceptors` to support WebSocket server protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "@bundled-es-modules/statuses": "^1.0.1",
     "@bundled-es-modules/tough-cookie": "^0.1.6",
     "@inquirer/confirm": "^5.0.0",
-    "@mswjs/interceptors": "^0.38.7",
+    "@mswjs/interceptors": "^0.39.0",
     "@open-draft/deferred-promise": "^2.2.0",
     "@open-draft/until": "^2.1.0",
     "@types/cookie": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "@bundled-es-modules/statuses": "^1.0.1",
     "@bundled-es-modules/tough-cookie": "^0.1.6",
     "@inquirer/confirm": "^5.0.0",
-    "@mswjs/interceptors": "^0.39.0",
+    "@mswjs/interceptors": "^0.39.1",
     "@open-draft/deferred-promise": "^2.2.0",
     "@open-draft/until": "^2.1.0",
     "@types/cookie": "^0.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.2(@types/node@18.19.28)
       '@mswjs/interceptors':
-        specifier: ^0.38.7
-        version: 0.38.7
+        specifier: ^0.39.0
+        version: 0.39.0
       '@open-draft/deferred-promise':
         specifier: ^2.2.0
         version: 2.2.0
@@ -995,8 +995,8 @@ packages:
     resolution: {integrity: sha512-stTxvLdJ2IcGOs76AnvGYAzGvx8JvQPRxC5DW0P5zdAAnhL33noqb5LKdPt3P37BKp9FzBKZHuihQI9oVqwm0g==}
     engines: {node: '>=16.13'}
 
-  '@mswjs/interceptors@0.38.7':
-    resolution: {integrity: sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==}
+  '@mswjs/interceptors@0.39.0':
+    resolution: {integrity: sha512-w7rBNu3L9pRk4FQOSDDo3gixg0wVM0mX5HbiK2zCnzqOB+vqAh4NsvHrn2qoh4jX06YhuTxDzcDxU1R99xIUBg==}
     engines: {node: '>=18'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6011,7 +6011,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@mswjs/interceptors@0.38.7':
+  '@mswjs/interceptors@0.39.0':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.2(@types/node@18.19.28)
       '@mswjs/interceptors':
-        specifier: ^0.39.0
-        version: 0.39.0
+        specifier: ^0.39.1
+        version: 0.39.1
       '@open-draft/deferred-promise':
         specifier: ^2.2.0
         version: 2.2.0
@@ -995,8 +995,8 @@ packages:
     resolution: {integrity: sha512-stTxvLdJ2IcGOs76AnvGYAzGvx8JvQPRxC5DW0P5zdAAnhL33noqb5LKdPt3P37BKp9FzBKZHuihQI9oVqwm0g==}
     engines: {node: '>=16.13'}
 
-  '@mswjs/interceptors@0.39.0':
-    resolution: {integrity: sha512-w7rBNu3L9pRk4FQOSDDo3gixg0wVM0mX5HbiK2zCnzqOB+vqAh4NsvHrn2qoh4jX06YhuTxDzcDxU1R99xIUBg==}
+  '@mswjs/interceptors@0.39.1':
+    resolution: {integrity: sha512-f/OVak8vv5LCi85wPDOUpqgAQV4qoZTr4H/pPuRggtdzgnU4+BYBv0+gK853ln//PDL7mUkAkR2kW313Tu1i8g==}
     engines: {node: '>=18'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6011,7 +6011,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@mswjs/interceptors@0.39.0':
+  '@mswjs/interceptors@0.39.1':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -1,6 +1,10 @@
 import { Emitter } from 'strict-event-emitter'
 import { createRequestId } from '@mswjs/interceptors'
-import type { WebSocketConnectionData } from '@mswjs/interceptors/WebSocket'
+import type {
+  WebSocketClientConnectionProtocol,
+  WebSocketConnectionData,
+  WebSocketServerConnectionProtocol,
+} from '@mswjs/interceptors/WebSocket'
 import {
   type Match,
   type Path,
@@ -18,7 +22,10 @@ export type WebSocketHandlerEventMap = {
   connection: [args: WebSocketHandlerConnection]
 }
 
-export interface WebSocketHandlerConnection extends WebSocketConnectionData {
+export interface WebSocketHandlerConnection {
+  client: WebSocketClientConnectionProtocol
+  server: WebSocketServerConnectionProtocol
+  info: WebSocketConnectionData['info']
   params: PathParams
 }
 

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -74,7 +74,9 @@ export class WebSocketHandler {
     return args.parsedResult.match.matches
   }
 
-  public async run(connection: WebSocketConnectionData): Promise<boolean> {
+  public async run(
+    connection: Omit<WebSocketHandlerConnection, 'params'>,
+  ): Promise<boolean> {
     const parsedResult = this.parse({
       url: connection.client.url,
     })

--- a/src/core/ws/WebSocketClientManager.ts
+++ b/src/core/ws/WebSocketClientManager.ts
@@ -1,7 +1,7 @@
 import type {
   WebSocketData,
-  WebSocketClientConnection,
   WebSocketClientConnectionProtocol,
+  WebSocketClientEventMap,
 } from '@mswjs/interceptors/WebSocket'
 import { WebSocketClientStore } from './WebSocketClientStore'
 import { WebSocketMemoryClientStore } from './WebSocketMemoryClientStore'
@@ -105,7 +105,9 @@ export class WebSocketClientManager {
     this.channel.postMessage({ type: 'db:update' })
   }
 
-  private async addClient(client: WebSocketClientConnection): Promise<void> {
+  private async addClient(
+    client: WebSocketClientConnectionProtocol,
+  ): Promise<void> {
     await this.store.add(client)
     // Sync the in-memory clients in this runtime with the
     // updated database. This pulls in all the stored clients.
@@ -119,7 +121,9 @@ export class WebSocketClientManager {
    * connection object because `addConnection()` is called only
    * for the opened connections in the same runtime.
    */
-  public async addConnection(client: WebSocketClientConnection): Promise<void> {
+  public async addConnection(
+    client: WebSocketClientConnectionProtocol,
+  ): Promise<void> {
     // Store this client in the map of clients created in this runtime.
     // This way, the manager can distinguish between this runtime clients
     // and extraneous runtime clients when synchronizing clients storage.
@@ -207,5 +211,31 @@ export class WebSocketRemoteClientConnection
         reason,
       },
     } as WebSocketBroadcastChannelMessage)
+  }
+
+  addEventListener<EventType extends keyof WebSocketClientEventMap>(
+    _type: EventType,
+    _listener: (
+      this: WebSocket,
+      event: WebSocketClientEventMap[EventType],
+    ) => void,
+    _options?: AddEventListenerOptions | boolean,
+  ): void {
+    throw new Error(
+      'WebSocketRemoteClientConnection.addEventListener is not supported',
+    )
+  }
+
+  removeEventListener<EventType extends keyof WebSocketClientEventMap>(
+    _event: EventType,
+    _listener: (
+      this: WebSocket,
+      event: WebSocketClientEventMap[EventType],
+    ) => void,
+    _options?: EventListenerOptions | boolean,
+  ): void {
+    throw new Error(
+      'WebSocketRemoteClientConnection.removeEventListener is not supported',
+    )
   }
 }

--- a/test/browser/rest-api/response/body/body-stream.test.ts
+++ b/test/browser/rest-api/response/body/body-stream.test.ts
@@ -25,7 +25,7 @@ test('responds with a mocked ReadableStream response', async ({
 
         chunks.push({
           text: decoder.decode(value),
-          timestamp: Date.now(),
+          timestamp: performance.now(),
         })
       }
     })

--- a/test/node/rest-api/response/body-stream.node.test.ts
+++ b/test/node/rest-api/response/body-stream.node.test.ts
@@ -81,7 +81,7 @@ test('supports delays when enqueuing chunks', async () => {
       response.on('data', (data) => {
         chunks.push({
           buffer: Buffer.from(data),
-          timestamp: Date.now(),
+          timestamp: performance.now(),
         })
       })
 

--- a/test/typings/ws.test-d.ts
+++ b/test/typings/ws.test-d.ts
@@ -53,7 +53,6 @@ it('exposes root-level "client" APIs', () => {
 
   link.addEventListener('connection', ({ client }) => {
     expectTypeOf(client.id).toBeString()
-    expectTypeOf(client.socket).toEqualTypeOf<WebSocket>()
     expectTypeOf(client.url).toEqualTypeOf<URL>()
 
     expectTypeOf(client.addEventListener).toBeFunction()
@@ -103,8 +102,6 @@ it('exposes root-level "server" APIs', () => {
   const link = ws.link('ws://localhost')
 
   link.addEventListener('connection', ({ server }) => {
-    expectTypeOf(server.socket).toEqualTypeOf<WebSocket>()
-
     expectTypeOf(server.connect).toEqualTypeOf<() => void>()
     expectTypeOf(server.addEventListener).toBeFunction()
     expectTypeOf(server.send).toBeFunction()


### PR DESCRIPTION
> [!WARNING]
> This removes type annotations for `client.socket` and `server.socket`. **Those were there by mistake**. The raw `WebSocket` reference mustn't be exposed to the user and wasn't documented, to begin with. The raw reference is still there, just not annotated to emphasize that it's not a part of the public API (`client['socket']`/`server['socket']`).

- Follow up to https://github.com/mswjs/interceptors/pull/726

## Roadmap

- [x] https://github.com/mswjs/interceptors/pull/727. Previously, `client.socket` and `server.socket` were accessible due to us relying on `WebSocketClientConnection` and `WebSocketServerConnection`. The protocols for client and server _do not require you to implement the `socket` property_. So we never receive those properties from the `connection` (although they _are_ there). 
- [x] Adjust MSW's `connection` event data _not_ to mirror the Interceptor's one. Instead, the `client` and `server` objects are strict protocol implementations. That way, custom implementations of those objects don't have to provide values which they might not have (like the `socket` property). 
