### PR TITLE
fix(ws): support `resolutionContext` on `parse` and `run`

### DIFF
--- a/src/core/handlers/WebSocketHandler.test.ts
+++ b/src/core/handlers/WebSocketHandler.test.ts
@@ -108,4 +108,20 @@ describe('parse', () => {
       },
     })
   })
+
+  it('supports a custom resolution context (base url)', () => {
+    expect(
+      new WebSocketHandler('/api/ws').parse({
+        url: new URL('ws://localhost:3000/api/ws'),
+        resolutionContext: {
+          baseUrl: 'ws://localhost:3000/',
+        },
+      }),
+    ).toEqual({
+      match: {
+        matches: true,
+        params: {},
+      },
+    })
+  })
 })


### PR DESCRIPTION
This change allows the user to specify relative WebSocket connection URLs and have them resolved against `resolutionContext?.baseUrl` during the request matching. 