### PR TITLE
feat: add quiet cli option for suppressing informational output

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -25,9 +25,15 @@ yargs(process.argv.slice(2))
           description: 'Custom current worker directory',
           normalize: true,
         })
+        .option('quiet', {
+          alias: 'q',
+          type: 'boolean',
+          description: 'Suppress informational output messages',
+        })
         .example('msw init')
         .example('msw init ./public')
         .example('msw init ./static --save')
+        .example('msw init ./public --quiet')
     },
     init,
   )


### PR DESCRIPTION
Hi, in our setup we use a pnpm prepare hook to run `msw init`, since we do not want to check the worker script into version control. This works fine, however the output gets annoying after a while, since every `pnpm install` prompts you with a whole block of messages on what happened and how to use msw:

<img width="831" height="87" alt="msw output" src="https://github.com/user-attachments/assets/aa1b72a4-cf3b-4f15-97c0-399e336e83d2" />

In the Pipeline it clutters the logs even more:
<img width="881" height="133" alt="Screenshot 2025-07-11 at 10 24 25" src="https://github.com/user-attachments/assets/f2455c14-f00d-4fa4-823e-723d49e0d64a" />


This is fine for new users, but we have been working with MSW for years (and think its great). So I thought a `--quiet` CLI option could be the way to suppress these informational messages for more advanced users. Let me know what you think!