### PR TITLE
test: add `range` mocked response test

### DIFF
--- a/test/browser/rest-api/request/body/body-arraybuffer-range.mocks.ts
+++ b/test/browser/rest-api/request/body/body-arraybuffer-range.mocks.ts
@@ -1,0 +1,31 @@
+import { http, HttpResponse } from 'msw'
+import { setupWorker } from 'msw/browser'
+
+const buffer = new TextEncoder().encode('hello world')
+
+const worker = setupWorker(
+  http.get('/resource', async ({ request }) => {
+    const range = request.headers.get('range')
+
+    if (!range) {
+      throw new Response('Missing range', { status: 400 })
+    }
+
+    const ranges = range.replace(/bytes=/, '').split('-')
+    const start = +ranges[0]
+    const end = ranges[1] ? +ranges[1] : buffer.byteLength - 1
+    const content = buffer.slice(start, end)
+
+    return HttpResponse.arrayBuffer(content, {
+      status: 206,
+      headers: {
+        'accept-range': 'bytes',
+        'content-range': `bytes=${start}-${end}/${buffer.byteLength}`,
+        'content-length': content.byteLength.toString(),
+        'content-type': 'text/plain',
+      },
+    })
+  }),
+)
+
+worker.start()

--- a/test/browser/rest-api/request/body/body-arraybuffer-range.test.ts
+++ b/test/browser/rest-api/request/body/body-arraybuffer-range.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '../../../playwright.extend'
+
+test('responds with a range of a mocked buffer response', async ({
+  loadExample,
+  fetch,
+}) => {
+  await loadExample(
+    new URL('./body-arraybuffer-range.mocks.ts', import.meta.url),
+  )
+
+  const response = await fetch('/resource', {
+    headers: {
+      range: 'bytes=4-8',
+    },
+  })
+
+  expect.soft(response.status()).toBe(206)
+  await expect.soft(response.text()).resolves.toBe('o wo')
+})


### PR DESCRIPTION
- Fixes #2552 

> [!IMPORTANT]
> This test case is not a 100% representation of the submitted use case. If you set `mode: 'no-cors` on the dispatched request in the test, the test will fail as described in the issue. That is caused by the browser behavior (stripping the `range` header from no-cors requests). Nothing we can do about this. 