### PR TITLE
chore: migrate to `rettime`

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "outvariant": "^1.4.3",
     "path-to-regexp": "^6.3.0",
     "picocolors": "^1.1.1",
-    "strict-event-emitter": "^0.5.1",
+    "rettime": "^0.6.2",
     "type-fest": "^4.26.1",
     "yargs": "^17.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      strict-event-emitter:
-        specifier: ^0.5.1
-        version: 0.5.1
+      rettime:
+        specifier: ^0.6.2
+        version: 0.6.2
       type-fest:
         specifier: ^4.26.1
         version: 4.29.0
@@ -4290,6 +4290,9 @@ packages:
   ret@0.4.3:
     resolution: {integrity: sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==}
     engines: {node: '>=10'}
+
+  rettime@0.6.2:
+    resolution: {integrity: sha512-0mHwLbBt6kLnt5UOiJWWcq0LiCSrBRpyANgIBP4CPE1pkbutGACXvLtdIjcltV4B0C3DffB7T1YN07gw2iEbag==}
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -9622,6 +9625,8 @@ snapshots:
       signal-exit: 4.1.0
 
   ret@0.4.3: {}
+
+  rettime@0.6.2: {}
 
   reusify@1.0.4: {}
 

--- a/src/browser/setupWorker/glossary.ts
+++ b/src/browser/setupWorker/glossary.ts
@@ -1,4 +1,4 @@
-import { Emitter } from 'strict-event-emitter'
+import { Emitter } from 'rettime'
 import {
   LifeCycleEventEmitter,
   LifeCycleEventsMap,
@@ -95,7 +95,7 @@ export interface SetupWorkerInternalContext {
     /**
      * Adds a Service Worker event listener.
      */
-    on<EventType extends keyof ServiceWorkerIncomingEventsMap>(
+    on: <EventType extends keyof ServiceWorkerIncomingEventsMap>(
       eventType: EventType,
       callback: (
         event: MessageEvent,
@@ -104,10 +104,10 @@ export interface SetupWorkerInternalContext {
           ServiceWorkerIncomingEventsMap[EventType]
         >,
       ) => void,
-    ): void
-    send<EventType extends ServiceWorkerOutgoingEventTypes>(
+    ) => void
+    send: <EventType extends ServiceWorkerOutgoingEventTypes>(
       eventType: EventType,
-    ): void
+    ) => void
   }
   events: {
     /**
@@ -122,13 +122,13 @@ export interface SetupWorkerInternalContext {
     /**
      * Removes all currently attached listeners.
      */
-    removeAllListeners(): void
+    removeAllListeners: () => void
     /**
      * Awaits a given message type from the Service Worker.
      */
-    once<EventType extends keyof ServiceWorkerIncomingEventsMap>(
+    once: <EventType extends keyof ServiceWorkerIncomingEventsMap>(
       eventType: EventType,
-    ): Promise<
+    ) => Promise<
       ServiceWorkerMessage<EventType, ServiceWorkerIncomingEventsMap[EventType]>
     >
   }
@@ -235,7 +235,7 @@ export interface SetupWorker {
    *
    * @see {@link https://mswjs.io/docs/api/setup-worker/list-handlers `worker.listHandlers()` API reference}
    */
-  listHandlers(): ReadonlyArray<RequestHandler | WebSocketHandler>
+  listHandlers: () => ReadonlyArray<RequestHandler | WebSocketHandler>
 
   /**
    * Life-cycle events.

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -1,4 +1,4 @@
-import { Emitter } from 'strict-event-emitter'
+import { type DefaultEventMap, Emitter, TypedEvent } from 'rettime'
 import { createRequestId } from '@mswjs/interceptors'
 import type {
   WebSocketClientConnectionProtocol,
@@ -18,8 +18,8 @@ type WebSocketHandlerParsedResult = {
   match: Match
 }
 
-export type WebSocketHandlerEventMap = {
-  connection: [args: WebSocketHandlerConnection]
+export interface WebSocketHandlerEventMap extends DefaultEventMap {
+  connection: TypedEvent<WebSocketHandlerConnection>
 }
 
 export interface WebSocketHandlerConnection {
@@ -136,7 +136,9 @@ export class WebSocketHandler {
 
     // Emit the connection event on the handler.
     // This is what the developer adds listeners for.
-    return this[kEmitter].emit('connection', connection)
+    return this[kEmitter].emit(
+      new TypedEvent('connection', { data: connection }),
+    )
   }
 }
 

--- a/src/core/sharedOptions.ts
+++ b/src/core/sharedOptions.ts
@@ -1,4 +1,4 @@
-import type { Emitter } from 'strict-event-emitter'
+import type { Emitter, DefaultEventMap } from 'rettime'
 import type { UnhandledRequestStrategy } from './utils/request/onUnhandledRequest'
 
 export interface SharedOptions {
@@ -13,7 +13,7 @@ export interface SharedOptions {
   onUnhandledRequest?: UnhandledRequestStrategy
 }
 
-export type LifeCycleEventsMap = {
+export interface LifeCycleEventsMap extends DefaultEventMap {
   'request:start': [
     args: {
       request: Request
@@ -61,6 +61,7 @@ export type LifeCycleEventsMap = {
   ]
 }
 
-export type LifeCycleEventEmitter<
-  EventsMap extends Record<string | symbol, any>,
-> = Pick<Emitter<EventsMap>, 'on' | 'removeListener' | 'removeAllListeners'>
+export type LifeCycleEventEmitter<EventMap extends DefaultEventMap> = Pick<
+  Emitter<EventMap>,
+  'on' | 'removeListener' | 'removeAllListeners'
+>

--- a/src/core/utils/handleRequest.test.ts
+++ b/src/core/utils/handleRequest.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { Emitter } from 'strict-event-emitter'
+import { Emitter } from 'rettime'
 import { createRequestId } from '@mswjs/interceptors'
 import { LifeCycleEventsMap, SharedOptions } from '../sharedOptions'
 import { RequestHandler } from '../handlers/RequestHandler'

--- a/src/core/utils/handleRequest.ts
+++ b/src/core/utils/handleRequest.ts
@@ -1,5 +1,5 @@
 import { until } from '@open-draft/until'
-import { Emitter } from 'strict-event-emitter'
+import { Emitter } from 'rettime'
 import { LifeCycleEventsMap, SharedOptions } from '../sharedOptions'
 import { RequiredDeep } from '../typeUtils'
 import type { RequestHandler } from '../handlers/RequestHandler'

--- a/src/core/utils/internal/pipeEvents.test.ts
+++ b/src/core/utils/internal/pipeEvents.test.ts
@@ -1,4 +1,4 @@
-import { Emitter } from 'strict-event-emitter'
+import { Emitter, TypedEvent } from 'rettime'
 import { pipeEvents } from './pipeEvents'
 
 it('pipes events from the source emitter to the destination emitter', () => {
@@ -9,6 +9,7 @@ it('pipes events from the source emitter to the destination emitter', () => {
   const callback = vi.fn()
   destination.on('hello', callback)
 
-  source.emit('hello', 'world', { data: true })
-  expect(callback).toHaveBeenNthCalledWith(1, 'world', { data: true })
+  const event = new TypedEvent('hello', { data: 'world' })
+  source.emit(event)
+  expect(callback).toHaveBeenNthCalledWith(1, event)
 })

--- a/src/core/utils/internal/pipeEvents.ts
+++ b/src/core/utils/internal/pipeEvents.ts
@@ -1,11 +1,11 @@
-import { Emitter, EventMap } from 'strict-event-emitter'
+import type { Emitter, DefaultEventMap } from 'rettime'
 
 /**
  * Pipes all emitted events from one emitter to another.
  */
-export function pipeEvents<Events extends EventMap>(
-  source: Emitter<Events>,
-  destination: Emitter<Events>,
+export function pipeEvents<EventMap extends DefaultEventMap>(
+  source: Emitter<EventMap>,
+  destination: Emitter<EventMap>,
 ): void {
   const rawEmit: typeof source.emit & { _isPiped?: boolean } = source.emit
 
@@ -14,9 +14,9 @@ export function pipeEvents<Events extends EventMap>(
   }
 
   const sourceEmit: typeof source.emit & { _isPiped?: boolean } =
-    function sourceEmit(this: typeof source, event, ...data) {
-      destination.emit(event, ...data)
-      return rawEmit.call(this, event, ...data)
+    function sourceEmit(this: typeof source, event) {
+      destination.emit(event)
+      return rawEmit.call(this, event)
     }
 
   sourceEmit._isPiped = true

--- a/src/core/ws.ts
+++ b/src/core/ws.ts
@@ -116,8 +116,8 @@ function createWebSocketLinkHandler(url: Path): WebSocketLink {
       // handler matches and emits a connection event.
       // When that happens, store that connection in the
       // set of all connections for reference.
-      handler[kEmitter].on('connection', async ({ client }) => {
-        await clientManager.addConnection(client)
+      handler[kEmitter].on('connection', async (event) => {
+        await clientManager.addConnection(event.data.client)
       })
 
       // The "handleWebSocketEvent" function will invoke

--- a/test/browser/setup/workerConsole.ts
+++ b/test/browser/setup/workerConsole.ts
@@ -1,5 +1,5 @@
 import { format } from 'outvariant'
-import { Emitter } from 'strict-event-emitter'
+import { type DefaultEventMap, Emitter, TypedEvent } from 'rettime'
 import { type Page } from '@playwright/test'
 
 type WorkerConsoleMessageType =
@@ -33,8 +33,8 @@ type WorkerConsoleMessageType =
   | 'context'
   | 'memory'
 
-type WorkerConsoleEventMap = {
-  [MessageType in WorkerConsoleMessageType]: [message: string]
+type WorkerConsoleEventMap = DefaultEventMap & {
+  [MessageType in WorkerConsoleMessageType]: TypedEvent<string>
 }
 
 type InternalWorkerConsoleMessageData = {
@@ -85,7 +85,7 @@ export class WorkerConsole extends Emitter<WorkerConsoleEventMap> {
         const formattedMessage = format(template, ...positionals)
 
         this.addMessage(messageType, formattedMessage)
-        this.emit(messageType, formattedMessage)
+        this.emit(new TypedEvent(messageType, { data: formattedMessage }))
       },
     )
 

--- a/test/support/WebSocketServer.ts
+++ b/test/support/WebSocketServer.ts
@@ -1,12 +1,12 @@
 import { invariant } from 'outvariant'
-import { Emitter } from 'strict-event-emitter'
+import { type DefaultEventMap, Emitter, TypedEvent } from 'rettime'
 import fastify, { FastifyInstance } from 'fastify'
 import fastifyWebSocket, { SocketStream } from '@fastify/websocket'
 
 type FastifySocket = SocketStream['socket']
 
-type WebSocketEventMap = {
-  connection: [client: FastifySocket]
+interface WebSocketEventMap extends DefaultEventMap {
+  connection: TypedEvent<FastifySocket>
 }
 
 export class WebSocketServer extends Emitter<WebSocketEventMap> {
@@ -24,8 +24,7 @@ export class WebSocketServer extends Emitter<WebSocketEventMap> {
       fastify.get('/', { websocket: true }, ({ socket }) => {
         this.clients.add(socket)
         socket.once('close', () => this.clients.delete(socket))
-
-        this.emit('connection', socket)
+        this.emit(new TypedEvent('connection', { data: socket }))
       })
     })
   }


### PR DESCRIPTION
Needs Interceptors to finish the migration first to expose `WebSocketConnectionEvent` with the root-level `client`, `server`, etc. that MSW then just infer. 