### PR TITLE
fix: export the `GraphQLResponseBody` type

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -49,6 +49,7 @@ export type {
   GraphQLQuery,
   GraphQLVariables,
   GraphQLRequestBody,
+  GraphQLResponseBody,
   GraphQLJsonRequestBody,
 } from './handlers/GraphQLHandler'
 export type { GraphQLRequestHandler, GraphQLResponseResolver } from './graphql'


### PR DESCRIPTION
Export the `GraphQLResponseBody` type from `core`.

We are using this in some helper functions and have needed to resort to using `patch-package` to make it available.