### PR TITLE
chore: skip release-preview on main

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - '!main'
       - '**'
     tags:
       - '!**'


### PR DESCRIPTION
No need to run previews on `main`. The branch is the release target anyway. 