### PR TITLE
chore: use fixture vs `WebSocketServer`

### DIFF
--- a/test/browser/playwright.extend.ts
+++ b/test/browser/playwright.extend.ts
@@ -20,6 +20,7 @@ import {
 import { waitFor } from '../support/waitFor'
 import { WorkerConsole } from './setup/workerConsole'
 import { getWebpackServer } from './setup/webpackHttpServer'
+import { WebSocketServer } from '../support/WebSocketServer'
 
 export interface TestFixtures {
   /**
@@ -50,6 +51,7 @@ export interface TestFixtures {
   spyOnConsole(): ConsoleMessages
   waitFor(predicate: () => unknown): Promise<void>
   waitForMswActivation(): Promise<void>
+  defineWebSocketServer(): Promise<WebSocketServer>
 }
 
 interface FetchOptions {
@@ -318,6 +320,14 @@ export const test = base.extend<TestFixtures>({
     })
 
     messages?.clear()
+  },
+  async defineWebSocketServer({ page }, use) {
+    const server = new WebSocketServer()
+    await use(async () => {
+      await server.listen()
+      return server
+    })
+    await server.close()
   },
 })
 

--- a/test/browser/ws-api/ws.intercept.server.browser.test.ts
+++ b/test/browser/ws-api/ws.intercept.server.browser.test.ts
@@ -1,7 +1,6 @@
 import type { ws } from 'msw'
 import type { setupWorker } from 'msw/browser'
 import { test, expect } from '../playwright.extend'
-import { WebSocketServer } from '../../support/WebSocketServer'
 
 declare global {
   interface Window {
@@ -12,20 +11,12 @@ declare global {
   }
 }
 
-const server = new WebSocketServer()
-
-test.beforeAll(async () => {
-  await server.listen()
-})
-
-test.afterAll(async () => {
-  await server.close()
-})
-
 test('intercepts incoming server text message', async ({
   loadExample,
   page,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
   })
@@ -71,7 +62,9 @@ test('intercepts incoming server text message', async ({
 test('intercepts incoming server Blob message', async ({
   loadExample,
   page,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
   })
@@ -121,7 +114,9 @@ test('intercepts incoming server Blob message', async ({
 test('intercepts outgoing server ArrayBuffer message', async ({
   loadExample,
   page,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
   })

--- a/test/browser/ws-api/ws.logging.browser.test.ts
+++ b/test/browser/ws-api/ws.logging.browser.test.ts
@@ -1,7 +1,6 @@
 import type { ws } from 'msw'
 import type { setupWorker } from 'msw/browser'
 import { test, expect } from '../playwright.extend'
-import { WebSocketServer } from '../../support/WebSocketServer'
 
 declare global {
   interface Window {
@@ -11,20 +10,6 @@ declare global {
     }
   }
 }
-
-const server = new WebSocketServer()
-
-test.beforeAll(async () => {
-  await server.listen()
-})
-
-test.afterEach(async () => {
-  server.resetState()
-})
-
-test.afterAll(async () => {
-  await server.close()
-})
 
 test('does not log anything if "quiet" was set to "true"', async ({
   loadExample,
@@ -132,7 +117,9 @@ test('logs the close event initiated by the original server', async ({
   spyOnConsole,
   page,
   waitFor,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   const consoleSpy = spyOnConsole()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
@@ -420,7 +407,9 @@ test('logs incoming server messages', async ({
   page,
   spyOnConsole,
   waitFor,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   const consoleSpy = spyOnConsole()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
@@ -484,7 +473,9 @@ test('logs raw incoming server events', async ({
   page,
   spyOnConsole,
   waitFor,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   const consoleSpy = spyOnConsole()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
@@ -539,7 +530,9 @@ test('logs mocked outgoing client message (server.send)', async ({
   page,
   spyOnConsole,
   waitFor,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   const consoleSpy = spyOnConsole()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
@@ -577,7 +570,9 @@ test('logs mocked incoming server message (client.send)', async ({
   page,
   spyOnConsole,
   waitFor,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   const consoleSpy = spyOnConsole()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
@@ -614,7 +609,9 @@ test('marks the prevented outgoing client event as dashed', async ({
   page,
   spyOnConsole,
   waitFor,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   const consoleSpy = spyOnConsole()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
@@ -654,7 +651,9 @@ test('marks the prevented incoming server event as dashed', async ({
   page,
   spyOnConsole,
   waitFor,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   const consoleSpy = spyOnConsole()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,

--- a/test/browser/ws-api/ws.server.connect.browser.test.ts
+++ b/test/browser/ws-api/ws.server.connect.browser.test.ts
@@ -1,7 +1,6 @@
 import type { ws } from 'msw'
 import type { setupWorker } from 'msw/browser'
 import { test, expect } from '../playwright.extend'
-import { WebSocketServer } from '../../support/WebSocketServer'
 
 declare global {
   interface Window {
@@ -12,20 +11,12 @@ declare global {
   }
 }
 
-const server = new WebSocketServer()
-
-test.beforeAll(async () => {
-  await server.listen()
-})
-
-test.afterAll(async () => {
-  await server.close()
-})
-
 test('does not connect to the actual server by default', async ({
   loadExample,
   page,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
   })
@@ -61,7 +52,9 @@ test('does not connect to the actual server by default', async ({
 test('forwards incoming server events to the client once connected', async ({
   loadExample,
   page,
+  defineWebSocketServer,
 }) => {
+  const server = await defineWebSocketServer()
   await loadExample(new URL('./ws.runtime.js', import.meta.url), {
     skipActivation: true,
   })


### PR DESCRIPTION
- Attempt to address #2557 

## Motivation

There's something clearly off with how the `WebSocketServer` utility integrates with the Playwright tests:

```
    FastifyError: Fastify has already been closed and cannot be reopened

       at ../support/WebSocketServer.ts:42

      40 |
      41 |   public async listen(port = 0): Promise<void> {
    > 42 |     const address = await this.app.listen({
         |                                    ^
      43 |       host: '127.0.0.1',
      44 |       port,
      45 |     })
```

To make sure that the server is managed properly, I'm moving it to a fixture. I hope this helps in preventing Fastify from failing here. 