### PR TITLE
fix(setupWorker): fix response init in `response:*` events

### DIFF
--- a/src/browser/setupWorker/start/createResponseListener.ts
+++ b/src/browser/setupWorker/start/createResponseListener.ts
@@ -35,7 +35,7 @@ export function createResponseListener(
               ? responseMessage.response.body
               : null,
             {
-              ...responseMessage,
+              ...responseMessage.response,
               /**
                * Set response URL if it's not set already.
                * @see https://github.com/mswjs/msw/issues/2030

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.mocks.ts
@@ -9,7 +9,7 @@ import { setupWorker } from 'msw/browser'
 
 const worker = setupWorker(
   http.get('*/user', () => {
-    return HttpResponse.text('response-body')
+    return HttpResponse.text('response-body', { status: 400 })
   }),
   http.post('*/no-response', () => {
     return
@@ -52,7 +52,7 @@ worker.events.on(
   async ({ response, request, requestId }) => {
     const body = await response.clone().text()
     console.warn(
-      `[response:mocked] ${response.url} ${body} ${request.method} ${request.url} ${requestId}`,
+      `[response:mocked] ${response.status} ${response.url} ${body} ${request.method} ${request.url} ${requestId}`,
     )
   },
 )
@@ -62,7 +62,7 @@ worker.events.on(
   async ({ response, request, requestId }) => {
     const body = await response.clone().text()
     console.warn(
-      `[response:bypass] ${response.url} ${body} ${request.method} ${request.url} ${requestId}`,
+      `[response:bypass] ${response.status} ${response.url} ${body} ${request.method} ${request.url} ${requestId}`,
     )
   },
 )

--- a/test/browser/msw-api/setup-worker/life-cycle-events/on.test.ts
+++ b/test/browser/msw-api/setup-worker/life-cycle-events/on.test.ts
@@ -16,6 +16,7 @@ const server = new HttpServer((app) => {
     res.send('original-response')
   })
   app.get('/unknown-route', (_req, res) => {
+    res.status(404)
     res.send('majestic-unknown')
   })
   app.get('/passthrough', (_req, res) => {
@@ -64,7 +65,7 @@ test('emits events for a handled request and mocked response', async ({
     `[request:start] GET ${url} ${requestId}`,
     `[request:match] GET ${url} ${requestId}`,
     `[request:end] GET ${url} ${requestId}`,
-    `[response:mocked] ${url} response-body GET ${url} ${requestId}`,
+    `[response:mocked] 400 ${url} response-body GET ${url} ${requestId}`,
   ])
 })
 
@@ -90,7 +91,7 @@ test('emits events for a handled request with no response', async ({
   expect(consoleSpy.get('warning')).toEqual([
     `[request:start] POST ${url} ${requestId}`,
     `[request:end] POST ${url} ${requestId}`,
-    `[response:bypass] ${url} original-response POST ${url} ${requestId}`,
+    `[response:bypass] 200 ${url} original-response POST ${url} ${requestId}`,
   ])
 })
 
@@ -117,7 +118,7 @@ test('emits events for an unhandled request', async ({
     `[request:start] GET ${url} ${requestId}`,
     `[request:unhandled] GET ${url} ${requestId}`,
     `[request:end] GET ${url} ${requestId}`,
-    `[response:bypass] ${url} majestic-unknown GET ${url} ${requestId}`,
+    `[response:bypass] 404 ${url} majestic-unknown GET ${url} ${requestId}`,
   ])
 })
 
@@ -141,7 +142,7 @@ test('emits events for a passthrough request', async ({
     expect(consoleSpy.get('warning')).toEqual([
       `[request:start] GET ${url} ${requestId}`,
       `[request:end] GET ${url} ${requestId}`,
-      `[response:bypass] ${url} passthrough-response GET ${url} ${requestId}`,
+      `[response:bypass] 200 ${url} passthrough-response GET ${url} ${requestId}`,
     ])
   })
 })
@@ -169,7 +170,7 @@ test('emits events for a bypassed request', async ({
         expect.stringContaining(`[request:start] GET ${url}`),
         expect.stringContaining(`[request:end] GET ${url}`),
         expect.stringContaining(
-          `[response:mocked] ${url} bypassed-response GET ${url}`,
+          `[response:mocked] 200 ${url} bypassed-response GET ${url}`,
         ),
       ]),
     )
@@ -180,7 +181,7 @@ test('emits events for a bypassed request', async ({
         expect.stringContaining(`[request:start] POST ${url}`),
         expect.stringContaining(`[request:end] POST ${url}`),
         expect.stringContaining(
-          `[response:bypass] ${url} bypassed-response POST ${url}`,
+          `[response:bypass] 200 ${url} bypassed-response POST ${url}`,
         ),
       ]),
     )


### PR DESCRIPTION
fix #2618