### PR TITLE
fix(node): move `browser` and `react-native` export conditions lower

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
       }
     },
     "./node": {
-      "browser": null,
-      "react-native": null,
       "module-sync": {
         "types": "./lib/node/index.d.mts",
         "default": "./lib/node/index.mjs"
@@ -79,6 +77,8 @@
         "types": "./lib/node/index.d.mts",
         "default": "./lib/node/index.mjs"
       },
+      "browser": null,
+      "react-native": null,
       "default": {
         "types": "./lib/node/index.d.ts",
         "default": "./lib/node/index.js"


### PR DESCRIPTION
Moved the "node" and "react-native" export definitions lower in the exports map. 
This fixes the "No known conditions for './node' specifier" error.

- Fixes mswjs/msw#2545