### PR TITLE
fix(toPublicUrl): remove search parameters in Node.js

### DIFF
--- a/src/core/utils/request/onUnhandledRequest.node.test.ts
+++ b/src/core/utils/request/onUnhandledRequest.node.test.ts
@@ -28,12 +28,16 @@ If you still wish to intercept this unhandled request, please create a request h
 Read more: https://mswjs.io/docs/http/intercepting-requests`,
 }
 
-beforeEach(() => {
+beforeAll(() => {
   vi.spyOn(console, 'warn').mockImplementation(() => void 0)
   vi.spyOn(console, 'error').mockImplementation(() => void 0)
 })
 
 afterEach(() => {
+  vi.clearAllMocks()
+})
+
+afterAll(() => {
   vi.restoreAllMocks()
 })
 

--- a/src/core/utils/request/onUnhandledRequest.node.test.ts
+++ b/src/core/utils/request/onUnhandledRequest.node.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { onUnhandledRequest } from './onUnhandledRequest'
+
+const fixtures = {
+  warningWithoutSuggestions: (url = `/api`) => `\
+[MSW] Warning: intercepted a request without a matching request handler:
+
+  • GET ${url}
+
+If you still wish to intercept this unhandled request, please create a request handler for it.
+Read more: https://mswjs.io/docs/http/intercepting-requests`,
+  warningWithResponseBody: (url = `/api`) => `\
+[MSW] Warning: intercepted a request without a matching request handler:
+
+  • POST ${url}
+
+  • Request body: {"variables":{"id":"abc-123"},"query":"query UserName($id: String!) { user(id: $id) { name } }"}
+
+If you still wish to intercept this unhandled request, please create a request handler for it.
+Read more: https://mswjs.io/docs/http/intercepting-requests`,
+
+  errorWithoutSuggestions: `\
+[MSW] Error: intercepted a request without a matching request handler:
+
+  • GET /api
+
+If you still wish to intercept this unhandled request, please create a request handler for it.
+Read more: https://mswjs.io/docs/http/intercepting-requests`,
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => void 0)
+  vi.spyOn(console, 'error').mockImplementation(() => void 0)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('prints with an absolute URL and search params', async () => {
+  await onUnhandledRequest(
+    new Request(new URL('https://mswjs.io/api?foo=boo')),
+    'warn',
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(
+    fixtures.warningWithoutSuggestions(`https://mswjs.io/api?foo=boo`),
+  )
+
+  await onUnhandledRequest(
+    new Request(new URL('http://localhost/api?foo=boo')),
+    'warn',
+  )
+
+  expect(console.warn).toHaveBeenCalledWith(
+    fixtures.warningWithoutSuggestions(`http://localhost/api?foo=boo`),
+  )
+})

--- a/src/core/utils/request/toPublicUrl.node.test.ts
+++ b/src/core/utils/request/toPublicUrl.node.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment node
- */
+// @vitest-environment node
 import { toPublicUrl } from './toPublicUrl'
 
 test('returns an absolute request URL without search params', () => {
@@ -12,8 +10,8 @@ test('returns an absolute request URL without search params', () => {
     'http://192.168.0.10/path',
   )
 
-  // URLs returned in a Node.js environment are never relative.
-  expect(toPublicUrl(new URL('http://localhost/path?foo=bar'))).toBe(
-    'http://localhost/path',
-  )
+  expect(
+    toPublicUrl(new URL('http://localhost/path?foo=bar')),
+    'Must not return relative URL in Node.js',
+  ).toBe('http://localhost/path')
 })

--- a/src/core/utils/request/toPublicUrl.node.test.ts
+++ b/src/core/utils/request/toPublicUrl.node.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @vitest-environment node
+ */
+import { toPublicUrl } from './toPublicUrl'
+
+test('returns an absolute request URL without search params', () => {
+  expect(toPublicUrl(new URL('https://test.mswjs.io/path'))).toBe(
+    'https://test.mswjs.io/path',
+  )
+
+  expect(toPublicUrl(new URL('http://192.168.0.10/path'))).toBe(
+    'http://192.168.0.10/path',
+  )
+
+  // URLs returned in a Node.js environment are never relative.
+  expect(toPublicUrl(new URL('http://localhost/path?foo=bar'))).toBe(
+    'http://localhost/path',
+  )
+})

--- a/src/core/utils/request/toPublicUrl.test.ts
+++ b/src/core/utils/request/toPublicUrl.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 import { toPublicUrl } from './toPublicUrl'
 
 test('returns an absolute request URL without search params', () => {

--- a/src/core/utils/request/toPublicUrl.ts
+++ b/src/core/utils/request/toPublicUrl.ts
@@ -3,13 +3,14 @@
  * to the current origin. Otherwise returns an absolute URL.
  */
 export function toPublicUrl(url: string | URL): string {
-  if (typeof location === 'undefined') {
-    return url.toString()
-  }
-
   const urlInstance = url instanceof URL ? url : new URL(url)
 
-  return urlInstance.origin === location.origin
-    ? urlInstance.pathname
-    : urlInstance.origin + urlInstance.pathname
+  if (
+    typeof location !== 'undefined' &&
+    urlInstance.origin === location.origin
+  ) {
+    return urlInstance.pathname
+  }
+
+  return urlInstance.origin + urlInstance.pathname
 }


### PR DESCRIPTION
Make `toPublicUrl` more consistent among environments and prevent `onUnhandledRequest` from presenting a duplicated query string.

Also add node env test suites for `toPublicUrl` and `onUnhandledRequest`.

Refs: #2628

---

Addendum: there was a suggestion to change the behavior of `toPublicUrl` so that it would include the search parameters everywhere, but this would have led to the breaking of multiple other assumptions from callers of `toPublicUrl`, so this seemed to me like a reasonable path with much less friction.