### PR TITLE
fix: handle incomplete `localStorage` in Node.js v25

### DIFF
--- a/src/core/utils/cookieStore.ts
+++ b/src/core/utils/cookieStore.ts
@@ -36,7 +36,10 @@ class CookieStore {
   }
 
   private getCookieStoreIndex(): MemoryCookieStoreIndex {
-    if (typeof localStorage === 'undefined') {
+    if (
+      typeof localStorage === 'undefined' ||
+      typeof localStorage.getItem !== 'function'
+    ) {
       return {}
     }
 
@@ -66,7 +69,10 @@ class CookieStore {
   }
 
   private persist(): void {
-    if (typeof localStorage === 'undefined') {
+    if (
+      typeof localStorage === 'undefined' ||
+      typeof localStorage.setItem !== 'function'
+    ) {
       return
     }
 


### PR DESCRIPTION
Closes https://github.com/mswjs/msw/issues/2624
Closes #2626

An alternative to https://github.com/mswjs/msw/pull/2626 that's a little more explicit and targets the Node.js v25 behaviour.

And re this comment in that thread:

> Node.js v25 is an experimental version by design

This is not true, it's intended to be stable and perfectly usable and is supposed to be a good target for developers to use. Just not recommended for production deployments where stability is key.

Like a lot of devs, I use `current` _and_ `lts/*` as targets in my GitHub actions, so this started coming up as a failure for us pretty quickly.