### PR TITLE
chore: use `--only-shell` when installing chromium for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install
+        run: pnpm exec playwright install chromium --with-deps --only-shell
 
       - name: Unit tests
         run: pnpm test:unit
@@ -235,7 +235,7 @@ jobs:
         run: pnpm install
 
       - name: Playwright install
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium --with-deps --only-shell
 
       - name: Browser tests
         run: pnpm test:browser

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install
+        run: pnpm exec playwright install chromium --with-deps --only-shell
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -29,7 +29,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install
+        run: pnpm exec playwright install chromium --with-deps --only-shell
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install
+        run: pnpm exec playwright install chromium --with-deps --only-shell
 
       - name: Lint
         run: pnpm lint


### PR DESCRIPTION
Installing only the Chromium shell can speed up the CI time quite a bit. 