### PR TITLE
feat(msw): Add workerd export

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,20 @@
         "default": "./lib/native/index.js"
       }
     },
+    "./workerd": {
+      "workerd": {
+        "types": "./lib/workerd/index.d.mts",
+        "default": "./lib/workerd/index.mjs"
+      },
+      "import": {
+        "types": "./lib/workerd/index.d.mts",
+        "default": "./lib/workerd/index.mjs"
+      },
+      "default": {
+        "types": "./lib/workerd/index.d.ts",
+        "default": "./lib/workerd/index.js"
+      }
+    },
     "./core/http": {
       "module-sync": {
         "types": "./lib/core/http.d.mts",

--- a/src/workerd/index.ts
+++ b/src/workerd/index.ts
@@ -1,0 +1,17 @@
+import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+import type { RequestHandler } from '~/core/handlers/RequestHandler'
+import { SetupServerCommonApi } from '../node/SetupServerCommonApi'
+
+/**
+ * Sets up a requests interception in workerd with the given request handlers.
+ * @param {RequestHandler[]} handlers List of request handlers.
+ *
+ * @see {@link https://mswjs.io/docs/api/setup-server `setupServer()` API reference}
+ */
+export function setupServer(
+  ...handlers: Array<RequestHandler>
+): SetupServerCommonApi {
+  // Provision request interception via patching `fetch` only
+  // in workerd. There is no `http`/`https` modules in that environment.
+  return new SetupServerCommonApi([new FetchInterceptor()], handlers)
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -125,6 +125,21 @@ const reactNativeConfig: Options = {
   esbuildPlugins: [resolveCoreImportsPlugin(), forceEsmExtensionsPlugin()],
 }
 
+const workerdConfig: Options = {
+  name: 'workerd',
+  platform: 'node',
+  entry: ['./src/workerd/index.ts'],
+  external: ['picocolors', 'util', 'events', mswCore, ecosystemDependencies],
+  format: ['esm', 'cjs'],
+  outDir: './lib/workerd',
+  bundle: true,
+  splitting: false,
+  sourcemap: true,
+  dts: true,
+  tsconfig: path.resolve(__dirname, 'src/tsconfig.node.build.json'),
+  esbuildPlugins: [resolveCoreImportsPlugin(), forceEsmExtensionsPlugin()],
+}
+
 const iifeConfig: Options = {
   name: 'iife',
   platform: 'browser',
@@ -154,6 +169,7 @@ export default defineConfig([
   coreConfig,
   nodeConfig,
   reactNativeConfig,
+  workerdConfig,
   browserConfig,
   iifeConfig,
 ])


### PR DESCRIPTION
Fix https://github.com/mswjs/msw/issues/2637

This PR adds a `msw/workerd` entrypoint in order to expose a `setupServer()` API compatible with the `workerd` runtime (i.e. just a `fetch()` interceptor). I've added this as a new entrypoint to fit the existing setup, but I wonder if at some point it might make sense to just have a `msw/setup` entrypoint that exposed different browser, node, react-native, and workerd export conditions?

This is called `workerd` to match the WinterCG list of runtime keys: https://runtime-keys.proposal.wintercg.org/#workerd