### PR TITLE
fix(sse): handle multi-line messages

### DIFF
--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -327,11 +327,12 @@ class ServerSentEventClient<
       frames.push(`event:${message.event?.toString()}`)
     }
 
-    // Split data on line terminators (LF, CR, or CRLF) per SSE spec
-    // and send each as a separate data: line.
-    const dataStr = message.data?.toString() ?? ''
-    for (const line of dataStr.split(/\r\n|\r|\n/)) {
-      frames.push(`data:${line}`)
+    if (message.data != null) {
+      // Split data on line terminators (LF, CR, or CRLF) per SSE spec
+      // and send each as a separate data: line.
+      for (const line of message.data.toString().split(/\r\n|\r|\n/)) {
+        frames.push(`data:${line}`)
+      }
     }
 
     frames.push('', '')

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -327,7 +327,13 @@ class ServerSentEventClient<
       frames.push(`event:${message.event?.toString()}`)
     }
 
-    frames.push(`data:${message.data}`)
+    // Split data on line terminators (LF, CR, or CRLF) per SSE spec
+    // and send each as a separate data: line.
+    const dataStr = message.data?.toString() ?? ''
+    for (const line of dataStr.split(/\r\n|\r|\n/)) {
+      frames.push(`data:${line}`)
+    }
+
     frames.push('', '')
 
     this.#controller.enqueue(this.#encoder.encode(frames.join('\n')))

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -328,8 +328,11 @@ class ServerSentEventClient<
     }
 
     if (message.data != null) {
-      // Split data on line terminators (LF, CR, or CRLF) per SSE spec
-      // and send each as a separate data: line.
+      /**
+       * Split data on line terminators (LF, CR, or CRLF) and translate them to individual frames.
+       * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+       * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
+       */
       for (const line of message.data.toString().split(/\r\n|\r|\n/)) {
         frames.push(`data:${line}`)
       }

--- a/test/browser/sse-api/sse.client.send.multiline.test.ts
+++ b/test/browser/sse-api/sse.client.send.multiline.test.ts
@@ -1,0 +1,246 @@
+import { sse } from 'msw'
+import { setupWorker } from 'msw/browser'
+import { test, expect } from '../playwright.extend'
+
+declare namespace window {
+  export const msw: {
+    setupWorker: typeof setupWorker
+    sse: typeof sse
+  }
+}
+
+const EXAMPLE_URL = new URL('./sse.mocks.ts', import.meta.url)
+
+test('sends data with LF newline', async ({ loadExample, page }) => {
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse('http://localhost/stream', ({ client }) => {
+        client.send({
+          data: 'line1\nline2',
+        })
+      }),
+    )
+    await worker.start()
+  })
+
+  const message = await page.evaluate(() => {
+    return new Promise<string>((resolve, reject) => {
+      const source = new EventSource('http://localhost/stream')
+      source.onerror = () => reject(new Error('EventSource error'))
+
+      source.addEventListener('message', (event) => {
+        resolve(event.data)
+      })
+    })
+  })
+
+  expect(message).toBe('line1\nline2')
+})
+
+test('sends data with double LF (blank line in middle)', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse('http://localhost/stream', ({ client }) => {
+        client.send({
+          data: 'before\n\nafter',
+        })
+      }),
+    )
+    await worker.start()
+  })
+
+  const message = await page.evaluate(() => {
+    return new Promise<string>((resolve, reject) => {
+      const source = new EventSource('http://localhost/stream')
+      source.onerror = () => reject(new Error('EventSource error'))
+
+      source.addEventListener('message', (event) => {
+        resolve(event.data)
+      })
+    })
+  })
+
+  expect(message).toBe('before\n\nafter')
+})
+
+test('sends data with CR newline', async ({ loadExample, page }) => {
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse('http://localhost/stream', ({ client }) => {
+        client.send({
+          data: 'line1\rline2',
+        })
+      }),
+    )
+    await worker.start()
+  })
+
+  const message = await page.evaluate(() => {
+    return new Promise<string>((resolve, reject) => {
+      const source = new EventSource('http://localhost/stream')
+      source.onerror = () => reject(new Error('EventSource error'))
+
+      source.addEventListener('message', (event) => {
+        resolve(event.data)
+      })
+    })
+  })
+
+  // CR is normalized to LF by the EventSource parser
+  expect(message).toBe('line1\nline2')
+})
+
+test('sends data with CRLF newline', async ({ loadExample, page }) => {
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse('http://localhost/stream', ({ client }) => {
+        client.send({
+          data: 'line1\r\nline2',
+        })
+      }),
+    )
+    await worker.start()
+  })
+
+  const message = await page.evaluate(() => {
+    return new Promise<string>((resolve, reject) => {
+      const source = new EventSource('http://localhost/stream')
+      source.onerror = () => reject(new Error('EventSource error'))
+
+      source.addEventListener('message', (event) => {
+        resolve(event.data)
+      })
+    })
+  })
+
+  // CRLF is normalized to LF by the EventSource parser
+  expect(message).toBe('line1\nline2')
+})
+
+test('sends data with mixed line endings', async ({ loadExample, page }) => {
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse('http://localhost/stream', ({ client }) => {
+        client.send({
+          // Mix of LF, CR, and CRLF
+          data: 'a\nb\rc\r\nd',
+        })
+      }),
+    )
+    await worker.start()
+  })
+
+  const message = await page.evaluate(() => {
+    return new Promise<string>((resolve, reject) => {
+      const source = new EventSource('http://localhost/stream')
+      source.onerror = () => reject(new Error('EventSource error'))
+
+      source.addEventListener('message', (event) => {
+        resolve(event.data)
+      })
+    })
+  })
+
+  // All line endings normalized to LF
+  expect(message).toBe('a\nb\nc\nd')
+})
+
+test('sends data with multiple consecutive newlines', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse('http://localhost/stream', ({ client }) => {
+        client.send({
+          data: 'a\n\n\nb',
+        })
+      }),
+    )
+    await worker.start()
+  })
+
+  const message = await page.evaluate(() => {
+    return new Promise<string>((resolve, reject) => {
+      const source = new EventSource('http://localhost/stream')
+      source.onerror = () => reject(new Error('EventSource error'))
+
+      source.addEventListener('message', (event) => {
+        resolve(event.data)
+      })
+    })
+  })
+
+  expect(message).toBe('a\n\n\nb')
+})
+
+test('sends empty string data', async ({ loadExample, page }) => {
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse('http://localhost/stream', ({ client }) => {
+        client.send({
+          data: '',
+        })
+      }),
+    )
+    await worker.start()
+  })
+
+  const message = await page.evaluate(() => {
+    return new Promise<string>((resolve, reject) => {
+      const source = new EventSource('http://localhost/stream')
+      source.onerror = () => reject(new Error('EventSource error'))
+
+      source.addEventListener('message', (event) => {
+        resolve(event.data)
+      })
+    })
+  })
+
+  expect(message).toBe('')
+})

--- a/test/browser/sse-api/sse.client.send.multiline.test.ts
+++ b/test/browser/sse-api/sse.client.send.multiline.test.ts
@@ -21,9 +21,7 @@ test('sends data with LF newline', async ({ loadExample, page }) => {
 
     const worker = setupWorker(
       sse('http://localhost/stream', ({ client }) => {
-        client.send({
-          data: 'line1\nline2',
-        })
+        client.send({ data: 'line1\nline2' })
       }),
     )
     await worker.start()
@@ -56,9 +54,7 @@ test('sends data with double LF (blank line in middle)', async ({
 
     const worker = setupWorker(
       sse('http://localhost/stream', ({ client }) => {
-        client.send({
-          data: 'before\n\nafter',
-        })
+        client.send({ data: 'before\n\nafter' })
       }),
     )
     await worker.start()
@@ -88,9 +84,7 @@ test('sends data with CR newline', async ({ loadExample, page }) => {
 
     const worker = setupWorker(
       sse('http://localhost/stream', ({ client }) => {
-        client.send({
-          data: 'line1\rline2',
-        })
+        client.send({ data: 'line1\rline2' })
       }),
     )
     await worker.start()
@@ -107,8 +101,9 @@ test('sends data with CR newline', async ({ loadExample, page }) => {
     })
   })
 
-  // CR is normalized to LF by the EventSource parser
-  expect(message).toBe('line1\nline2')
+  expect(message, 'Normalizes CR to LF (via EventSource parser)').toBe(
+    'line1\nline2',
+  )
 })
 
 test('sends data with CRLF newline', async ({ loadExample, page }) => {
@@ -121,9 +116,7 @@ test('sends data with CRLF newline', async ({ loadExample, page }) => {
 
     const worker = setupWorker(
       sse('http://localhost/stream', ({ client }) => {
-        client.send({
-          data: 'line1\r\nline2',
-        })
+        client.send({ data: 'line1\r\nline2' })
       }),
     )
     await worker.start()
@@ -140,8 +133,9 @@ test('sends data with CRLF newline', async ({ loadExample, page }) => {
     })
   })
 
-  // CRLF is normalized to LF by the EventSource parser
-  expect(message).toBe('line1\nline2')
+  expect(message, 'Normalizes CRLF to LF (via EventSource parser)').toBe(
+    'line1\nline2',
+  )
 })
 
 test('sends data with mixed line endings', async ({ loadExample, page }) => {
@@ -174,8 +168,7 @@ test('sends data with mixed line endings', async ({ loadExample, page }) => {
     })
   })
 
-  // All line endings normalized to LF
-  expect(message).toBe('a\nb\nc\nd')
+  expect(message, 'Normalizes line endings to LF').toBe('a\nb\nc\nd')
 })
 
 test('sends data with multiple consecutive newlines', async ({
@@ -213,7 +206,7 @@ test('sends data with multiple consecutive newlines', async ({
   expect(message).toBe('a\n\n\nb')
 })
 
-test('sends empty string data', async ({ loadExample, page }) => {
+test('sends an empty string data', async ({ loadExample, page }) => {
   await loadExample(EXAMPLE_URL, {
     skipActivation: true,
   })
@@ -223,9 +216,7 @@ test('sends empty string data', async ({ loadExample, page }) => {
 
     const worker = setupWorker(
       sse('http://localhost/stream', ({ client }) => {
-        client.send({
-          data: '',
-        })
+        client.send({ data: '' })
       }),
     )
     await worker.start()


### PR DESCRIPTION
Fixes an issue where SSE messages containing newlines in the `data` field would be incorrectly parsed by the client.

Per the SSE spec, multi-line data must be sent as multiple `data:` lines that the EventSource parser concatenates. Previously, MSW sent the data as a single `data:` field, which caused messages containing `\n\n` to be truncated (since `\n\n` terminates an SSE message).

**Before:**
data:line1\n\nline2
Client receives: `"line1"` (truncated)

**After:**
data:line1
data:
data:line2

Client receives: `"line1\n\nline2"` (correct)

The fix handles all SSE line terminators per spec: LF (`\n`), CR (`\r`), and CRLF (`\r\n`).

Let me know your thoughts. Thanks!