### PR TITLE
fix(sse): respect the worker `quiet` option

### DIFF
--- a/src/browser/setupWorker/start/createFallbackRequestListener.ts
+++ b/src/browser/setupWorker/start/createFallbackRequestListener.ts
@@ -29,6 +29,9 @@ export function createFallbackRequestListener(
       options,
       context.emitter,
       {
+        resolutionContext: {
+          quiet: options.quiet,
+        },
         onMockedResponse(_, { handler, parsedResult }) {
           if (!options.quiet) {
             context.emitter.once('response:mocked', ({ response }) => {

--- a/src/browser/setupWorker/start/createRequestListener.ts
+++ b/src/browser/setupWorker/start/createRequestListener.ts
@@ -46,6 +46,9 @@ export const createRequestListener = (
         options,
         context.emitter,
         {
+          resolutionContext: {
+            quiet: options.quiet,
+          },
           onPassthroughResponse() {
             event.postMessage('PASSTHROUGH')
           },

--- a/src/core/utils/executeHandlers.ts
+++ b/src/core/utils/executeHandlers.ts
@@ -11,6 +11,7 @@ export interface HandlersExecutionResult {
 
 export interface ResponseResolutionContext {
   baseUrl?: string
+  quiet?: boolean
 }
 
 /**

--- a/src/core/utils/executeHandlers.ts
+++ b/src/core/utils/executeHandlers.ts
@@ -10,6 +10,11 @@ export interface HandlersExecutionResult {
 }
 
 export interface ResponseResolutionContext {
+  /**
+   * A base url to use when resolving relative urls.
+   * @note This is primarily used by the `@mswjs/http-middleware`
+   * to resolve relative urls in the context of the running server
+   */
   baseUrl?: string
   quiet?: boolean
 }

--- a/src/core/utils/handleRequest.ts
+++ b/src/core/utils/handleRequest.ts
@@ -20,6 +20,8 @@ export interface HandleRequestOptions {
      * to resolve relative urls in the context of the running server
      */
     baseUrl?: string
+
+    quiet?: boolean
   }
 
   /**

--- a/src/core/utils/handleRequest.ts
+++ b/src/core/utils/handleRequest.ts
@@ -3,7 +3,11 @@ import { Emitter } from 'strict-event-emitter'
 import { LifeCycleEventsMap, SharedOptions } from '../sharedOptions'
 import { RequiredDeep } from '../typeUtils'
 import type { RequestHandler } from '../handlers/RequestHandler'
-import { HandlersExecutionResult, executeHandlers } from './executeHandlers'
+import {
+  type HandlersExecutionResult,
+  type ResponseResolutionContext,
+  executeHandlers,
+} from './executeHandlers'
 import { onUnhandledRequest } from './request/onUnhandledRequest'
 import { storeResponseCookies } from './request/storeResponseCookies'
 
@@ -13,16 +17,7 @@ export interface HandleRequestOptions {
    * but is exposed to aid in creating extensions like
    * `@mswjs/http-middleware`.
    */
-  resolutionContext?: {
-    /**
-     * A base url to use when resolving relative urls.
-     * @note This is primarily used by the `@mswjs/http-middleware`
-     * to resolve relative urls in the context of the running server
-     */
-    baseUrl?: string
-
-    quiet?: boolean
-  }
+  resolutionContext?: ResponseResolutionContext
 
   /**
    * Invoked whenever a request is performed as-is.

--- a/test/browser/sse-api/sse.quiet.test.ts
+++ b/test/browser/sse-api/sse.quiet.test.ts
@@ -1,0 +1,49 @@
+import { sse } from 'msw'
+import { setupWorker } from 'msw/browser'
+import { test, expect } from '../playwright.extend'
+
+declare namespace window {
+  export const msw: {
+    setupWorker: typeof setupWorker
+    sse: typeof sse
+  }
+}
+
+const EXAMPLE_URL = new URL('./sse.mocks.ts', import.meta.url)
+
+test('does not log anything if the "quiet" option is set to true', async ({
+  loadExample,
+  spyOnConsole,
+  page,
+}) => {
+  const consoleSpy = spyOnConsole()
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse('http://localhost/stream', ({ client }) => {
+        client.send({
+          data: { username: 'john' },
+        })
+      }),
+    )
+    await worker.start({ quiet: true })
+  })
+
+  await page.evaluate(() => {
+    return new Promise<string>((resolve, reject) => {
+      const source = new EventSource('http://localhost/stream')
+      source.onerror = () => reject()
+
+      source.addEventListener('message', (event) => {
+        resolve(`${event.type}:${event.data}`)
+      })
+    })
+  })
+
+  expect(consoleSpy.get('startGroupCollapsed')).toBeUndefined()
+})


### PR DESCRIPTION
- Fixes #2642 

## Changes

- Exposes `quiet` on `resolutionContext` so it can be accessed from handler methods, like `parse` or `predicate`.
- Add a missing test case. 