### PR TITLE
fix(graphql): export the `GraphQLLinkHandlers` type

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -73,7 +73,12 @@ export type {
   GraphQLOperationType,
   GraphQLCustomPredicate,
 } from './handlers/GraphQLHandler'
-export type { GraphQLRequestHandler, GraphQLResponseResolver } from './graphql'
+export type {
+  GraphQLRequestHandler,
+  GraphQLOperationHandler,
+  GraphQLResponseResolver,
+  GraphQLLinkHandlers,
+} from './graphql'
 
 export type { WebSocketData, WebSocketEventListener } from './ws'
 


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/1509

## Changes

- Exports a new `GraphQLLinkHandlers` type that annotates all the GraphQL handlers returned from `graphql.link()`. 

> [!IMPORTANT]
> After https://github.com/mswjs/msw/discussions/1892, we should rename `GraphQLLinkHandlers` to be just `GraphQLHandlers` as you'd be able to create handlers only via `graphql.link()`. 