### PR TITLE
fix: handle special characters in `postinstall` script

### DIFF
--- a/config/scripts/postinstall.js
+++ b/config/scripts/postinstall.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 
 // When executing the "postinstall" script, the "process.cwd" equals
 // the package directory, not the parent project where the package is installed.
@@ -23,7 +23,7 @@ function postInstall() {
      * @note Call the "init" command directly. It will now copy the worker script
      * to all saved paths in "msw.workerDirectory"
      */
-    execSync(`node ${cliExecutable} init`, {
+    execFileSync('node', [cliExecutable, 'init'], {
       cwd: parentPackageCwd,
     })
   } catch (error) {

--- a/config/scripts/postinstall.js
+++ b/config/scripts/postinstall.js
@@ -23,7 +23,7 @@ function postInstall() {
      * @note Call the "init" command directly. It will now copy the worker script
      * to all saved paths in "msw.workerDirectory"
      */
-    execFileSync('node', [cliExecutable, 'init'], {
+    execFileSync(process.execPath, [cliExecutable, 'init'], {
       cwd: parentPackageCwd,
     })
   } catch (error) {


### PR DESCRIPTION
Improve handling of shell metacharacters in folder names in the `postinstall` script by replacing `execSync` with `execFileSync`.

For example, spaces in folder names are now allowed:

### Current behaviour

Installing `msw` with a `msw.workerDirectory` set in your `package.json` file fails if the folder structure has shell special characters (e.g. spaces) in it.

```console
alois@my-pc:~/Documents/msw with a space (main)$ npm run postinstall

> msw@2.12.7 postinstall
> node -e "import('./config/scripts/postinstall.js').catch(() => void 0)"

node:internal/modules/cjs/loader:1215
  throw err;
  ^

Error: Cannot find module '/home/alois/Documents/msw'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1212:15)
    at Module._load (node:internal/modules/cjs/loader:1043:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.19.4
[MSW] Failed to automatically update the worker script.

Error: Command failed: node /home/alois/Documents/msw with a space/cli/index.js init
node:internal/modules/cjs/loader:1215
  throw err;
  ^

Error: Cannot find module '/home/alois/Documents/msw'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1212:15)
    at Module._load (node:internal/modules/cjs/loader:1043:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.19.4
```

### Proposed

Installing `msw` with a `msw.workerDirectory` set in your `package.json` file works, even if your folder structure has spaces in it.

```console
alois@my-pc:~/Documents/msw with a space (fix/improve-postinstall-script)$ npm run postinstall

> msw@2.12.7 postinstall
> node -e "import('./config/scripts/postinstall.js').catch(() => void 0)"
```

## Future work

The `config/scripts/patch-ts.js` script is still vulnerable to this issue too, but since that only affects developers of this library, not users, I've ignored it for this PR:

https://github.com/mswjs/msw/blob/e0a46431e0f78f1b89d906c3919540dc7947b5bf/config/scripts/patch-ts.js#L91-L96