### PR TITLE
chore: add support for windows builds

### DIFF
--- a/config/scripts/patch-ts.js
+++ b/config/scripts/patch-ts.js
@@ -32,8 +32,8 @@ function searchFilesForPattern(filePattern, searchPattern, errorMessage) {
 }
 
 function getRelativePaths(paths) {
-  const base = fileURLToPath(BUILD_DIR)
-  return paths.map((absolutePath) => path.relative(base, absolutePath))
+  const basePath = fileURLToPath(BUILD_DIR)
+  return paths.map((absolutePath) => path.relative(basePath, absolutePath))
 }
 
 async function patchTypeDefs() {
@@ -106,9 +106,9 @@ ${getRelativePaths(modulesWithUnresolvedImports)
   // Ensure that the .d.ts files compile without errors after resolving the "~/core" imports.
   console.log('Compiling the .d.ts modules with tsc...')
   const tscCompilation = await execAsync(
-    `tsc --noEmit --skipLibCheck ${typeDefsPaths.join(' ')}`,
+    `tsc --noEmit --skipLibCheck ${typeDefsPaths.map((filePath) => `"${filePath}"`).join(' ')}`,
     {
-      cwd: BUILD_DIR,
+      cwd: fileURLToPath(BUILD_DIR),
     },
   )
 

--- a/config/scripts/patch-ts.js
+++ b/config/scripts/patch-ts.js
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 import { fileURLToPath } from 'node:url'
-import path from 'path'
+import path from 'node:path'
 import * as glob from 'glob'
 import { hasCoreImports, replaceCoreImports } from '../replaceCoreImports.js'
 
@@ -14,8 +14,6 @@ function searchFilesForPattern(filePattern, searchPattern, errorMessage) {
   const filePaths = glob.sync(filePattern, {
     cwd: BUILD_DIR,
     absolute: true,
-    posix: true,
-    dotRelative: true,
   })
 
   let matchingFiles = []
@@ -34,20 +32,14 @@ function searchFilesForPattern(filePattern, searchPattern, errorMessage) {
 }
 
 function getRelativePaths(paths) {
-  return paths.map((p) => {
-    const normalisedFilePath = p
-      .replace(/^\/\/\?\//, '')
-      .replace(/\\/g, path.sep)
-    return path.relative(fileURLToPath(BUILD_DIR), normalisedFilePath)
-  })
+  const base = fileURLToPath(BUILD_DIR)
+  return paths.map((absolutePath) => path.relative(base, absolutePath))
 }
 
 async function patchTypeDefs() {
   const typeDefsPaths = glob.sync('**/*.d.{ts,mts}', {
     cwd: BUILD_DIR,
     absolute: true,
-    posix: true,
-    dotRelative: true,
   })
   const typeDefsWithCoreImports = typeDefsPaths
     .map((modulePath) => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -28,7 +28,10 @@ const SERVICE_WORKER_CHECKSUM = getWorkerChecksum()
 const shimConfig: Options = {
   name: 'shims',
   platform: 'neutral',
-  entry: glob.sync('./src/shims/**/*.ts'),
+  entry: glob.sync('./src/shims/**/*.ts', {
+    posix: true,
+    dotRelative: true,
+  }),
   format: ['esm', 'cjs'],
   noExternal: Object.keys(packageJson.dependencies),
   outDir: './lib/shims',
@@ -43,6 +46,8 @@ const coreConfig: Options = {
   platform: 'neutral',
   entry: glob.sync('./src/core/**/*.ts', {
     ignore: '**/*.test.ts',
+    posix: true,
+    dotRelative: true,
   }),
   external: [ecosystemDependencies],
   noExternal: ['cookie'],


### PR DESCRIPTION
When trying to build the project on a windows machine there are a few errors relating to file paths and commands used within `tsup.config.ts` and `patch-ts.js`. I have updated the files to support both linux / mac and windows development but I have not created a new ci job to run on windows (happy to add that if you would like it).

**tsup failure:**
<img width="510" height="295" alt="image" src="https://github.com/user-attachments/assets/c3370fe4-0404-4af2-b3a8-4128c86949b8" />

**patch failure:**
<img width="588" height="375" alt="image" src="https://github.com/user-attachments/assets/d8db76fa-cdc1-4eda-851d-cdcc08e39b57" />

`tsup.config.ts` is an easy fix as there are simple params that can be added to `glob.sync` that solve the path issues.

`patch-ts.js` is slightly more involved, you cannot run `/bin/bash` and grep on windows. I have written a simple version using glob to find the file paths, then fs to read the file to search for references of "~/core" etc. This works for both windows and Linux but is significantly slower than using grep so I have kept the grep implementation for non windows builds. Happy to consolidate this if you care more about simplicity over performance (I think the functions are a little bit ugly but hopefully clear).
