### PR TITLE
fix: translate unhandled connection handler errors to WebSocket error events

### DIFF
--- a/test/node/ws-api/ws.connection-error.test.ts
+++ b/test/node/ws-api/ws.connection-error.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node-websocket
+import { ws } from 'msw'
+import { setupServer } from 'msw/node'
+
+const server = setupServer()
+
+const service = ws.link('ws://example.com/*')
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it('translates unhandled connection handler errors to WebSocket error events', async () => {
+  const errorListener = vi.fn()
+  const openListener = vi.fn()
+  const connectionError = new Error('Connection error')
+
+  server.use(
+    service.addEventListener('connection', () => {
+      throw connectionError
+    }),
+  )
+
+  const socket = new WebSocket('ws://example.com/path')
+  socket.onerror = errorListener
+  socket.onopen = openListener
+
+  await vi.waitFor(() => {
+    expect(errorListener).toHaveBeenCalledTimes(1)
+
+    const errorEvent = errorListener.mock.calls[0][0] as Event
+    expect(errorEvent.type).toBe('error')
+    expect((errorEvent as any).cause).toBe(connectionError)
+  })
+
+  // The connection should not have opened successfully.
+  expect(openListener).not.toHaveBeenCalled()
+})
+
+it('translates unhandled async connection handler errors to WebSocket error events', async () => {
+  const errorListener = vi.fn()
+  const openListener = vi.fn()
+  const connectionError = new Error('Async connection error')
+
+  server.use(
+    service.addEventListener('connection', async () => {
+      await Promise.resolve()
+      throw connectionError
+    }),
+  )
+
+  const socket = new WebSocket('ws://example.com/path')
+  socket.onerror = errorListener
+  socket.onopen = openListener
+
+  await vi.waitFor(() => {
+    expect(errorListener).toHaveBeenCalledTimes(1)
+
+    const errorEvent = errorListener.mock.calls[0][0] as Event
+    expect(errorEvent.type).toBe('error')
+    expect((errorEvent as any).cause).toBe(connectionError)
+  })
+
+  expect(openListener).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Fixes #2446.

## Summary

When an error is thrown in a WebSocket connection handler, it now translates to a WebSocket error event on the client, making it possible to test \websocket.onerror\ scenarios.

## Changes

- Wrapped the \Promise.all(handlers.map(...))\ in \handleWebSocketEvent.ts\ with try/catch
- On error, dispatch an error event to \connection.client.socket\ with the original error as \cause\
- Added tests for both sync and async error cases

## Before

Errors thrown in connection handlers would bubble up unhandled, making it impossible to test \onerror\ behavior.

## After

Errors are caught and translated to WebSocket error events, consistent with how \onUnhandledRequest\ errors are already handled in the same file.

---
*Found this helpful? [☕ Buy me a coffee](https://ko-fi.com/jarvisdev)*