### PR TITLE
fix(ws): support relative urls in `ws.link`

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
   "sideEffects": false,
   "dependencies": {
     "@inquirer/confirm": "^5.0.0",
-    "@mswjs/interceptors": "^0.41.0",
+    "@mswjs/interceptors": "^0.41.2",
     "@open-draft/deferred-promise": "^2.2.0",
     "@types/statuses": "^2.0.6",
     "cookie": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.2(@types/node@20.19.25)
       '@mswjs/interceptors':
-        specifier: ^0.41.0
-        version: 0.41.0
+        specifier: ^0.41.2
+        version: 0.41.2
       '@open-draft/deferred-promise':
         specifier: ^2.2.0
         version: 2.2.0
@@ -955,8 +955,8 @@ packages:
     resolution: {integrity: sha512-stTxvLdJ2IcGOs76AnvGYAzGvx8JvQPRxC5DW0P5zdAAnhL33noqb5LKdPt3P37BKp9FzBKZHuihQI9oVqwm0g==}
     engines: {node: '>=16.13'}
 
-  '@mswjs/interceptors@0.41.0':
-    resolution: {integrity: sha512-edAo9bW53BLYeSK+UPRr2Iz1Fj9DeGMjytvVM0HXRoo750ElWUgPsZPAOTQa12EUiwgDErH2PsFNTLvk1jBxjQ==}
+  '@mswjs/interceptors@0.41.2':
+    resolution: {integrity: sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==}
     engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@1.0.7':
@@ -6074,7 +6074,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@mswjs/interceptors@0.41.0':
+  '@mswjs/interceptors@0.41.2':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -44,20 +44,10 @@ export class WebSocketHandler {
   public id: string
   public callFrame?: string
 
-  protected readonly url: Path
   protected [kEmitter]: Emitter<WebSocketHandlerEventMap>
 
-  constructor(url: Path) {
+  constructor(protected readonly url: Path) {
     this.id = createRequestId()
-
-    // Resolve the WebSocket handler path:
-    // - Plain string URLs resolved as per the specification (via Interceptors).
-    // - String URLs starting with a wildcard are preserved (prepending a scheme there will break them).
-    // - RegExp paths are preserved.
-    this.url =
-      url instanceof RegExp || url.startsWith('*')
-        ? url
-        : resolveWebSocketUrl(url)
 
     this[kEmitter] = new Emitter()
     this.callFrame = getCallFrame(new Error())
@@ -70,6 +60,15 @@ export class WebSocketHandler {
   }): WebSocketHandlerParsedResult {
     const clientUrl = new URL(args.url)
 
+    // Resolve the WebSocket handler path:
+    // - Plain string URLs resolved as per the specification (via Interceptors).
+    // - String URLs starting with a wildcard are preserved (prepending a scheme there will break them).
+    // - RegExp paths are preserved.
+    const resolvedHandlerUrl =
+      this.url instanceof RegExp || this.url.startsWith('*')
+        ? this.url
+        : this.#resolveWebSocketUrl(this.url, args.resolutionContext?.baseUrl)
+
     /**
      * @note Remove the Socket.IO path prefix from the WebSocket
      * client URL. This is an exception to keep the users from
@@ -79,7 +78,7 @@ export class WebSocketHandler {
 
     const match = matchRequestUrl(
       clientUrl,
-      this.url,
+      resolvedHandlerUrl,
       args.resolutionContext?.baseUrl,
     )
 
@@ -147,6 +146,26 @@ export class WebSocketHandler {
     // Emit the connection event on the handler.
     // This is what the developer adds listeners for.
     return this[kEmitter].emit('connection', connection)
+  }
+
+  #resolveWebSocketUrl(url: string, baseUrl?: string): string {
+    const resolvedUrl = resolveWebSocketUrl(
+      baseUrl
+        ? /**
+           * @note Resolve against the base URL preemtively because `resolveWebSocketUrl` only
+           * resolves against `location.href`, which is missing in Node.js. Base URL allows
+           * the handler to accept a relative URL in Node.js.
+           */
+          new URL(url, baseUrl)
+        : url,
+    )
+
+    /**
+     * @note Omit the trailing slash.
+     * While the browser always produces a trailing slash at the end of a WebSocket URL,
+     * having it in as the handler's predicate would mean it is *required* in the actual URL.
+     */
+    return resolvedUrl.replace(/\/$/, '')
   }
 }
 

--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -5,71 +5,85 @@ import { coercePath, matchRequestUrl } from './matchRequestUrl'
 
 describe('matchRequestUrl', () => {
   test('returns true when matches against an exact URL', () => {
-    const match = matchRequestUrl(
-      new URL('https://test.mswjs.io'),
-      'https://test.mswjs.io',
-    )
-    expect(match).toHaveProperty('matches', true)
-    expect(match).toHaveProperty('params', {})
+    expect(
+      matchRequestUrl(
+        new URL('https://test.mswjs.io'),
+        'https://test.mswjs.io',
+      ),
+    ).toEqual({
+      matches: true,
+      params: {},
+    })
   })
 
   test('returns true when matched against a wildcard', () => {
-    const match = matchRequestUrl(new URL('https://test.mswjs.io'), '*')
-    expect(match).toHaveProperty('matches', true)
-    expect(match).toHaveProperty('params', {
-      '0': 'https://test.mswjs.io/',
+    expect(matchRequestUrl(new URL('https://test.mswjs.io'), '*')).toEqual({
+      matches: true,
+      params: {
+        '0': 'https://test.mswjs.io/',
+      },
     })
   })
 
   test('returns true when matched against a RegExp', () => {
-    const match = matchRequestUrl(
-      new URL('https://test.mswjs.io'),
-      /test\.mswjs\.io/,
-    )
-    expect(match).toHaveProperty('matches', true)
-    expect(match).toHaveProperty('params', {})
+    expect(
+      matchRequestUrl(new URL('https://test.mswjs.io'), /test\.mswjs\.io/),
+    ).toEqual({
+      matches: true,
+      params: {},
+    })
   })
 
   test('returns path parameters when matched', () => {
-    const match = matchRequestUrl(
-      new URL('https://test.mswjs.io/user/abc-123'),
-      'https://test.mswjs.io/user/:userId',
-    )
-    expect(match).toHaveProperty('matches', true)
-    expect(match).toHaveProperty('params', {
-      userId: 'abc-123',
+    expect(
+      matchRequestUrl(
+        new URL('https://test.mswjs.io/user/abc-123'),
+        'https://test.mswjs.io/user/:userId',
+      ),
+    ).toEqual({
+      matches: true,
+      params: {
+        userId: 'abc-123',
+      },
     })
   })
 
   test('decodes path parameters', () => {
     const url = 'http://example.com:5001/example'
-    const match = matchRequestUrl(
-      new URL(`https://test.mswjs.io/reflect-url/${encodeURIComponent(url)}`),
-      'https://test.mswjs.io/reflect-url/:url',
-    )
-    expect(match).toHaveProperty('matches', true)
-    expect(match).toHaveProperty('params', {
-      url,
+
+    expect(
+      matchRequestUrl(
+        new URL(`https://test.mswjs.io/reflect-url/${encodeURIComponent(url)}`),
+        'https://test.mswjs.io/reflect-url/:url',
+      ),
+    ).toEqual({
+      matches: true,
+      params: {
+        url,
+      },
     })
   })
 
   test('returns false when does not match against the request URL', () => {
-    const match = matchRequestUrl(
-      new URL('https://test.mswjs.io'),
-      'https://google.com',
-    )
-    expect(match).toHaveProperty('matches', false)
-    expect(match).toHaveProperty('params', {})
+    expect(
+      matchRequestUrl(new URL('https://test.mswjs.io'), 'https://google.com'),
+    ).toEqual({
+      matches: false,
+      params: {},
+    })
   })
 
   test('returns true when matching optional path parameters', () => {
-    const match = matchRequestUrl(
-      new URL('https://test.mswjs.io/user'),
-      'https://test.mswjs.io/user/:userId?',
-    )
-    expect(match).toHaveProperty('matches', true)
-    expect(match).toHaveProperty('params', {
-      userId: undefined,
+    expect(
+      matchRequestUrl(
+        new URL('https://test.mswjs.io/user/123'),
+        'https://test.mswjs.io/user/:userId?',
+      ),
+    ).toEqual({
+      matches: true,
+      params: {
+        userId: '123',
+      },
     })
   })
 

--- a/test/browser/ws-api/ws.intercept.client.browser.test.ts
+++ b/test/browser/ws-api/ws.intercept.client.browser.test.ts
@@ -74,7 +74,7 @@ test('intercepts outgoing client text message', async ({
     socket.onopen = () => socket.send('hello world')
   })
 
-  expect(await clientMessagePromise).toBe('hello world')
+  await expect(clientMessagePromise).resolves.toBe('hello world')
 })
 
 test('intercepts outgoing client Blob message', async ({
@@ -108,7 +108,7 @@ test('intercepts outgoing client Blob message', async ({
     socket.onopen = () => socket.send(new Blob(['hello world']))
   })
 
-  expect(await clientMessagePromise).toBe('hello world')
+  await expect(clientMessagePromise).resolves.toBe('hello world')
 })
 
 test('intercepts outgoing client ArrayBuffer message', async ({
@@ -142,5 +142,38 @@ test('intercepts outgoing client ArrayBuffer message', async ({
     socket.onopen = () => socket.send(new TextEncoder().encode('hello world'))
   })
 
-  expect(await clientMessagePromise).toBe('hello world')
+  await expect(clientMessagePromise).resolves.toBe('hello world')
+})
+
+test('resolves relative link URL against the page origin', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(new URL('./ws.runtime.js', import.meta.url), {
+    skipActivation: true,
+  })
+
+  await page.evaluate(async () => {
+    const { setupWorker, ws } = window.msw
+    const service = ws.link('/api')
+
+    const worker = setupWorker(
+      service.addEventListener('connection', ({ client }) => {
+        client.send('hello world')
+      }),
+    )
+    await worker.start()
+  })
+
+  const messagePromise = page.evaluate(() => {
+    const pendingMessage = Promise.withResolvers<string>()
+    const socket = new WebSocket('/api')
+    socket.onmessage = (event) => pendingMessage.resolve(event.data)
+    socket.onerror = () =>
+      pendingMessage.reject('Did not match the WebSocket connection')
+
+    return pendingMessage.promise
+  })
+
+  await expect(messagePromise).resolves.toBe('hello world')
 })

--- a/test/browser/ws-api/ws.intercept.client.browser.test.ts
+++ b/test/browser/ws-api/ws.intercept.client.browser.test.ts
@@ -36,7 +36,7 @@ test('does not throw on connecting to a non-existing host', async ({
 
     return new Promise<void>((resolve, reject) => {
       socket.onclose = () => resolve()
-      socket.onerror = reject
+      socket.onerror = () => reject('WebSocket connection errored')
     })
   })
 
@@ -159,6 +159,8 @@ test('resolves relative link URL against the page origin', async ({
 
     const worker = setupWorker(
       service.addEventListener('connection', ({ client }) => {
+        console.log('HANDLER!')
+
         client.send('hello world')
       }),
     )

--- a/test/node/ws-api/ws.stop-propagation.test.ts
+++ b/test/node/ws-api/ws.stop-propagation.test.ts
@@ -386,8 +386,7 @@ it('stops immediate propagation for server "error" event', async () => {
 
   await vi.waitFor(() => {
     /**
-     * @note Ideally, await the "CLOSED" ready state,
-     * but Node.js doesn't dispatch it correctly.
+     * @note Ideally, await the "CLOSED" ready state, but Node.js doesn't dispatch it correctly.
      * @see https://github.com/nodejs/undici/issues/3697
      */
     return new Promise<void>((resolve) => {


### PR DESCRIPTION
- Requires https://github.com/mswjs/interceptors/pull/763

Looks like `ws.link()` doesn't resolve relative URLs against the page's origin. The logic is there on MSW side, but Interceptors throw on relative WebSocket URLs because it never resolves them according to the specification. 

> Our logic didn't account that the `WebSocket` constructor will enforce the `ws`/`wss` scheme on the actual URL. Since a relative handler URL is resolved against `location.href`, it always produced a mismatch. 

```ts
ws.link('/api') // "http://localhost/api"
new WebSocket('/api') // "ws://localhost/api"
```

We are now correctly resolving relative paths in the `ws.link` before passing them to the URL matching. 

> [!CAUTION]
> Relative URLs are still not allowed in Node.js. However, if you have `baseUrl` defined in the resolution context, MSW will use it to resolve any relative WebSocket link URLs against it. 