### PR TITLE
fix: export `AnyHandler` type

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -26,6 +26,12 @@ export {
   type ServerSentEventMessage,
 } from './sse'
 
+import type { HttpHandler } from './handlers/HttpHandler'
+import type { GraphQLHandler } from './handlers/GraphQLHandler'
+import type { WebSocketHandler } from './handlers/WebSocketHandler'
+
+export type AnyHandler = HttpHandler | GraphQLHandler | WebSocketHandler
+
 /* Utils */
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'
 export * from './utils/handleRequest'


### PR DESCRIPTION
MSW now exports the `AnyHandler` type that can be used when creating your own abstractions over it. Creating a manual union of all currently present handler types isn't practical. 