### PR TITLE
fix: replace barrel exports with granular exports

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -92,7 +92,12 @@ export type { Path, PathParams, Match } from './utils/matching/matchRequestUrl'
 export type { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'
 export type { ResponseResolutionContext } from './utils/executeHandlers'
 
-export * from './HttpResponse'
+export {
+  HttpResponse,
+  type HttpResponseInit,
+  type StrictRequest,
+  type StrictResponse,
+} from './HttpResponse'
 export { delay, type DelayMode } from './delay'
 export { bypass } from './bypass'
 export { passthrough } from './passthrough'

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -93,7 +93,7 @@ export type { ParsedGraphQLRequest } from './utils/internal/parseGraphQLRequest'
 export type { ResponseResolutionContext } from './utils/executeHandlers'
 
 export * from './HttpResponse'
-export * from './delay'
+export { delay, type DelayMode } from './delay'
 export { bypass } from './bypass'
 export { passthrough } from './passthrough'
 export { isCommonAssetRequest } from './isCommonAssetRequest'

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,7 +34,7 @@ export type AnyHandler = HttpHandler | GraphQLHandler | WebSocketHandler
 
 /* Utils */
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'
-export * from './utils/handleRequest'
+export { handleRequest, type HandleRequestOptions } from './utils/handleRequest'
 export {
   onUnhandledRequest,
   type UnhandledRequestStrategy,


### PR DESCRIPTION
Removes barrel exports for `delay.ts` and `HttpResponse.ts` to stop leaking internal things into public exports. 