### PR TITLE
fix(HttpResponse): mark implicit `content-type` headers with a symbol

### DIFF
--- a/src/core/HttpResponse.test.ts
+++ b/src/core/HttpResponse.test.ts
@@ -2,14 +2,14 @@
  * @vitest-environment node
  */
 import { TextEncoder } from 'util'
-import { HttpResponse } from './HttpResponse'
+import { HttpResponse, kDefaultContentType } from './HttpResponse'
 
 it('creates a plain response', async () => {
   const response = new HttpResponse(null, { status: 301 })
   expect(response.status).toBe(301)
   expect(response.statusText).toBe('Moved Permanently')
   expect(response.body).toBe(null)
-  expect(await response.text()).toBe('')
+  await expect(response.text()).resolves.toBe('')
   expect(Object.fromEntries(response.headers.entries())).toEqual({})
 })
 
@@ -24,11 +24,12 @@ describe('HttpResponse.text()', () => {
     expect(response.status).toBe(201)
     expect(response.statusText).toBe('Created')
     expect(response.body).toBeInstanceOf(ReadableStream)
-    expect(await response.text()).toBe('hello world')
+    await expect(response.text()).resolves.toBe('hello world')
     expect(Object.fromEntries(response.headers.entries())).toEqual({
       'content-length': '11',
       'content-type': 'text/plain',
     })
+    expect(kDefaultContentType in response).toBe(true)
   })
 
   it('creates a text response with special characters', async () => {
@@ -37,7 +38,7 @@ describe('HttpResponse.text()', () => {
     expect(response.status).toBe(201)
     expect(response.statusText).toBe('Created')
     expect(response.body).toBeInstanceOf(ReadableStream)
-    expect(await response.text()).toBe('안녕 세상')
+    await expect(response.text()).resolves.toBe('안녕 세상')
     expect(Object.fromEntries(response.headers.entries())).toEqual({
       'content-length': '13',
       'content-type': 'text/plain',
@@ -52,11 +53,12 @@ describe('HttpResponse.text()', () => {
     expect(response.status).toBe(200)
     expect(response.statusText).toBe('OK')
     expect(response.body).toBeInstanceOf(ReadableStream)
-    expect(await response.text()).toBe('hello world')
+    await expect(response.text()).resolves.toBe('hello world')
     expect(Object.fromEntries(response.headers.entries())).toEqual({
       'content-length': '11',
       'content-type': 'text/plain; charset=utf-8',
     })
+    expect(kDefaultContentType in response).toBe(false)
   })
 
   it('allows overriding the "Content-Length" response header', async () => {
@@ -83,6 +85,7 @@ describe('HttpResponse.json()', () => {
       'content-length': '20',
       'content-type': 'application/json',
     })
+    expect(kDefaultContentType in response).toBe(true)
   })
 
   it('creates a json response given an object with special characters', async () => {
@@ -172,6 +175,7 @@ describe('HttpResponse.json()', () => {
       },
     )
 
+    expect(kDefaultContentType in response).toBe(false)
     expect(response.status).toBe(200)
     expect(response.statusText).toBe('OK')
     expect(response.body).toBeInstanceOf(ReadableStream)
@@ -201,13 +205,15 @@ describe('HttpResponse.xml()', () => {
   it('creates an xml response', async () => {
     const response = HttpResponse.xml('<user name="John" />')
 
+    expect(kDefaultContentType in response).toBe(true)
     expect(response.status).toBe(200)
     expect(response.statusText).toBe('OK')
     expect(response.body).toBeInstanceOf(ReadableStream)
-    expect(await response.text()).toBe('<user name="John" />')
+    await expect(response.text()).resolves.toBe('<user name="John" />')
     expect(Object.fromEntries(response.headers.entries())).toEqual({
       'content-type': 'text/xml',
     })
+    expect(kDefaultContentType in response).toBe(true)
   })
 
   it('allows overriding the "Content-Type" response header', async () => {
@@ -220,10 +226,11 @@ describe('HttpResponse.xml()', () => {
     expect(response.status).toBe(200)
     expect(response.statusText).toBe('OK')
     expect(response.body).toBeInstanceOf(ReadableStream)
-    expect(await response.text()).toBe('<user name="John" />')
+    await expect(response.text()).resolves.toBe('<user name="John" />')
     expect(Object.fromEntries(response.headers.entries())).toEqual({
       'content-type': 'text/xml; charset=utf-8',
     })
+    expect(kDefaultContentType in response).toBe(false)
   })
 })
 
@@ -234,10 +241,13 @@ describe('HttpResponse.html()', () => {
     expect(response.status).toBe(200)
     expect(response.statusText).toBe('OK')
     expect(response.body).toBeInstanceOf(ReadableStream)
-    expect(await response.text()).toBe('<p class="author">Jane Doe</p>')
+    await expect(response.text()).resolves.toBe(
+      '<p class="author">Jane Doe</p>',
+    )
     expect(Object.fromEntries(response.headers.entries())).toEqual({
       'content-type': 'text/html',
     })
+    expect(kDefaultContentType in response).toBe(true)
   })
 
   it('allows overriding the "Content-Type" response header', async () => {
@@ -250,10 +260,13 @@ describe('HttpResponse.html()', () => {
     expect(response.status).toBe(200)
     expect(response.statusText).toBe('OK')
     expect(response.body).toBeInstanceOf(ReadableStream)
-    expect(await response.text()).toBe('<p class="author">Jane Doe</p>')
+    await expect(response.text()).resolves.toBe(
+      '<p class="author">Jane Doe</p>',
+    )
     expect(Object.fromEntries(response.headers.entries())).toEqual({
       'content-type': 'text/html; charset=utf-8',
     })
+    expect(kDefaultContentType in response).toBe(false)
   })
 })
 
@@ -272,6 +285,7 @@ describe('HttpResponse.arrayBuffer()', () => {
       'content-length': '11',
       'content-type': 'application/octet-stream',
     })
+    expect(kDefaultContentType in response).toBe(true)
   })
 
   it('allows overriding the "Content-Type" response header', async () => {
@@ -292,6 +306,7 @@ describe('HttpResponse.arrayBuffer()', () => {
       'content-length': '11',
       'content-type': 'text/plain; charset=utf-8',
     })
+    expect(kDefaultContentType in response).toBe(false)
   })
 
   it('creates an array buffer response from a shared array buffer', async () => {
@@ -340,6 +355,7 @@ describe('HttpResponse.arrayBuffer()', () => {
       'content-length': '11',
       'content-type': 'text/plain; charset=utf-8',
     })
+    expect(kDefaultContentType in response).toBe(false)
   })
 })
 

--- a/src/core/HttpResponse.ts
+++ b/src/core/HttpResponse.ts
@@ -28,6 +28,8 @@ export interface StrictRequest<BodyType extends JsonBodyType> extends Request {
 export type StrictResponse<BodyType extends DefaultBodyType> =
   HttpResponse<BodyType>
 
+export const kDefaultContentType = Symbol.for('kDefaultContentType')
+
 /**
  * A drop-in replacement for the standard `Response` class
  * to allow additional features, like mocking the response `Set-Cookie` header.
@@ -65,8 +67,9 @@ export class HttpResponse<
     init?: HttpResponseInit,
   ): HttpResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
+    const hasExplicitContentType = responseInit.headers.has('Content-Type')
 
-    if (!responseInit.headers.has('Content-Type')) {
+    if (!hasExplicitContentType) {
       responseInit.headers.set('Content-Type', 'text/plain')
     }
 
@@ -80,7 +83,16 @@ export class HttpResponse<
       )
     }
 
-    return new HttpResponse(body, responseInit)
+    const response = new HttpResponse(body, responseInit)
+
+    if (!hasExplicitContentType) {
+      Object.defineProperty(response, kDefaultContentType, {
+        value: true,
+        enumerable: false,
+      })
+    }
+
+    return response
   }
 
   /**
@@ -94,8 +106,9 @@ export class HttpResponse<
     init?: HttpResponseInit,
   ): HttpResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
+    const hasExplicitContentType = responseInit.headers.has('Content-Type')
 
-    if (!responseInit.headers.has('Content-Type')) {
+    if (!hasExplicitContentType) {
       responseInit.headers.set('Content-Type', 'application/json')
     }
 
@@ -112,7 +125,16 @@ export class HttpResponse<
       )
     }
 
-    return new HttpResponse(responseText as BodyType, responseInit)
+    const response = new HttpResponse(responseText, responseInit)
+
+    if (!hasExplicitContentType) {
+      Object.defineProperty(response, kDefaultContentType, {
+        value: true,
+        enumerable: false,
+      })
+    }
+
+    return response as HttpResponse<BodyType>
   }
 
   /**
@@ -126,12 +148,22 @@ export class HttpResponse<
     init?: HttpResponseInit,
   ): HttpResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
+    const hasExplicitContentType = responseInit.headers.has('Content-Type')
 
-    if (!responseInit.headers.has('Content-Type')) {
+    if (!hasExplicitContentType) {
       responseInit.headers.set('Content-Type', 'text/xml')
     }
 
-    return new HttpResponse(body, responseInit)
+    const response = new HttpResponse(body, responseInit)
+
+    if (!hasExplicitContentType) {
+      Object.defineProperty(response, kDefaultContentType, {
+        value: true,
+        enumerable: false,
+      })
+    }
+
+    return response as HttpResponse<BodyType>
   }
 
   /**
@@ -145,12 +177,22 @@ export class HttpResponse<
     init?: HttpResponseInit,
   ): HttpResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
+    const hasExplicitContentType = responseInit.headers.has('Content-Type')
 
-    if (!responseInit.headers.has('Content-Type')) {
+    if (!hasExplicitContentType) {
       responseInit.headers.set('Content-Type', 'text/html')
     }
 
-    return new HttpResponse(body, responseInit)
+    const response = new HttpResponse(body, responseInit)
+
+    if (!hasExplicitContentType) {
+      Object.defineProperty(response, kDefaultContentType, {
+        value: true,
+        enumerable: false,
+      })
+    }
+
+    return response as HttpResponse<BodyType>
   }
 
   /**
@@ -167,8 +209,9 @@ export class HttpResponse<
     init?: HttpResponseInit,
   ): HttpResponse<BodyType> {
     const responseInit = normalizeResponseInit(init)
+    const hasExplicitContentType = responseInit.headers.has('Content-Type')
 
-    if (!responseInit.headers.has('Content-Type')) {
+    if (!hasExplicitContentType) {
       responseInit.headers.set('Content-Type', 'application/octet-stream')
     }
 
@@ -176,7 +219,16 @@ export class HttpResponse<
       responseInit.headers.set('Content-Length', body.byteLength.toString())
     }
 
-    return new HttpResponse(body, responseInit)
+    const response = new HttpResponse(body, responseInit)
+
+    if (!hasExplicitContentType) {
+      Object.defineProperty(response, kDefaultContentType, {
+        value: true,
+        enumerable: false,
+      })
+    }
+
+    return response as HttpResponse<BodyType>
   }
 
   /**


### PR DESCRIPTION
- Prerequisite for #2513 

This is to help differentiate implicit headers added by `HttpResponse` and the same value headers added by the user. 