### PR TITLE
fix: ensure `RequestHandler` type is accepted in setup functions

### DIFF
--- a/src/core/experimental/handlers-controller.ts
+++ b/src/core/experimental/handlers-controller.ts
@@ -1,11 +1,10 @@
 import { invariant } from 'outvariant'
-import { type HttpHandler } from '../handlers/HttpHandler'
-import { type GraphQLHandler } from '../handlers/GraphQLHandler'
+import { type RequestHandler } from '../handlers/RequestHandler'
 import { type WebSocketHandler } from '../handlers/WebSocketHandler'
 import { devUtils } from '../utils/internal/devUtils'
 
-export type AnyHandler = HttpHandler | GraphQLHandler | WebSocketHandler
-export type HandlersMap = Partial<Record<string, Array<AnyHandler>>>
+export type AnyHandler = RequestHandler | WebSocketHandler
+export type HandlersMap = Partial<Record<AnyHandler['kind'], Array<AnyHandler>>>
 
 export function groupHandlersByKind(handlers: Array<AnyHandler>): HandlersMap {
   const groups: HandlersMap = {}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -26,11 +26,6 @@ export {
   type ServerSentEventMessage,
 } from './sse'
 
-import type { RequestHandler } from './handlers/RequestHandler'
-import type { WebSocketHandler } from './handlers/WebSocketHandler'
-
-export type AnyHandler = RequestHandler | WebSocketHandler
-
 /* Utils */
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'
 export { handleRequest, type HandleRequestOptions } from './utils/handleRequest'
@@ -45,6 +40,8 @@ export { cleanUrl } from './utils/url/cleanUrl'
 /**
  * Type definitions.
  */
+
+export type { AnyHandler } from './experimental/handlers-controller'
 
 export type { SharedOptions, LifeCycleEventsMap } from './sharedOptions'
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -26,11 +26,10 @@ export {
   type ServerSentEventMessage,
 } from './sse'
 
-import type { HttpHandler } from './handlers/HttpHandler'
-import type { GraphQLHandler } from './handlers/GraphQLHandler'
+import type { RequestHandler } from './handlers/RequestHandler'
 import type { WebSocketHandler } from './handlers/WebSocketHandler'
 
-export type AnyHandler = HttpHandler | GraphQLHandler | WebSocketHandler
+export type AnyHandler = RequestHandler | WebSocketHandler
 
 /* Utils */
 export { matchRequestUrl } from './utils/matching/matchRequestUrl'

--- a/test/typings/regressions/request-handler-type.test-d.ts
+++ b/test/typings/regressions/request-handler-type.test-d.ts
@@ -1,14 +1,28 @@
 /**
  * @see https://github.com/mswjs/msw/discussions/498
  */
-import { http, HttpResponse } from 'msw'
+import { http, HttpResponse, type RequestHandler } from 'msw'
 import { setupWorker } from 'msw/browser'
+import { setupServer } from 'msw/node'
+
+const handlers: Array<RequestHandler> = [
+  http.get('/resource', () => {
+    return HttpResponse.json({ data: 'abc-123' })
+  }),
+]
 
 it('does not conflict when passing request handlers to `setupWorker`', () => {
+  setupWorker(...handlers)
+})
+
+it('does not conflict when passing request handlers to `setupServer`', () => {
+  setupServer(...handlers)
+})
+
+it('does not conflict when inferring request handlers for `setupWorker`', () => {
   const resourceHandler = http.get('/resource', () => {
     return HttpResponse.json({ data: 'abc-123' })
   })
 
-  const handlers = [resourceHandler]
-  setupWorker(...handlers)
+  setupWorker(...[resourceHandler])
 })

--- a/test/typings/regressions/request-handler-type.test-d.ts
+++ b/test/typings/regressions/request-handler-type.test-d.ts
@@ -1,28 +1,76 @@
 /**
  * @see https://github.com/mswjs/msw/discussions/498
  */
-import { http, HttpResponse, type RequestHandler } from 'msw'
-import { setupWorker } from 'msw/browser'
+import {
+  http,
+  graphql,
+  HttpHandler,
+  ws,
+  RequestHandler,
+  type AnyHandler,
+  type WebSocketHandler,
+  type GraphQLHandler,
+} from 'msw'
 import { setupServer } from 'msw/node'
+import { setupWorker } from 'msw/browser'
 
-const handlers: Array<RequestHandler> = [
-  http.get('/resource', () => {
-    return HttpResponse.json({ data: 'abc-123' })
-  }),
-]
-
-it('does not conflict when passing request handlers to `setupWorker`', () => {
-  setupWorker(...handlers)
+it('handler types extend the AnyHandler type', () => {
+  expectTypeOf<RequestHandler>().toExtend<AnyHandler>()
+  expectTypeOf<HttpHandler>().toExtend<AnyHandler>()
+  expectTypeOf<GraphQLHandler>().toExtend<AnyHandler>()
+  expectTypeOf<WebSocketHandler>().toExtend<AnyHandler>()
 })
 
-it('does not conflict when passing request handlers to `setupServer`', () => {
-  setupServer(...handlers)
+it('http handlers extend the RequestHandler type', () => {
+  const handlers = [http.get('/', () => {})]
+
+  expectTypeOf<HttpHandler>().toExtend<RequestHandler>()
+  expectTypeOf(handlers).toExtend<Array<RequestHandler>>()
+  expectTypeOf(handlers).toEqualTypeOf<Array<HttpHandler>>()
 })
 
-it('does not conflict when inferring request handlers for `setupWorker`', () => {
-  const resourceHandler = http.get('/resource', () => {
-    return HttpResponse.json({ data: 'abc-123' })
-  })
+it('graphql handlers extend the RequestHandler type', () => {
+  const handlers = [graphql.query('GetUser', () => {})]
 
-  setupWorker(...[resourceHandler])
+  expectTypeOf<GraphQLHandler>().toExtend<RequestHandler>()
+  expectTypeOf(handlers).toExtend<Array<RequestHandler>>()
+  expectTypeOf(handlers).toEqualTypeOf<Array<GraphQLHandler>>()
+})
+
+it('a list of http and graphql handlers extend the RequestHandler type', () => {
+  const handlers = [http.get('/', () => {}), graphql.query('GetUser', () => {})]
+
+  expectTypeOf(handlers).toExtend<Array<RequestHandler>>()
+  expectTypeOf(handlers).toEqualTypeOf<Array<HttpHandler | GraphQLHandler>>()
+})
+
+it('websocket handler extends the WebSocketHandler type', () => {
+  expectTypeOf([ws.link('/').addEventListener('connection', () => {})])
+    .toEqualTypeOf<Array<WebSocketHandler>>
+})
+
+it('accepts different handler types in setupWorker', () => {
+  expectTypeOf(setupWorker).parameters.toEqualTypeOf<Array<AnyHandler>>()
+  expectTypeOf(setupWorker).parameters.toExtend<
+    Array<RequestHandler | WebSocketHandler>
+  >()
+})
+
+it('accepts narrower handler types in setupWorker', () => {
+  setupWorker(...([] as Array<HttpHandler>))
+  setupWorker(...([] as Array<GraphQLHandler>))
+  setupWorker(...([] as Array<WebSocketHandler>))
+})
+
+it('accepts different handler types in setupServer', () => {
+  expectTypeOf(setupServer).parameters.toEqualTypeOf<Array<AnyHandler>>()
+  expectTypeOf(setupServer).parameters.toExtend<
+    Array<RequestHandler | WebSocketHandler>
+  >()
+})
+
+it('accepts narrower handler types in setupServer', () => {
+  setupServer(...([] as Array<HttpHandler>))
+  setupServer(...([] as Array<GraphQLHandler>))
+  setupServer(...([] as Array<WebSocketHandler>))
 })


### PR DESCRIPTION
## Summary
- accept base `RequestHandler` instances in the shared `AnyHandler` type
- keep `setupWorker` and `setupServer` compatible with explicitly typed `RequestHandler[]` arrays
- add regression coverage for both setup APIs

## Verification
- pnpm build
- pnpm test:ts
- pnpm test:unit -- --run src/core/experimental/handlers-controller.test.ts test/node/msw-api/setup-server/listHandlers.node.test.ts
- pnpm lint

Fixes the compatibility gap reported while testing #2650, where arrays typed as `RequestHandler[]` no longer spread into `setupWorker`/`setupServer`.