### PR TITLE
fix: support wildcard ports in url matching

### DIFF
--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -93,7 +93,7 @@ describe('matchRequestUrl', () => {
       .toEqual({
         matches: true,
         params: {
-          '0': '3000',
+          '0': '3000/',
         },
       })
 

--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -130,6 +130,42 @@ describe('matchRequestUrl', () => {
       },
     })
   })
+
+  test('returns true when matching URLs with wildcard ports', () => {
+    expect(
+      matchRequestUrl(new URL('http://localhost:3000'), 'http://localhost:*'),
+    ).toEqual({
+      matches: true,
+      params: {
+        '0': '3000/',
+      },
+    })
+  })
+
+  test('returns true when matching URLs with wildcard ports and pathnames', () => {
+    expect(
+      matchRequestUrl(
+        new URL('http://localhost:3000/resource'),
+        'http://localhost:*/resource',
+      ),
+    ).toEqual({
+      matches: true,
+      params: {
+        '0': '3000',
+      },
+    })
+  })
+
+  test('returns true for matching WebSocket URLs with wildcard ports', () => {
+    expect(
+      matchRequestUrl(new URL('ws://localhost:3000'), 'ws://localhost:*'),
+    ).toEqual({
+      matches: true,
+      params: {
+        '0': '3000/',
+      },
+    })
+  })
 })
 
 describe('coercePath', () => {
@@ -156,6 +192,10 @@ describe('coercePath', () => {
     expect(coercePath('https://example.com:8080/:5678')).toEqual(
       'https\\://example.com\\:8080/:5678',
     )
+    expect(coercePath('http://localhost:*')).toEqual(
+      'http\\://localhost\\:(.*)',
+    )
+    expect(coercePath('ws://localhost:*')).toEqual('ws\\://localhost\\:(.*)')
   })
 
   test('replaces wildcard with an unnnamed capturing group', () => {

--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 import { coercePath, matchRequestUrl } from './matchRequestUrl'
 
 describe('matchRequestUrl', () => {
@@ -87,6 +85,77 @@ describe('matchRequestUrl', () => {
     })
   })
 
+  test('returns true when matching URLs with wildcard ports', () => {
+    expect
+      .soft(
+        matchRequestUrl(new URL('http://localhost:3000'), 'http://localhost:*'),
+      )
+      .toEqual({
+        matches: true,
+        params: {
+          '0': '3000',
+        },
+      })
+
+    expect
+      .soft(
+        matchRequestUrl(
+          new URL('http://localhost:3000'),
+          'http://localhost:*/',
+        ),
+      )
+      .toEqual({
+        matches: true,
+        params: {
+          '0': '3000',
+        },
+      })
+  })
+
+  test('returns true when matching URLs with wildcard ports and pathnames', () => {
+    expect(
+      matchRequestUrl(
+        new URL('http://localhost:3000/resource'),
+        'http://localhost:*/resource',
+      ),
+    ).toEqual({
+      matches: true,
+      params: {
+        '0': '3000',
+      },
+    })
+  })
+
+  test('matches wildcard ports with other wildcard parameters', () => {
+    expect(
+      matchRequestUrl(
+        new URL('http://subdomain.localhost:3000/user/settings'),
+        'http://*.localhost:*/user/*',
+      ),
+    ).toEqual({
+      matches: true,
+      params: {
+        '0': 'subdomain',
+        '1': '3000',
+        '2': 'settings',
+      },
+    })
+  })
+
+  test('matches wildcard ports that also match a part of the pathname', () => {
+    expect(
+      matchRequestUrl(
+        new URL('http://localhost:3000/user/settings'),
+        'http://localhost:*/settings',
+      ),
+    ).toEqual({
+      matches: true,
+      params: {
+        '0': '3000/user',
+      },
+    })
+  })
+
   test('returns true for matching WebSocket URL', () => {
     expect(
       matchRequestUrl(new URL('ws://test.mswjs.io'), 'ws://test.mswjs.io'),
@@ -127,31 +196,6 @@ describe('matchRequestUrl', () => {
       matches: true,
       params: {
         service: 'test',
-      },
-    })
-  })
-
-  test('returns true when matching URLs with wildcard ports', () => {
-    expect(
-      matchRequestUrl(new URL('http://localhost:3000'), 'http://localhost:*'),
-    ).toEqual({
-      matches: true,
-      params: {
-        '0': '3000/',
-      },
-    })
-  })
-
-  test('returns true when matching URLs with wildcard ports and pathnames', () => {
-    expect(
-      matchRequestUrl(
-        new URL('http://localhost:3000/resource'),
-        'http://localhost:*/resource',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {
-        '0': '3000',
       },
     })
   })

--- a/src/core/utils/matching/matchRequestUrl.ts
+++ b/src/core/utils/matching/matchRequestUrl.ts
@@ -40,9 +40,9 @@ export function coercePath(path: string): string {
       )
       /**
        * Escape the port so that "path-to-regexp" can match
-       * absolute URLs including port numbers.
+       * absolute URLs with numeric or wildcard ports.
        */
-      .replace(/([^/])(:)(?=\d+)/, '$1\\$2')
+      .replace(/([^/])(:)(?=(?:\d+|\(\.\*\))(?=\/|$))/, '$1\\$2')
       /**
        * Escape the protocol so that "path-to-regexp" could match
        * absolute URL.


### PR DESCRIPTION
Support absolute URLs that use wildcard ports in request matching.

MSW already coerces request masks before passing them to `path-to-regexp`. Numeric ports were escaped there, but wildcard ports like `http://localhost:*` were left as `:(.*)`, which `path-to-regexp` interprets as an invalid parameter declaration and throws.

This updates `coercePath()` to escape the port separator when the port is either numeric or a wildcard-expanded capture group. It also adds regression tests for HTTP and WebSocket URLs, including a pathname case.

This keeps the current `path-to-regexp`-based matching behavior intact instead of broadening the fix into a larger matcher change.

Fixes #2204