### PR TITLE
feat!: migrate to `@msw/url`

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
   "sideEffects": false,
   "dependencies": {
     "@inquirer/confirm": "^5.0.0",
+    "@msw/url": "^0.0.2",
     "@mswjs/interceptors": "^0.41.2",
     "@open-draft/deferred-promise": "^2.2.0",
     "@types/statuses": "^2.0.6",
@@ -246,7 +247,6 @@
     "headers-polyfill": "^4.0.2",
     "is-node-process": "^1.2.0",
     "outvariant": "^1.4.3",
-    "path-to-regexp": "^6.3.0",
     "picocolors": "^1.1.1",
     "rettime": "^0.10.1",
     "statuses": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
   "sideEffects": false,
   "dependencies": {
     "@inquirer/confirm": "^5.0.0",
-    "@msw/url": "^0.0.2",
+    "@msw/url": "^0.1.0",
     "@mswjs/interceptors": "^0.41.2",
     "@open-draft/deferred-promise": "^2.2.0",
     "@types/statuses": "^2.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.2(@types/node@20.19.25)
       '@msw/url':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.1.0
+        version: 0.1.0
       '@mswjs/interceptors':
         specifier: ^0.41.2
         version: 0.41.2
@@ -955,8 +955,8 @@ packages:
     resolution: {integrity: sha512-stTxvLdJ2IcGOs76AnvGYAzGvx8JvQPRxC5DW0P5zdAAnhL33noqb5LKdPt3P37BKp9FzBKZHuihQI9oVqwm0g==}
     engines: {node: '>=16.13'}
 
-  '@msw/url@0.0.2':
-    resolution: {integrity: sha512-INra0REan1xMRZGbrpgbGeCoBLQTcc23bPf+uRUwzQNoMogAo/tMKDuRlt+xUTQ/7H20DHgLs9t9Q1GEntrdbQ==}
+  '@msw/url@0.1.0':
+    resolution: {integrity: sha512-UPCjI5lITlbAerHQiTJT4F/Fqqeai/vLyUhnRLKDSXbLSoYcR2JEvJfnngSw8G7+0BI2488fDrfVDuv4pTqC6g==}
 
   '@mswjs/interceptors@0.41.2':
     resolution: {integrity: sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==}
@@ -6055,7 +6055,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@msw/url@0.0.2': {}
+  '@msw/url@0.1.0': {}
 
   '@mswjs/interceptors@0.41.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@inquirer/confirm':
         specifier: ^5.0.0
         version: 5.0.2(@types/node@20.19.25)
+      '@msw/url':
+        specifier: ^0.0.2
+        version: 0.0.2
       '@mswjs/interceptors':
         specifier: ^0.41.2
         version: 0.41.2
@@ -35,9 +38,6 @@ importers:
       outvariant:
         specifier: ^1.4.3
         version: 1.4.3
-      path-to-regexp:
-        specifier: ^6.3.0
-        version: 6.3.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -954,6 +954,9 @@ packages:
   '@miniflare/web-sockets@2.14.4':
     resolution: {integrity: sha512-stTxvLdJ2IcGOs76AnvGYAzGvx8JvQPRxC5DW0P5zdAAnhL33noqb5LKdPt3P37BKp9FzBKZHuihQI9oVqwm0g==}
     engines: {node: '>=16.13'}
+
+  '@msw/url@0.0.2':
+    resolution: {integrity: sha512-INra0REan1xMRZGbrpgbGeCoBLQTcc23bPf+uRUwzQNoMogAo/tMKDuRlt+xUTQ/7H20DHgLs9t9Q1GEntrdbQ==}
 
   '@mswjs/interceptors@0.41.2':
     resolution: {integrity: sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==}
@@ -4039,9 +4042,6 @@ packages:
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
-  path-to-regexp@6.3.0:
-    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
   path-to-regexp@8.2.0:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
@@ -6054,6 +6054,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@msw/url@0.0.2': {}
 
   '@mswjs/interceptors@0.41.2':
     dependencies:
@@ -9407,8 +9409,6 @@ snapshots:
       minipass: 7.1.2
 
   path-to-regexp@0.1.7: {}
-
-  path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.2.0: {}
 

--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -45,3 +45,27 @@ it('ignores query parameters when matching against a RegExp', () => {
     params: {},
   })
 })
+
+it('parses matching RegExp groups into index-based parameters', () => {
+  expect(
+    matchRequestUrl(new URL('https://test.mswjs.io/path'), /(.+)\.mswjs\.io/g),
+  ).toEqual({
+    matches: true,
+    params: {
+      0: 'https://test',
+    },
+  })
+
+  expect(
+    matchRequestUrl(
+      new URL('https://test.mswjs.io/path'),
+      /https:\/\/(.+)\.mswjs\.io\/(.+)/g,
+    ),
+  ).toEqual({
+    matches: true,
+    params: {
+      0: 'test',
+      1: 'path',
+    },
+  })
+})

--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -1,213 +1,47 @@
 // @vitest-environment jsdom
 import { matchRequestUrl } from './matchRequestUrl'
 
-describe(matchRequestUrl, () => {
-  test('returns true when matches against an exact URL', () => {
-    expect(
-      matchRequestUrl(
-        new URL('https://test.mswjs.io'),
-        'https://test.mswjs.io',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {},
-    })
+it('returns true when matched against a string URL', () => {
+  expect(
+    matchRequestUrl(new URL('https://test.mswjs.io'), 'https://test.mswjs.io'),
+  ).toEqual({
+    matches: true,
+    params: {},
   })
+})
 
-  test('returns true when matched against a wildcard', () => {
-    expect(matchRequestUrl(new URL('https://test.mswjs.io'), '*')).toEqual({
-      matches: true,
-      params: {
-        '0': 'https://test.mswjs.io/',
-      },
-    })
+it('returns false when a string URL does not match', () => {
+  expect(
+    matchRequestUrl(new URL('https://test.mswjs.io'), 'https://google.com'),
+  ).toEqual({
+    matches: false,
+    params: {},
   })
+})
 
-  test('returns true when matched against a RegExp', () => {
-    expect(
-      matchRequestUrl(new URL('https://test.mswjs.io'), /test\.mswjs\.io/),
-    ).toEqual({
-      matches: true,
-      params: {},
-    })
+it('returns true when matched against a RegExp', () => {
+  expect(
+    matchRequestUrl(new URL('https://test.mswjs.io'), /test\.mswjs\.io/),
+  ).toEqual({
+    matches: true,
+    params: {},
   })
+})
 
-  test('returns path parameters when matched', () => {
-    expect(
-      matchRequestUrl(
-        new URL('https://test.mswjs.io/user/abc-123'),
-        'https://test.mswjs.io/user/:userId',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {
-        userId: 'abc-123',
-      },
-    })
-  })
-
-  test('decodes path parameters', () => {
-    const url = 'http://example.com:5001/example'
-
-    expect(
-      matchRequestUrl(
-        new URL(`https://test.mswjs.io/reflect-url/${encodeURIComponent(url)}`),
-        'https://test.mswjs.io/reflect-url/:url',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {
-        url,
-      },
-    })
-  })
-
-  test('returns false when does not match against the request URL', () => {
-    expect(
-      matchRequestUrl(new URL('https://test.mswjs.io'), 'https://google.com'),
-    ).toEqual({
+it('returns false when a RegExp does not match', () => {
+  expect(matchRequestUrl(new URL('https://test.mswjs.io'), /foo\.bar/)).toEqual(
+    {
       matches: false,
       params: {},
-    })
-  })
+    },
+  )
+})
 
-  test('returns true when matching optional path parameters', () => {
-    expect(
-      matchRequestUrl(
-        new URL('https://test.mswjs.io/user/123'),
-        'https://test.mswjs.io/user/:userId?',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {
-        userId: '123',
-      },
-    })
-  })
-
-  test('returns true when matching URLs with wildcard ports', () => {
-    expect
-      .soft(
-        matchRequestUrl(new URL('http://localhost:3000'), 'http://localhost:*'),
-      )
-      .toEqual({
-        matches: true,
-        params: {
-          '0': '3000/',
-        },
-      })
-
-    expect
-      .soft(
-        matchRequestUrl(
-          new URL('http://localhost:3000'),
-          'http://localhost:*/',
-        ),
-      )
-      .toEqual({
-        matches: true,
-        params: {
-          '0': '3000',
-        },
-      })
-  })
-
-  test('returns true when matching URLs with wildcard ports and pathnames', () => {
-    expect(
-      matchRequestUrl(
-        new URL('http://localhost:3000/resource'),
-        'http://localhost:*/resource',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {
-        '0': '3000',
-      },
-    })
-  })
-
-  test('matches wildcard ports with other wildcard parameters', () => {
-    expect(
-      matchRequestUrl(
-        new URL('http://subdomain.localhost:3000/user/settings'),
-        'http://*.localhost:*/user/*',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {
-        '0': 'subdomain',
-        '1': '3000',
-        '2': 'settings',
-      },
-    })
-  })
-
-  test('matches wildcard ports that also match a part of the pathname', () => {
-    expect(
-      matchRequestUrl(
-        new URL('http://localhost:3000/user/settings'),
-        'http://localhost:*/settings',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {
-        '0': '3000/user',
-      },
-    })
-  })
-
-  test('returns true for matching WebSocket URL', () => {
-    expect(
-      matchRequestUrl(new URL('ws://test.mswjs.io'), 'ws://test.mswjs.io'),
-    ).toEqual({
-      matches: true,
-      params: {},
-    })
-    expect(
-      matchRequestUrl(new URL('wss://test.mswjs.io'), 'wss://test.mswjs.io'),
-    ).toEqual({
-      matches: true,
-      params: {},
-    })
-  })
-
-  test('returns false for non-matching WebSocket URL', () => {
-    expect(
-      matchRequestUrl(new URL('ws://test.mswjs.io'), 'ws://foo.mswjs.io'),
-    ).toEqual({
-      matches: false,
-      params: {},
-    })
-    expect(
-      matchRequestUrl(new URL('wss://test.mswjs.io'), 'wss://completely.diff'),
-    ).toEqual({
-      matches: false,
-      params: {},
-    })
-  })
-
-  test('returns path parameters when matched a WebSocket URL', () => {
-    expect(
-      matchRequestUrl(
-        new URL('wss://test.mswjs.io'),
-        'wss://:service.mswjs.io',
-      ),
-    ).toEqual({
-      matches: true,
-      params: {
-        service: 'test',
-      },
-    })
-  })
-
-  test('returns true for matching WebSocket URLs with wildcard ports', () => {
-    expect(
-      matchRequestUrl(new URL('ws://localhost:3000'), 'ws://localhost:*'),
-    ).toEqual({
-      matches: true,
-      params: {
-        '0': '3000/',
-      },
-    })
+it('ignores query parameters when matching against a RegExp', () => {
+  expect(
+    matchRequestUrl(new URL('https://test.mswjs.io/path?foo=bar'), /\/path$/),
+  ).toEqual({
+    matches: true,
+    params: {},
   })
 })

--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -1,9 +1,7 @@
-/**
- * @vitest-environment jsdom
- */
-import { coercePath, matchRequestUrl } from './matchRequestUrl'
+// @vitest-environment jsdom
+import { matchRequestUrl } from './matchRequestUrl'
 
-describe('matchRequestUrl', () => {
+describe(matchRequestUrl, () => {
   test('returns true when matches against an exact URL', () => {
     expect(
       matchRequestUrl(
@@ -129,55 +127,5 @@ describe('matchRequestUrl', () => {
         service: 'test',
       },
     })
-  })
-})
-
-describe('coercePath', () => {
-  test('escapes the colon in protocol', () => {
-    expect(coercePath('https://example.com')).toEqual('https\\://example.com')
-    expect(coercePath('https://example.com/:userId')).toEqual(
-      'https\\://example.com/:userId',
-    )
-    expect(coercePath('http://localhost:3000')).toEqual(
-      'http\\://localhost\\:3000',
-    )
-  })
-
-  test('escapes the colon before the port number', () => {
-    expect(coercePath('localhost:8080')).toEqual('localhost\\:8080')
-    expect(coercePath('http://127.0.0.1:8080')).toEqual(
-      'http\\://127.0.0.1\\:8080',
-    )
-    expect(coercePath('https://example.com:1234')).toEqual(
-      'https\\://example.com\\:1234',
-    )
-
-    expect(coercePath('localhost:8080/:5678')).toEqual('localhost\\:8080/:5678')
-    expect(coercePath('https://example.com:8080/:5678')).toEqual(
-      'https\\://example.com\\:8080/:5678',
-    )
-  })
-
-  test('replaces wildcard with an unnnamed capturing group', () => {
-    expect(coercePath('*')).toEqual('(.*)')
-    expect(coercePath('**')).toEqual('(.*)')
-    expect(coercePath('/us*')).toEqual('/us(.*)')
-    expect(coercePath('/user/*')).toEqual('/user/(.*)')
-    expect(coercePath('https://example.com/user/*')).toEqual(
-      'https\\://example.com/user/(.*)',
-    )
-    expect(coercePath('https://example.com/us*')).toEqual(
-      'https\\://example.com/us(.*)',
-    )
-  })
-
-  test('preserves path parameter modifiers', () => {
-    expect(coercePath(':name*')).toEqual(':name*')
-    expect(coercePath('/foo/:name*')).toEqual('/foo/:name*')
-    expect(coercePath('/foo/**:name*')).toEqual('/foo/(.*):name*')
-    expect(coercePath('**/foo/*/:name*')).toEqual('(.*)/foo/(.*)/:name*')
-    expect(coercePath('/foo/:first/bar/:second*/*')).toEqual(
-      '/foo/:first/bar/:second*/(.*)',
-    )
   })
 })

--- a/src/core/utils/matching/matchRequestUrl.test.ts
+++ b/src/core/utils/matching/matchRequestUrl.test.ts
@@ -35,6 +35,25 @@ it('returns false when a RegExp does not match', () => {
       params: {},
     },
   )
+
+  expect(
+    matchRequestUrl(new URL('https://test.mswjs.io'), /foo\.bar/g),
+  ).toEqual({
+    matches: false,
+    params: {},
+  })
+
+  expect(matchRequestUrl(new URL('https://test.mswjs.io'), /foo(.+)/)).toEqual({
+    matches: false,
+    params: {},
+  })
+
+  expect(matchRequestUrl(new URL('https://test.mswjs.io'), /foo(.+)/g)).toEqual(
+    {
+      matches: false,
+      params: {},
+    },
+  )
 })
 
 it('ignores query parameters when matching against a RegExp', () => {

--- a/src/core/utils/matching/matchRequestUrl.ts
+++ b/src/core/utils/matching/matchRequestUrl.ts
@@ -35,5 +35,5 @@ export function matchRequestUrl(
 
   // Resolve potentially realive patterns against the baseUrl.
   const normalizedPath = normalizePath(pattern, baseUrl)
-  return matchPattern(cleanUrl, normalizedPath)
+  return matchPattern(normalizedPath, cleanUrl)
 }

--- a/src/core/utils/matching/matchRequestUrl.ts
+++ b/src/core/utils/matching/matchRequestUrl.ts
@@ -32,7 +32,7 @@ export function matchRequestUrl(
       : cleanUrl.match(pattern)
 
     return {
-      matches: match != null,
+      matches: match != null && match.length > 0,
       params: Object.fromEntries(
         (match ?? []).slice(1).map((value, index) => [index, value]),
       ),

--- a/src/core/utils/matching/matchRequestUrl.ts
+++ b/src/core/utils/matching/matchRequestUrl.ts
@@ -27,9 +27,15 @@ export function matchRequestUrl(
   const cleanUrl = getCleanUrl(url)
 
   if (pattern instanceof RegExp) {
+    const match = pattern.flags.includes('g')
+      ? [...cleanUrl.matchAll(pattern)].flat()
+      : cleanUrl.match(pattern)
+
     return {
-      matches: pattern.test(cleanUrl),
-      params: {},
+      matches: match != null,
+      params: Object.fromEntries(
+        (match ?? []).slice(1).map((value, index) => [index, value]),
+      ),
     }
   }
 

--- a/src/core/utils/matching/matchRequestUrl.ts
+++ b/src/core/utils/matching/matchRequestUrl.ts
@@ -1,4 +1,4 @@
-import { match } from 'path-to-regexp'
+import { matchPattern } from '@msw/url'
 import { getCleanUrl } from '@mswjs/interceptors'
 import { normalizePath } from './normalizePath'
 
@@ -12,66 +12,28 @@ export interface Match {
   params?: PathParams
 }
 
-/**
- * Coerce a path supported by MSW into a path
- * supported by "path-to-regexp".
- */
-export function coercePath(path: string): string {
-  return (
-    path
-      /**
-       * Replace wildcards ("*") with unnamed capturing groups
-       * because "path-to-regexp" doesn't support wildcards.
-       * Ignore path parameter' modifiers (i.e. ":name*").
-       */
-      .replace(
-        /([:a-zA-Z_-]*)(\*{1,2})+/g,
-        (_, parameterName: string | undefined, wildcard: string) => {
-          const expression = '(.*)'
-
-          if (!parameterName) {
-            return expression
-          }
-
-          return parameterName.startsWith(':')
-            ? `${parameterName}${wildcard}`
-            : `${parameterName}${expression}`
-        },
-      )
-      /**
-       * Escape the port so that "path-to-regexp" can match
-       * absolute URLs including port numbers.
-       */
-      .replace(/([^/])(:)(?=\d+)/, '$1\\$2')
-      /**
-       * Escape the protocol so that "path-to-regexp" could match
-       * absolute URL.
-       * @see https://github.com/pillarjs/path-to-regexp/issues/259
-       */
-      .replace(/^([^/]+)(:)(?=\/\/)/, '$1\\$2')
-  )
-}
-
-/**
- * Returns the result of matching given request URL against a mask.
- */
-export function matchRequestUrl(url: URL, path: Path, baseUrl?: string): Match {
-  const normalizedPath = normalizePath(path, baseUrl)
-  const cleanPath =
-    typeof normalizedPath === 'string'
-      ? coercePath(normalizedPath)
-      : normalizedPath
-
-  const cleanUrl = getCleanUrl(url)
-  const result = match(cleanPath, { decode: decodeURIComponent })(cleanUrl)
-  const params = (result && (result.params as PathParams)) || {}
-
-  return {
-    matches: result !== false,
-    params,
-  }
-}
-
 export function isPath(value: unknown): value is Path {
   return typeof value === 'string' || value instanceof RegExp
+}
+
+/**
+ * Match the given URL against a path pattern.
+ */
+export function matchRequestUrl(
+  url: URL,
+  pattern: Path,
+  baseUrl?: string,
+): Match {
+  const cleanUrl = getCleanUrl(url)
+
+  if (pattern instanceof RegExp) {
+    return {
+      matches: pattern.test(cleanUrl),
+      params: {},
+    }
+  }
+
+  // Resolve potentially realive patterns against the baseUrl.
+  const normalizedPath = normalizePath(pattern, baseUrl)
+  return matchPattern(cleanUrl, normalizedPath)
 }

--- a/src/core/utils/matching/normalizePath.ts
+++ b/src/core/utils/matching/normalizePath.ts
@@ -10,7 +10,7 @@ import { getAbsoluteUrl } from '../url/getAbsoluteUrl'
  * - Preserves relative URLs in Node.js, unless specified otherwise.
  * - Preserves optional path parameters.
  */
-export function normalizePath(path: Path, baseUrl?: string): Path {
+export function normalizePath<P extends Path>(path: P, baseUrl?: string): P {
   // RegExp paths do not need normalization.
   if (path instanceof RegExp) {
     return path
@@ -18,5 +18,5 @@ export function normalizePath(path: Path, baseUrl?: string): Path {
 
   const maybeAbsoluteUrl = getAbsoluteUrl(path, baseUrl)
 
-  return cleanUrl(maybeAbsoluteUrl)
+  return cleanUrl(maybeAbsoluteUrl) as P
 }

--- a/test/browser/ws-api/ws.clients.browser.test.ts
+++ b/test/browser/ws-api/ws.clients.browser.test.ts
@@ -228,7 +228,9 @@ test('clears the list of clients when the worker is stopped', async ({
   // Must purge the local storage on reload.
   // The worker has been started as a part of the test, not runtime,
   // so it will start with empty clients.
-  await expect(page.evaluate(() => window.link.clients.size)).resolves.toBe(0)
+  await expect(
+    page.waitForFunction(() => window.link.clients.size === 0),
+  ).resolves.toBeTruthy()
 })
 
 test('clears the list of clients when the page is reloaded', async ({
@@ -252,7 +254,9 @@ test('clears the list of clients when the page is reloaded', async ({
 
   await enableMocking()
 
-  await expect(page.evaluate(() => window.link.clients.size)).resolves.toBe(0)
+  await expect(
+    page.waitForFunction(() => window.link.clients.size === 0),
+  ).resolves.toBeTruthy()
 
   await page.evaluate(async () => {
     const ws = new WebSocket('wss://example.com')
@@ -270,5 +274,7 @@ test('clears the list of clients when the page is reloaded', async ({
   // Must purge the local storage on reload.
   // The worker has been started as a part of the test, not runtime,
   // so it will start with empty clients.
-  await expect(page.evaluate(() => window.link.clients.size)).resolves.toBe(0)
+  await expect(
+    page.waitForFunction(() => window.link.clients.size === 0),
+  ).resolves.toBeTruthy()
 })

--- a/test/node/rest-api/request/matching/all.node.test.ts
+++ b/test/node/rest-api/request/matching/all.node.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment node
- */
+// @vitest-environment node
 import { HttpServer } from '@open-draft/test-server/http'
 import { HttpMethods, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'

--- a/test/node/rest-api/request/matching/path-params-optional.node.test.ts
+++ b/test/node/rest-api/request/matching/path-params-optional.node.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment node
- */
+// @vitest-environment node
 import { HttpResponse, http } from 'msw'
 import { setupServer } from 'msw/node'
 
@@ -18,7 +16,7 @@ afterAll(() => {
   server.close()
 })
 
-it('intercepts the request that fully matches the path', async () => {
+it('intercepts a request that fully matches the path', async () => {
   server.use(
     http.get('http://localhost/user/:id?', () =>
       HttpResponse.json({ mocked: true }),
@@ -26,11 +24,11 @@ it('intercepts the request that fully matches the path', async () => {
   )
 
   const response = await fetch('http://localhost/user/123')
-  expect(response.status).toBe(200)
-  expect(await response.json()).toEqual({ mocked: true })
+  expect.soft(response.status).toBe(200)
+  await expect.soft(response.json()).resolves.toEqual({ mocked: true })
 })
 
-it('intercepts the request that partially matches the path', async () => {
+it('intercepts a request that partially matches the path', async () => {
   server.use(
     http.get('http://localhost/user/:id?', () =>
       HttpResponse.json({ mocked: true }),
@@ -38,6 +36,6 @@ it('intercepts the request that partially matches the path', async () => {
   )
 
   const response = await fetch('http://localhost/user')
-  expect(response.status).toBe(200)
-  expect(await response.json()).toEqual({ mocked: true })
+  expect.soft(response.status).toBe(200)
+  await expect.soft(response.json()).resolves.toEqual({ mocked: true })
 })


### PR DESCRIPTION
- Fixes #2204 
- Closes https://github.com/mswjs/msw/pull/2677
- Closes https://github.com/mswjs/msw/pull/2209

## ⚠️ BREAKING CHANGES

- You can no longer list RegExp tokens in string predicates for requests. You can still provide a `RegExp` instance for matching, listing those tokens. The mix isn't supported anymore.

## Changes

- Migrates from `path-to-regexp` to an in-house [`@msw/url`](https://github.com/mswjs/url). Path matching is no longer regexp-based but token-based. Better performance, fewer vulnerabilities.
- Improves path matching performance in certain scenarios (`@msw/url` is faster than `path-to-regexp` in most scenarios, in others the performance is roughly the same).
- Refactors the related functionality in MSW.
- No breaking changes expected. 

## Todos

- [x] Rewrite `matchRequestUrl.test.ts`. No need to assert what `matchPattern` does already. Actually test what the function does: handles `RegExp`, cleans urls, normalizes the path, and 1-2 simple absolute/relative url matches for posterity.
- [x] Check the `params` value for matching against `RegExp` in `path-to-regexp`. If it returned index-based capturing groups, implement that. 