### PR TITLE
fix(browser): reject duplicate setupWorker calls

### DIFF
--- a/src/browser/setupWorker/setupWorker.ts
+++ b/src/browser/setupWorker/setupWorker.ts
@@ -24,6 +24,8 @@ import { printStartMessage } from './start/utils/printStartMessage'
 import { printStopMessage } from './stop/utils/printStopMessage'
 import { supportsServiceWorker } from '../utils/supports'
 
+const SETUP_WORKER_APPLIED = Symbol.for('msw.setupWorker')
+
 export class SetupWorkerApi
   extends SetupApi<LifeCycleEventsMap>
   implements SetupWorker
@@ -180,5 +182,15 @@ export class SetupWorkerApi
 export function setupWorker(
   ...handlers: Array<RequestHandler | WebSocketHandler>
 ): SetupWorker {
-  return new SetupWorkerApi(...handlers)
+  invariant(
+    Reflect.get(globalThis, SETUP_WORKER_APPLIED) == null,
+    devUtils.formatMessage(
+      'Failed to execute `setupWorker()` more than once in the same page. Create the worker once and reuse it for the lifetime of the page. If you wish to apply a different set of request handlers, use `worker.use()` or `worker.resetHandlers()` instead.',
+    ),
+  )
+
+  const worker = new SetupWorkerApi(...handlers)
+  Reflect.set(globalThis, SETUP_WORKER_APPLIED, true)
+
+  return worker
 }

--- a/src/browser/setupWorker/setupWorker.ts
+++ b/src/browser/setupWorker/setupWorker.ts
@@ -24,7 +24,7 @@ import { printStartMessage } from './start/utils/printStartMessage'
 import { printStopMessage } from './stop/utils/printStopMessage'
 import { supportsServiceWorker } from '../utils/supports'
 
-const SETUP_WORKER_APPLIED = Symbol.for('msw.setupWorker')
+const kSetupWorkerApplied = Symbol.for('msw.setupWorkerApplied')
 
 export class SetupWorkerApi
   extends SetupApi<LifeCycleEventsMap>
@@ -183,14 +183,14 @@ export function setupWorker(
   ...handlers: Array<RequestHandler | WebSocketHandler>
 ): SetupWorker {
   invariant(
-    Reflect.get(globalThis, SETUP_WORKER_APPLIED) == null,
+    Reflect.get(globalThis, kSetupWorkerApplied) == null,
     devUtils.formatMessage(
       'Failed to execute `setupWorker()` more than once in the same page. Create the worker once and reuse it for the lifetime of the page. If you wish to apply a different set of request handlers, use `worker.use()` or `worker.resetHandlers()` instead.',
     ),
   )
 
   const worker = new SetupWorkerApi(...handlers)
-  Reflect.set(globalThis, SETUP_WORKER_APPLIED, true)
+  Reflect.set(globalThis, kSetupWorkerApplied, true)
 
   return worker
 }

--- a/test/browser/msw-api/setup-worker/multiple-instances.mocks.ts
+++ b/test/browser/msw-api/setup-worker/multiple-instances.mocks.ts
@@ -1,0 +1,7 @@
+import { setupWorker } from 'msw/browser'
+
+Object.assign(window, {
+  msw: {
+    setupWorker,
+  },
+})

--- a/test/browser/msw-api/setup-worker/multiple-instances.test.ts
+++ b/test/browser/msw-api/setup-worker/multiple-instances.test.ts
@@ -1,0 +1,36 @@
+import type { setupWorker } from 'msw/browser'
+import { test, expect } from '../../playwright.extend'
+
+declare namespace window {
+  export const msw: {
+    setupWorker: typeof setupWorker
+  }
+}
+
+test('throws an error when calling "setupWorker()" more than once on the same page', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(new URL('./multiple-instances.mocks.ts', import.meta.url), {
+    skipActivation: true,
+  })
+
+  await page.waitForFunction(() => {
+    return typeof window.msw !== 'undefined'
+  })
+
+  const errorMessage = await page.evaluate(() => {
+    window.msw.setupWorker()
+
+    try {
+      window.msw.setupWorker()
+      return null
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error)
+    }
+  })
+
+  expect(errorMessage).toContain(
+    '[MSW] Failed to execute `setupWorker()` more than once',
+  )
+})


### PR DESCRIPTION
Reject duplicate `setupWorker()` calls in the same page by guarding initialization with a page-global symbol. This makes the failure explicit before multiple worker instances can attach conflicting browser-side listeners.

The browser worker state is shared per page, so creating multiple setupWorker instances is ambiguous and leads to clashing request handling. Failing fast here keeps `setupWorker()` as a single-construction API and points users toward reusing the existing worker with `worker.use()` or `worker.resetHandlers()`.

This also adds a browser regression test for the duplicate call path while asserting only on a stable error prefix so the developer-facing guidance can still evolve.

Fixes #2585