### PR TITLE
fix(browser): restore setupWorker lifecycle

### DIFF
--- a/src/browser/setup-worker.ts
+++ b/src/browser/setup-worker.ts
@@ -66,7 +66,50 @@ export function setupWorker(...handlers: Array<AnyHandler>): SetupWorkerApi {
     handlers,
   })
 
+  const webSocketSource = new InterceptorSource({
+    interceptors: [new WebSocketInterceptor() as any],
+  })
+
   let isStarted = false
+  let currentRegistration: ServiceWorkerRegistration | undefined
+  let currentStart: Promise<ServiceWorkerRegistration | undefined> | undefined
+  let currentStop: Promise<void> | undefined
+  let httpSource: ServiceWorkerSource | FallbackHttpSource | undefined
+
+  const getHttpSource = (
+    options?: SetupWorkerStartOptions,
+  ): ServiceWorkerSource | FallbackHttpSource => {
+    if (supportsServiceWorker()) {
+      const nextOptions = {
+        serviceWorker: {
+          url: options?.serviceWorker?.url?.toString() || DEFAULT_WORKER_URL,
+          options: options?.serviceWorker?.options,
+        },
+        findWorker: options?.findWorker,
+        quiet: options?.quiet,
+      }
+
+      if (!(httpSource instanceof ServiceWorkerSource)) {
+        httpSource = new ServiceWorkerSource(nextOptions)
+      } else {
+        httpSource.configure(nextOptions)
+      }
+
+      return httpSource
+    }
+
+    const nextOptions = {
+      quiet: options?.quiet,
+    }
+
+    if (!(httpSource instanceof FallbackHttpSource)) {
+      httpSource = new FallbackHttpSource(nextOptions)
+    } else {
+      httpSource.configure(nextOptions)
+    }
+
+    return httpSource
+  }
 
   return {
     async start(options) {
@@ -84,30 +127,17 @@ export function setupWorker(...handlers: Array<AnyHandler>): SetupWorkerApi {
         devUtils.warn(
           'Found a redundant "worker.start()" call. Note that starting the worker while mocking is already enabled will have no effect. Consider removing this "worker.start()" call.',
         )
-        return
+        return currentStart || currentRegistration
       }
 
-      const httpSource = supportsServiceWorker()
-        ? new ServiceWorkerSource({
-            serviceWorker: {
-              url:
-                options?.serviceWorker?.url?.toString() || DEFAULT_WORKER_URL,
-              options: options?.serviceWorker?.options,
-            },
-            findWorker: options?.findWorker,
-            quiet: options?.quiet,
-          })
-        : new FallbackHttpSource({
-            quiet: options?.quiet,
-          })
+      if (currentStop) {
+        await currentStop
+      }
+
+      const nextHttpSource = getHttpSource(options)
 
       network.configure({
-        sources: [
-          httpSource,
-          new InterceptorSource({
-            interceptors: [new WebSocketInterceptor() as any],
-          }),
-        ],
+        sources: [nextHttpSource, webSocketSource],
         onUnhandledFrame: fromLegacyOnUnhandledRequest(() => {
           return options?.onUnhandledRequest || 'warn'
         }),
@@ -116,22 +146,65 @@ export function setupWorker(...handlers: Array<AnyHandler>): SetupWorkerApi {
         },
       })
 
-      await network.enable()
       isStarted = true
+      const startPromise = (async () => {
+        await network.enable()
 
-      if (httpSource instanceof ServiceWorkerSource) {
-        const [, registration] = await httpSource.workerPromise
-        return registration
+        if (!isStarted) {
+          return undefined
+        }
+
+        if (nextHttpSource instanceof ServiceWorkerSource) {
+          const [, registration] = await nextHttpSource.workerPromise
+
+          if (!isStarted) {
+            return undefined
+          }
+
+          currentRegistration = registration
+          return registration
+        }
+
+        currentRegistration = undefined
+        return undefined
+      })()
+
+      currentStart = startPromise
+
+      try {
+        return await startPromise
+      } catch (error) {
+        isStarted = false
+        currentRegistration = undefined
+        throw error
+      } finally {
+        if (currentStart === startPromise) {
+          currentStart = undefined
+        }
       }
     },
     stop() {
       if (!isStarted) {
+        devUtils.warn(
+          'Found a redundant "worker.stop()" call. Notice that stopping the worker after it has already been stopped has no effect. Consider removing this "worker.stop()" call.',
+        )
         return
       }
 
-      network.disable().then(() => {
+      isStarted = false
+      currentRegistration = undefined
+
+      const stopPromise = network.disable().then(() => {
         window.postMessage({ type: 'msw/worker:stop' })
       })
+
+      const stopTask = stopPromise.finally(() => {
+        if (currentStop === stopTask) {
+          currentStop = undefined
+        }
+      })
+
+      currentStop = stopTask
     },
     events: network.events,
     use: network.use.bind(network),

--- a/src/browser/sources/fallback-http-source.ts
+++ b/src/browser/sources/fallback-http-source.ts
@@ -8,10 +8,14 @@ interface FallbackHttpSourceOptions {
 }
 
 export class FallbackHttpSource extends InterceptorSource {
-  constructor(private readonly options: FallbackHttpSourceOptions) {
+  constructor(private options: FallbackHttpSourceOptions) {
     super({
       interceptors: [new XMLHttpRequestInterceptor(), new FetchInterceptor()],
     })
+  }
+
+  public configure(options: FallbackHttpSourceOptions): void {
+    this.options = options
   }
 
   public async enable(): Promise<void> {

--- a/src/browser/sources/service-worker-source.ts
+++ b/src/browser/sources/service-worker-source.ts
@@ -56,7 +56,7 @@ export class ServiceWorkerSource extends NetworkSource<ServiceWorkerHttpNetworkF
     [ServiceWorker, ServiceWorkerRegistration]
   >
 
-  constructor(private readonly options: ServiceWorkerSourceOptions) {
+  constructor(private options: ServiceWorkerSourceOptions) {
     super()
 
     invariant(
@@ -67,19 +67,31 @@ export class ServiceWorkerSource extends NetworkSource<ServiceWorkerHttpNetworkF
     this.#frames = new Map()
     this.workerPromise = new DeferredPromise()
     this.#channel = new WorkerChannel({
-      worker: this.workerPromise.then(([worker]) => worker),
+      worker: () => this.workerPromise.then(([worker]) => worker),
     })
   }
 
+  public configure(options: ServiceWorkerSourceOptions): void {
+    this.options = options
+  }
+
   public async enable(): Promise<ServiceWorkerRegistration> {
+    const isRedundantStart =
+      typeof this.#stoppedAt === 'undefined' &&
+      this.workerPromise.state !== 'pending'
+
     this.#stoppedAt = undefined
 
-    if (this.workerPromise.state !== 'pending') {
+    if (isRedundantStart) {
       devUtils.warn(
         'Found a redundant "worker.start()" call. Note that starting the worker while mocking is already enabled will have no effect. Consider removing this "worker.start()" call.',
       )
 
       return this.workerPromise.then(([, registration]) => registration)
+    }
+
+    if (this.workerPromise.state !== 'pending') {
+      this.workerPromise = new DeferredPromise()
     }
 
     this.#channel.removeAllListeners()
@@ -138,7 +150,7 @@ export class ServiceWorkerSource extends NetworkSource<ServiceWorkerHttpNetworkF
 
     this.#stoppedAt = Date.now()
     this.#frames.clear()
-    this.workerPromise = new DeferredPromise()
+    this.#clearKeepAliveInterval()
 
     if (!this.options.quiet) {
       this.#printStopMessage()
@@ -146,9 +158,7 @@ export class ServiceWorkerSource extends NetworkSource<ServiceWorkerHttpNetworkF
   }
 
   async #startWorker() {
-    if (this.#keepAliveInterval) {
-      clearInterval(this.#keepAliveInterval)
-    }
+    this.#clearKeepAliveInterval()
 
     const workerUrl = this.options.serviceWorker.url
 
@@ -191,7 +201,7 @@ Please consider using a custom "serviceWorker.url" option to point to the actual
         this.#channel.postMessage('CLIENT_CLOSED')
       }
 
-      clearInterval(this.#keepAliveInterval)
+      this.#clearKeepAliveInterval()
 
       window.postMessage({ type: 'msw/worker:stop' })
     })
@@ -212,6 +222,15 @@ Please consider using a custom "serviceWorker.url" option to point to the actual
     }
 
     return [worker, registration] as const
+  }
+
+  #clearKeepAliveInterval(): void {
+    if (typeof this.#keepAliveInterval === 'undefined') {
+      return
+    }
+
+    clearInterval(this.#keepAliveInterval)
+    this.#keepAliveInterval = undefined
   }
 
   async #handleRequest(event: WorkerChannelRequestEvent): Promise<void> {

--- a/src/browser/utils/workerChannel.ts
+++ b/src/browser/utils/workerChannel.ts
@@ -5,7 +5,7 @@ import type { StringifiedResponse } from '../glossary'
 import { supportsServiceWorker } from '../utils/supports'
 
 export interface WorkerChannelOptions {
-  worker: Promise<ServiceWorker>
+  worker(): Promise<ServiceWorker>
 }
 
 export type WorkerChannelEventMap = {
@@ -130,7 +130,7 @@ export class WorkerChannel extends Emitter<WorkerChannelEventMap> {
     }
 
     navigator.serviceWorker.addEventListener('message', async (event) => {
-      const worker = await this.options.worker
+      const worker = await this.options.worker()
 
       if (event.source != null && event.source !== worker) {
         return
@@ -152,7 +152,7 @@ export class WorkerChannel extends Emitter<WorkerChannelEventMap> {
       'Failed to post message on a WorkerChannel: the Service Worker API is unavailable in this context. This is likely an issue with MSW. Please report it on GitHub: https://github.com/mswjs/msw/issues',
     )
 
-    this.options.worker.then((worker) => {
+    this.options.worker().then((worker) => {
       worker.postMessage(type)
     })
   }

--- a/test/browser/msw-api/setup-worker/start/start.mocks.ts
+++ b/test/browser/msw-api/setup-worker/start/start.mocks.ts
@@ -9,8 +9,8 @@ const worker = setupWorker(
 
 Object.assign(window, {
   msw: {
-    async startWorker() {
-      await worker.start({
+    startWorker() {
+      return worker.start({
         serviceWorker: {
           // Use a custom Service Worker for this test that intentionally
           // delays the worker installation time. This allows us to test

--- a/test/browser/msw-api/setup-worker/start/start.test.ts
+++ b/test/browser/msw-api/setup-worker/start/start.test.ts
@@ -120,3 +120,24 @@ test('prints a warning if "worker.start()" is called multiple times', async ({
     `[MSW] Found a redundant "worker.start()" call. Note that starting the worker while mocking is already enabled will have no effect. Consider removing this "worker.start()" call.`,
   ])
 })
+
+test('returns the active registration on a redundant "worker.start()" call', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(...exampleOptions)
+
+  await page.waitForFunction(() => {
+    return typeof window.msw !== 'undefined'
+  })
+
+  const [firstScope, secondScope] = await page.evaluate(async () => {
+    const firstRegistration = await window.msw.startWorker()
+    const secondRegistration = await window.msw.startWorker()
+
+    return [firstRegistration?.scope || null, secondRegistration?.scope || null]
+  })
+
+  expect(firstScope).not.toBeNull()
+  expect(secondScope).toEqual(firstScope)
+})

--- a/test/browser/msw-api/setup-worker/stop.test.ts
+++ b/test/browser/msw-api/setup-worker/stop.test.ts
@@ -98,6 +98,41 @@ test('keeps the mocking enabled in one tab when stopping the worker in another t
   await expect(response.json()).resolves.toEqual({ mocked: true })
 })
 
+test('re-enables mocking after the worker is stopped', async ({
+  loadExample,
+  fetch,
+  page,
+}) => {
+  await using server = await createTestHttpServer({
+    defineRoutes(router) {
+      router.get('/resource', () => {
+        return Response.json(
+          { original: true },
+          {
+            headers: {
+              'Access-Control-Allow-Origin': '*',
+              'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE',
+              'Access-Control-Allow-Headers': 'Content-Type',
+            },
+          },
+        )
+      })
+    },
+  })
+
+  await loadExample(new URL('./stop.mocks.ts', import.meta.url))
+  await stopWorkerOn(page)
+
+  await page.evaluate(() => {
+    return window.msw.worker.start()
+  })
+
+  const response = await fetch(server.http.url('/resource'))
+
+  expect.soft(response.fromServiceWorker()).toBe(true)
+  await expect(response.json()).resolves.toEqual({ mocked: true })
+})
+
 test('prints a warning on multiple "worker.stop()" calls', async ({
   loadExample,
   spyOnConsole,

--- a/test/browser/msw-api/setup-worker/stop/keepalive.mocks.ts
+++ b/test/browser/msw-api/setup-worker/stop/keepalive.mocks.ts
@@ -1,0 +1,40 @@
+import { http, HttpResponse } from 'msw'
+import { setupWorker } from 'msw/browser'
+
+let keepaliveRequests = 0
+
+const originalSetInterval = window.setInterval.bind(window)
+window.setInterval = ((handler, timeout, ...args) => {
+  const nextTimeout = timeout === 5000 ? 50 : timeout
+  return originalSetInterval(handler, nextTimeout, ...args)
+}) as typeof window.setInterval
+
+ServiceWorker.prototype.postMessage = new Proxy(
+  ServiceWorker.prototype.postMessage as (...args: Array<any>) => void,
+  {
+    apply(target, thisArg, args) {
+      if (args[0] === 'KEEPALIVE_REQUEST') {
+        keepaliveRequests += 1
+      }
+
+      return Reflect.apply(target, thisArg, args)
+    },
+  },
+) as ServiceWorker['postMessage']
+
+const worker = setupWorker(
+  http.get('/resource', () => {
+    return HttpResponse.json({ mocked: true })
+  }),
+)
+
+worker.start()
+
+Object.assign(window, {
+  msw: {
+    worker,
+    getKeepaliveRequests() {
+      return keepaliveRequests
+    },
+  },
+})

--- a/test/browser/msw-api/setup-worker/stop/keepalive.test.ts
+++ b/test/browser/msw-api/setup-worker/stop/keepalive.test.ts
@@ -1,0 +1,36 @@
+import type { SetupWorkerApi } from 'msw/browser'
+import { test, expect } from '../../../playwright.extend'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorkerApi
+    getKeepaliveRequests(): number
+  }
+}
+
+test('stops sending keepalive requests after "worker.stop()"', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(new URL('./keepalive.mocks.ts', import.meta.url))
+
+  await page.waitForFunction(() => {
+    return window.msw.getKeepaliveRequests() >= 2
+  })
+
+  await page.evaluate(() => {
+    window.msw.worker.stop()
+  })
+
+  await page.waitForTimeout(75)
+  const requestsAfterStop = await page.evaluate(() => {
+    return window.msw.getKeepaliveRequests()
+  })
+
+  await page.waitForTimeout(200)
+  const requestsAfterWait = await page.evaluate(() => {
+    return window.msw.getKeepaliveRequests()
+  })
+
+  expect(requestsAfterWait).toBe(requestsAfterStop)
+})


### PR DESCRIPTION
Follow-up for #2650.

## Summary
- reuse the browser HTTP and WebSocket sources across `worker.start()` / `worker.stop()` cycles
- restore the active `ServiceWorkerRegistration` return value on redundant `worker.start()` calls
- stop service-worker keepalive traffic on `worker.stop()` while preserving post-stop passthrough and restart behavior
- add browser regressions for redundant `worker.start()`, restart after stop, and keepalive cleanup

## Testing
- `pnpm build`
- `pnpm test:browser -- test/browser/msw-api/setup-worker/start/start.test.ts test/browser/msw-api/setup-worker/stop.test.ts test/browser/msw-api/setup-worker/stop/keepalive.test.ts`