### PR TITLE
fix(sse): respect `request.signal` for the underlying stream

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -20,10 +20,6 @@ export {
 /* Server-Sent Events */
 export {
   sse,
-  SSE_RESPONSE_INIT,
-  createEventStream,
-  type EventStream,
-  type EventStreamMessage,
   type ServerSentEventRequestHandler,
   type ServerSentEventResolver,
   type ServerSentEventResolverExtras,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -20,6 +20,10 @@ export {
 /* Server-Sent Events */
 export {
   sse,
+  SSE_RESPONSE_INIT,
+  createEventStream,
+  type EventStream,
+  type EventStreamMessage,
   type ServerSentEventRequestHandler,
   type ServerSentEventResolver,
   type ServerSentEventResolverExtras,

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -1,4 +1,5 @@
 import { invariant } from 'outvariant'
+import { DeferredPromise } from '@open-draft/deferred-promise'
 import { Emitter } from 'strict-event-emitter'
 import type { ResponseResolver } from './handlers/RequestHandler'
 import {
@@ -366,6 +367,7 @@ class ServerSentEventServer {
          */
         accept: 'msw/passthrough',
       },
+      signal: this.#request.signal,
     })
 
     source[kOnAnyMessage] = (event) => {
@@ -412,6 +414,7 @@ class ServerSentEventServer {
 
 interface ObservableEventSourceInit extends EventSourceInit {
   headers?: HeadersInit
+  signal?: AbortSignal
 }
 
 type EventHandler<EventType extends Event> = (
@@ -471,6 +474,18 @@ class ObservableEventSource extends EventTarget implements EventSource {
       credentials: this.withCredentials ? 'include' : 'omit',
       signal: this[kAbortController].signal,
     })
+
+    if (init?.signal) {
+      if (init.signal.aborted) {
+        this.close()
+        return
+      }
+
+      init.signal.addEventListener('abort', () => this.close(), {
+        once: true,
+        signal: this[kAbortController].signal,
+      })
+    }
 
     this.connect()
   }
@@ -675,7 +690,20 @@ class ObservableEventSource extends EventTarget implements EventSource {
       this.dispatchEvent(new Event('error'))
     })
 
-    await delay(this[kReconnectionTime])
+    const signal = this[kAbortController].signal
+    const aborted = new DeferredPromise<void>()
+    const onAbort = () => aborted.resolve()
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    await Promise.race([delay(this[kReconnectionTime]), aborted]).finally(
+      () => {
+        signal.removeEventListener('abort', onAbort)
+      },
+    )
+
+    if (signal.aborted) {
+      return
+    }
 
     queueMicrotask(async () => {
       if (this.readyState !== this.CONNECTING) {
@@ -928,7 +956,7 @@ export function createEventStream<EventMap extends EventMapConstraint>(
   request: Request,
 ): EventStream<EventMap> {
   invariant(
-    request.signal.aborted,
+    !request.signal.aborted,
     'Failed to call "createEventStream" on the "%s %s" request: request aborted',
     request.method,
     request.url,

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -715,6 +715,11 @@ class ObservableEventSource extends EventTarget implements EventSource {
     })
 
     const signal = this[kAbortController].signal
+
+    if (signal.aborted) {
+      return
+    }
+
     const aborted = new DeferredPromise<void>()
     const onAbort = () => aborted.resolve()
     signal.addEventListener('abort', onAbort, { once: true })

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -289,7 +289,12 @@ class ServerSentEventClient<
    * error.
    */
   public error(): void {
-    this.#writer.abort()
+    this.#writer.abort().catch((error) => {
+      console.error(error)
+      devUtils.error(
+        'Failed to abort server-side EventSource. Please see the original error above.',
+      )
+    })
     this[kClientEmitter]?.emit('error')
   }
 
@@ -297,12 +302,24 @@ class ServerSentEventClient<
    * Closes the underlying `EventSource`, closing the connection.
    */
   public close(): void {
-    this.#writer.close()
+    this.#writer.close().catch((error) => {
+      console.error(error)
+      devUtils.error(
+        'Failed to close server-side EventSource. Please see the original error above.',
+      )
+    })
     this[kClientEmitter]?.emit('close')
   }
 
   #sendRetry(retry: number): void {
-    this.#writer.write(this.#encoder.encode(`retry:${retry}\n\n`))
+    this.#writer
+      .write(this.#encoder.encode(`retry:${retry}\n\n`))
+      .catch((error) => {
+        console.error(error)
+        devUtils.error(
+          'Failed to send a retry packet to server-side EventSource. Please see the original error above.',
+        )
+      })
   }
 
   #sendMessage(message: {
@@ -333,7 +350,14 @@ class ServerSentEventClient<
 
     frames.push('', '')
 
-    this.#writer.write(this.#encoder.encode(frames.join('\n')))
+    this.#writer
+      .write(this.#encoder.encode(frames.join('\n')))
+      .catch((error) => {
+        console.error(error)
+        devUtils.error(
+          'Failed to send a message to server-side EventSource. Please see the original error above.',
+        )
+      })
 
     this[kClientEmitter]?.emit('message', {
       id: message.id,

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -68,7 +68,7 @@ export const sse: ServerSentEventRequestHandler = (path, resolver) => {
   return new ServerSentEventHandler(path, resolver)
 }
 
-const SSE_RESPONSE_INIT: ResponseInit = {
+export const SSE_RESPONSE_INIT: ResponseInit = {
   headers: {
     'content-type': 'text/event-stream',
     'cache-control': 'no-cache',
@@ -89,26 +89,19 @@ class ServerSentEventHandler<
     )
 
     super('GET', path, async (info) => {
-      const stream = new ReadableStream({
-        start: async (controller) => {
-          const client = new ServerSentEventClient<EventMap>({
-            controller,
-            emitter: this.#emitter,
-          })
-          const server = new ServerSentEventServer({
-            request: info.request,
-            client,
-          })
+      const { client, server, response } = createEventStream<EventMap>(
+        info.request,
+      )
 
-          await resolver({
-            ...info,
-            client,
-            server,
-          })
-        },
+      client[kClientEmitter] = this.#emitter
+
+      await resolver({
+        ...info,
+        client,
+        server,
       })
 
-      return new Response(stream, SSE_RESPONSE_INIT)
+      return response
     })
 
     this.#emitter = new Emitter<ServerSentEventClientEventMap>()
@@ -222,32 +215,24 @@ type ToEventDiscriminatedUnion<T> = Values<{
 }>
 
 type ServerSentEventClientEventMap = {
-  message: [
-    payload: {
-      id?: string
-      event: string
-      data?: unknown
-      frames: Array<string>
-    },
-  ]
+  message: [payload: EventStreamMessage]
   error: []
   close: []
 }
 
+const kClientEmitter = Symbol.for('kClientEmitter')
+
 class ServerSentEventClient<
   EventMap extends EventMapConstraint = { message: unknown },
 > {
-  #encoder: TextEncoder
-  #controller: ReadableStreamDefaultController
-  #emitter: Emitter<ServerSentEventClientEventMap>
+  private [kClientEmitter]?: Emitter<ServerSentEventClientEventMap>
 
-  constructor(args: {
-    controller: ReadableStreamDefaultController
-    emitter: Emitter<ServerSentEventClientEventMap>
-  }) {
+  #encoder: TextEncoder
+  #writer: WritableStreamDefaultWriter
+
+  constructor(writable: WritableStream) {
     this.#encoder = new TextEncoder()
-    this.#controller = args.controller
-    this.#emitter = args.emitter
+    this.#writer = writable.getWriter()
   }
 
   /**
@@ -303,22 +288,20 @@ class ServerSentEventClient<
    * error.
    */
   public error(): void {
-    this.#controller.error()
-    this.#emitter.emit('error')
+    this.#writer.abort()
+    this[kClientEmitter]?.emit('error')
   }
 
   /**
    * Closes the underlying `EventSource`, closing the connection.
    */
   public close(): void {
-    this.#controller.close()
-    this.#emitter.emit('close')
+    this.#writer.close()
+    this[kClientEmitter]?.emit('close')
   }
 
   #sendRetry(retry: number): void {
-    if (typeof retry === 'number') {
-      this.#controller.enqueue(this.#encoder.encode(`retry:${retry}\n\n`))
-    }
+    this.#writer.write(this.#encoder.encode(`retry:${retry}\n\n`))
   }
 
   #sendMessage(message: {
@@ -349,9 +332,9 @@ class ServerSentEventClient<
 
     frames.push('', '')
 
-    this.#controller.enqueue(this.#encoder.encode(frames.join('\n')))
+    this.#writer.write(this.#encoder.encode(frames.join('\n')))
 
-    this.#emitter.emit('message', {
+    this[kClientEmitter]?.emit('message', {
       id: message.id,
       event: message.event?.toString() || 'message',
       data: message.data,
@@ -642,10 +625,6 @@ class ObservableEventSource extends EventTarget implements EventSource {
           this[kLastEventId] = message.id
         }
 
-        if (message.retry) {
-          this[kReconnectionTime] = message.retry
-        }
-
         const messageEvent = new MessageEvent(
           message.event ? message.event : 'message',
           {
@@ -658,6 +637,9 @@ class ObservableEventSource extends EventTarget implements EventSource {
 
         this[kOnAnyMessage]?.(messageEvent)
         this.dispatchEvent(messageEvent)
+      },
+      retry: (reconnectionTime) => {
+        this[kReconnectionTime] = reconnectionTime
       },
       abort: () => {
         throw new Error('Stream abort is not implemented')
@@ -743,7 +725,6 @@ interface EventSourceMessage {
   id?: string
   event?: string
   data?: string
-  retry?: number
 }
 
 class EventSourceParsingStream extends WritableStream {
@@ -758,12 +739,12 @@ class EventSourceParsingStream extends WritableStream {
     id: undefined,
     event: undefined,
     data: undefined,
-    retry: undefined,
   }
 
   constructor(
     private underlyingSink: {
       message: (message: EventSourceMessage) => void
+      retry?: (reconnectionTime: number) => void
       abort?: (reason: any) => void
       close?: () => void
     },
@@ -789,7 +770,6 @@ class EventSourceParsingStream extends WritableStream {
       id: undefined,
       event: undefined,
       data: undefined,
-      retry: undefined,
     }
   }
 
@@ -903,14 +883,63 @@ class EventSourceParsingStream extends WritableStream {
         }
 
         case 'retry': {
-          const retry = parseInt(value, 10)
-
-          if (!isNaN(retry)) {
-            this.message.retry = retry
+          /**
+           * Apply the retry immediately. Don't buffer onto the current message.
+           * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+           */
+          if (/^\d+$/.test(value)) {
+            this.underlyingSink.retry?.(parseInt(value, 10))
           }
           break
         }
       }
     }
+  }
+}
+
+export interface EventStreamMessage {
+  id?: string
+  event: string
+  data?: unknown
+  frames: Array<string>
+}
+
+export interface EventStream<EventMap extends EventMapConstraint> {
+  client: ServerSentEventClient<EventMap>
+  server: ServerSentEventServer
+  response: Response
+}
+
+/**
+ * Create an event stream out of the given Fetch API `Request`.
+ * Returns the following properties:
+ * - `client`, to operate on the intercepted request;
+ * - `server`, to establish and manage the actual server connection;
+ * - `response`, a `Response` to use as the mock response's body.
+ *
+ * @example
+ * http.post('/resource', ({ request }) => {
+ *   const { client, server, response } = createEventStream(request)
+ *   client.send({ data: 'hello world' })
+ *   return response
+ * })
+ */
+export function createEventStream<EventMap extends EventMapConstraint>(
+  request: Request,
+): EventStream<EventMap> {
+  const { readable, writable } = new TransformStream()
+
+  const client = new ServerSentEventClient<EventMap>(writable)
+  const server = new ServerSentEventServer({
+    request,
+    client,
+  })
+
+  const response = new Response(readable, SSE_RESPONSE_INIT)
+
+  return {
+    client,
+    server,
+    response,
   }
 }

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -69,7 +69,7 @@ export const sse: ServerSentEventRequestHandler = (path, resolver) => {
   return new ServerSentEventHandler(path, resolver)
 }
 
-export const SSE_RESPONSE_INIT: ResponseInit = {
+const SSE_RESPONSE_INIT: ResponseInit = {
   headers: {
     'content-type': 'text/event-stream',
     'cache-control': 'no-cache',
@@ -954,14 +954,14 @@ class EventSourceParsingStream extends WritableStream {
   }
 }
 
-export interface EventStreamMessage {
+interface EventStreamMessage {
   id?: string
   event: string
   data?: unknown
   frames: Array<string>
 }
 
-export interface EventStream<EventMap extends EventMapConstraint> {
+interface EventStream<EventMap extends EventMapConstraint> {
   client: ServerSentEventClient<EventMap>
   server: ServerSentEventServer
   response: Response
@@ -981,7 +981,7 @@ export interface EventStream<EventMap extends EventMapConstraint> {
  *   return response
  * })
  */
-export function createEventStream<EventMap extends EventMapConstraint>(
+function createEventStream<EventMap extends EventMapConstraint>(
   request: Request,
 ): EventStream<EventMap> {
   invariant(

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -540,7 +540,7 @@ class ObservableEventSource extends EventTarget implements EventSource {
   get onerror(): EventHandler<Event> | null {
     return this[kOnError]
   }
-  set oneerror(handler: EventHandler<Event>) {
+  set onerror(handler: EventHandler<Event>) {
     if (this[kOnError]) {
       this.removeEventListener('error', { handleEvent: this[kOnError] })
     }

--- a/src/core/sse.ts
+++ b/src/core/sse.ts
@@ -927,6 +927,13 @@ export interface EventStream<EventMap extends EventMapConstraint> {
 export function createEventStream<EventMap extends EventMapConstraint>(
   request: Request,
 ): EventStream<EventMap> {
+  invariant(
+    request.signal.aborted,
+    'Failed to call "createEventStream" on the "%s %s" request: request aborted',
+    request.method,
+    request.url,
+  )
+
   const { readable, writable } = new TransformStream()
 
   const client = new ServerSentEventClient<EventMap>(writable)
@@ -936,6 +943,14 @@ export function createEventStream<EventMap extends EventMapConstraint>(
   })
 
   const response = new Response(readable, SSE_RESPONSE_INIT)
+
+  request.signal.addEventListener(
+    'abort',
+    () => {
+      client.close()
+    },
+    { once: true },
+  )
 
   return {
     client,

--- a/test/browser/sse-api/sse.signal.test.ts
+++ b/test/browser/sse-api/sse.signal.test.ts
@@ -1,0 +1,92 @@
+import { setTimeout } from 'node:timers/promises'
+import { sse } from 'msw'
+import { setupWorker } from 'msw/browser'
+import { createTestHttpServer } from '@epic-web/test-server/http'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+import { test, expect } from '../playwright.extend'
+
+declare namespace window {
+  export const msw: {
+    setupWorker: typeof setupWorker
+    sse: typeof sse
+  }
+}
+
+const EXAMPLE_URL = new URL('./sse.mocks.ts', import.meta.url)
+
+const SSE_HEADERS = {
+  'access-control-allow-origin': '*',
+  'content-type': 'text/event-stream',
+  'cache-control': 'no-cache',
+  connection: 'keep-alive',
+}
+
+test('stops reconnecting to the upstream when the consumer closes mid-backoff', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(EXAMPLE_URL, {
+    skipActivation: true,
+  })
+
+  let upstreamRequestCount = 0
+  const firstRequestReceived = new DeferredPromise<void>()
+
+  await using server = await createTestHttpServer({
+    defineRoutes(router) {
+      router.get('/stream', () => {
+        upstreamRequestCount += 1
+        if (upstreamRequestCount === 1) {
+          firstRequestReceived.resolve()
+        }
+
+        const stream = new ReadableStream({
+          start(controller) {
+            // Set a short reconnection time so the test does not
+            // have to wait the default 2s.
+            controller.enqueue(new TextEncoder().encode('retry:200\n\n'))
+            controller.enqueue(
+              new TextEncoder().encode('data: {"message": "hello"}\n\n'),
+            )
+            // Close the stream to push the upstream EventSource into
+            // its reconnect backoff window.
+            controller.close()
+          },
+        })
+
+        return new Response(stream, { headers: SSE_HEADERS })
+      })
+    },
+  })
+  const url = server.http.url('/stream').href
+
+  await page.evaluate(async (url) => {
+    const { setupWorker, sse } = window.msw
+
+    const worker = setupWorker(
+      sse(url, ({ server }) => {
+        server.connect()
+      }),
+    )
+    await worker.start()
+  }, url)
+
+  await page.evaluate((url) => {
+    return new Promise<void>((resolve) => {
+      const source = new EventSource(url)
+      source.addEventListener('message', () => {
+        // Close while the upstream EventSource is mid-reconnect-backoff (200ms).
+        source.close()
+        resolve()
+      })
+    })
+  }, url)
+
+  await firstRequestReceived
+
+  // Wait long enough for a second reconnect to have fired if the
+  // abort wiring did not cancel the backoff.
+  await setTimeout(600)
+
+  expect(upstreamRequestCount).toBe(1)
+})


### PR DESCRIPTION
> [!WARNING]
> This likely doesn't make sense. I like the refactor and the bugfixes, but the public APIs seem to cover use cases that are impossible in practice (non-GET event sources). **Remove the new APIs from public**. 

## Changes

- Respects `request.signal` when working with SSE.