### PR TITLE
fix: use `pagehide` instead of `beforeunload` for tracking closing pages

### DIFF
--- a/src/browser/sources/service-worker-source.ts
+++ b/src/browser/sources/service-worker-source.ts
@@ -278,8 +278,12 @@ Please consider using a custom "serviceWorker.url" option to point to the actual
     this.#channel.on('RESPONSE', this.#handleResponse.bind(this))
 
     window.addEventListener(
-      'beforeunload',
-      () => {
+      'pagehide',
+      (event) => {
+        if (event.persisted) {
+          return
+        }
+
         if (worker.state !== 'redundant') {
           this.#channel.postMessage('CLIENT_CLOSED')
         }

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -27,11 +27,11 @@ addEventListener('message', async function (event) {
     return
   }
 
-  const allClients = await self.clients.matchAll({
-    type: 'window',
-  })
-
   if (event.data === 'CLIENT_CLOSED') {
+    const allClients = await self.clients.matchAll({
+      type: 'window',
+    })
+
     activeClientIds.delete(clientId)
 
     const remainingClients = allClients.filter((client) => {

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -27,15 +27,32 @@ addEventListener('message', async function (event) {
     return
   }
 
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  if (event.data === 'CLIENT_CLOSED') {
+    console.warn('CLIENT_CLOSED', clientId, Array.from(activeClientIds))
+    activeClientIds.delete(clientId)
+
+    const remainingClients = allClients.filter((client) => {
+      return client.id !== clientId
+    })
+
+    console.warn('REMAINING CLIENTS:', remainingClients.length)
+
+    // Unregister itself when there are no more clients
+    if (remainingClients.length === 0) {
+      console.warn('UNREGISTER ITSELF!')
+      self.registration.unregister()
+    }
+  }
+
   const client = await self.clients.get(clientId)
 
   if (!client) {
     return
   }
-
-  const allClients = await self.clients.matchAll({
-    type: 'window',
-  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
@@ -68,21 +85,6 @@ addEventListener('message', async function (event) {
           },
         },
       })
-      break
-    }
-
-    case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId)
-
-      const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId
-      })
-
-      // Unregister itself when there are no more clients
-      if (remainingClients.length === 0) {
-        self.registration.unregister()
-      }
-
       break
     }
   }

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -32,18 +32,14 @@ addEventListener('message', async function (event) {
   })
 
   if (event.data === 'CLIENT_CLOSED') {
-    console.warn('CLIENT_CLOSED', clientId, Array.from(activeClientIds))
     activeClientIds.delete(clientId)
 
     const remainingClients = allClients.filter((client) => {
       return client.id !== clientId
     })
 
-    console.warn('REMAINING CLIENTS:', remainingClients.length)
-
     // Unregister itself when there are no more clients
     if (remainingClients.length === 0) {
-      console.warn('UNREGISTER ITSELF!')
       self.registration.unregister()
     }
   }

--- a/test/browser/msw-api/unregister.test.ts
+++ b/test/browser/msw-api/unregister.test.ts
@@ -1,9 +1,9 @@
-import type { SetupWorkerApi } from 'msw/browser'
+import type { SetupWorker } from 'msw/browser'
 import { test, expect } from '../playwright.extend'
 
 declare namespace window {
   export const msw: {
-    worker: SetupWorkerApi
+    worker: SetupWorker
   }
 }
 


### PR DESCRIPTION
- Addresses #1105 

## Root cause

`beforeunload` gives no means to know if upstream listener has prevented it. 

## Changes

- Uses `pagehide` event instead of `beforeunload`. This will respect the developer's decision to prevent page closure and _will not_ send the `CLIENT_CLOSED` message to the worker in that case. 