### PR TITLE
fix(WebSocketHandler): add public `test()` method

### DIFF
--- a/src/core/handlers/WebSocketHandler.test.ts
+++ b/src/core/handlers/WebSocketHandler.test.ts
@@ -147,7 +147,7 @@ describe('test', () => {
     ).toBe(true)
   })
 
-  it('returns false for a relative matching string', () => {
+  it('returns false for a relative non-matching string', () => {
     expect(
       new WebSocketHandler('ws://localhost/ws').test('/other', {
         baseUrl: 'ws://localhost',

--- a/src/core/handlers/WebSocketHandler.test.ts
+++ b/src/core/handlers/WebSocketHandler.test.ts
@@ -125,3 +125,61 @@ describe('parse', () => {
     })
   })
 })
+
+describe('test', () => {
+  it('returns true for a matching string', () => {
+    expect(
+      new WebSocketHandler('ws://localhost/ws').test('ws://localhost/ws'),
+    ).toBe(true)
+  })
+
+  it('returns false for a non-matching string', () => {
+    expect(
+      new WebSocketHandler('ws://localhost/ws').test('ws://localhost/other'),
+    ).toBe(false)
+  })
+
+  it('returns true for a relative matching string', () => {
+    expect(
+      new WebSocketHandler('ws://localhost/ws').test('/ws', {
+        baseUrl: 'ws://localhost',
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false for a relative matching string', () => {
+    expect(
+      new WebSocketHandler('ws://localhost/ws').test('/other', {
+        baseUrl: 'ws://localhost',
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true for a matching URL', () => {
+    expect(
+      new WebSocketHandler('ws://localhost/ws').test(
+        new URL('ws://localhost/ws'),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false for a non-matching URL', () => {
+    expect(
+      new WebSocketHandler('ws://localhost/ws').test(
+        new URL('ws://localhost/other'),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true for a matching HTTP url string', () => {
+    expect(
+      new WebSocketHandler('ws://localhost/ws').test('http://localhost/ws'),
+    ).toBe(true)
+  })
+
+  it('returns false for a non-matching HTTP url string', () => {
+    expect(
+      new WebSocketHandler('ws://localhost/ws').test('http://localhost/other'),
+    ).toBe(false)
+  })
+})

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -100,31 +100,16 @@ export class WebSocketHandler {
     url: string | URL,
     resolutionContext?: WebSocketResolutionContext & { strict?: boolean },
   ): boolean {
-    const resolvedUrl = this.#resolveWebSocketUrl(
-      url.toString(),
-      resolutionContext?.baseUrl,
-    )
-    const parsedResult = this.parse({
-      url: resolvedUrl,
-      resolutionContext,
-    })
-
-    return this.predicate({
-      url,
-      parsedResult,
-    })
+    return this.#match(url, resolutionContext) != null
   }
 
   public async run(
     connection: WebSocketConnectionData,
     resolutionContext?: WebSocketResolutionContext,
   ): Promise<WebSocketHandlerConnection | null> {
-    const parsedResult = this.parse({
-      url: connection.client.url,
-      resolutionContext,
-    })
+    const parsedResult = this.#match(connection.client.url, resolutionContext)
 
-    if (!this.predicate({ url: connection.client.url, parsedResult })) {
+    if (parsedResult == null) {
       return null
     }
 
@@ -142,6 +127,31 @@ export class WebSocketHandler {
     }
 
     return resolvedConnection
+  }
+
+  #match(
+    url: string | URL,
+    resolutionContext?: WebSocketResolutionContext & { strict?: boolean },
+  ): WebSocketHandlerParsedResult | null {
+    const resolvedUrl = this.#resolveWebSocketUrl(
+      url.toString(),
+      resolutionContext?.baseUrl,
+    )
+    const parsedResult = this.parse({
+      url: resolvedUrl,
+      resolutionContext,
+    })
+
+    if (
+      this.predicate({
+        url,
+        parsedResult,
+      })
+    ) {
+      return parsedResult
+    }
+
+    return null
   }
 
   protected [kConnect](connection: WebSocketHandlerConnection): boolean {

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -57,7 +57,7 @@ export class WebSocketHandler {
   }
 
   public parse(args: {
-    url: URL
+    url: string | URL
     resolutionContext?: WebSocketResolutionContext
   }): WebSocketHandlerParsedResult {
     const clientUrl = new URL(args.url)
@@ -90,10 +90,29 @@ export class WebSocketHandler {
   }
 
   public predicate(args: {
-    url: URL
+    url: string | URL
     parsedResult: WebSocketHandlerParsedResult
   }): boolean {
     return args.parsedResult.match.matches
+  }
+
+  public test(
+    url: string | URL,
+    resolutionContext?: WebSocketResolutionContext & { strict?: boolean },
+  ): boolean {
+    const resolvedUrl = this.#resolveWebSocketUrl(
+      url.toString(),
+      resolutionContext?.baseUrl,
+    )
+    const parsedResult = this.parse({
+      url: resolvedUrl,
+      resolutionContext,
+    })
+
+    return this.predicate({
+      url,
+      parsedResult,
+    })
   }
 
   public async run(


### PR DESCRIPTION
## Motivation

There isn't an easy way to check if a given WebSocketHandler matches a URL. 

## Changes

- Adds the `WebSocketHandler.test` method that functions similarly to the same method from RequestHandler. 
- Uses the same internal `#match` logic for consistent predicate in `.run()` and `.test()`.