### PR TITLE
chore: use `Headers.getSetCookie`

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         # As a general rule, when adding a new version, remove the oldest version
         # Check if the oldest version is EOL or not first.
-        ts: ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8']
+        ts: ['5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -1,4 +1,3 @@
-import { Headers as HeadersPolyfill } from 'headers-polyfill'
 import { getCallFrame } from '../utils/internal/getCallFrame'
 import {
   isIterable,
@@ -432,22 +431,7 @@ export function forwardResponseCookies(response: Response): void {
     return
   }
 
-  const responseCookies = getRawSetCookie(response)
-
-  if (!responseCookies) {
-    return
-  }
-
-  // Write the mocked response cookies to the document.
-  // Use `headers-polyfill` to get the Set-Cookie header value correctly.
-  // This is an alternative until TypeScript 5.2
-  // and Node.js v20 become the minimum supported versions
-  // and "Headers.prototype.getSetCookie" can be used directly.
-  const allResponseCookies = HeadersPolyfill.prototype.getSetCookie.call(
-    new Headers([['set-cookie', responseCookies]]),
-  )
-
-  for (const cookieString of allResponseCookies) {
+  for (const cookieString of getRawSetCookie(response)) {
     document.cookie = cookieString
   }
 }

--- a/src/core/utils/HttpResponse/decorators.ts
+++ b/src/core/utils/HttpResponse/decorators.ts
@@ -39,7 +39,7 @@ export function decorateResponse(
     })
   }
 
-  const responseCookies = init.headers.get('set-cookie')
+  const responseCookies = init.headers.getSetCookie()
 
   if (responseCookies) {
     // Record the raw "Set-Cookie" response header provided
@@ -56,6 +56,6 @@ export function decorateResponse(
   return response
 }
 
-export function getRawSetCookie(response: Response): string | undefined {
-  return Reflect.get(response, kSetCookie)
+export function getRawSetCookie(response: Response): Array<string> {
+  return Reflect.get(response, kSetCookie) || []
 }

--- a/src/core/utils/request/storeResponseCookies.ts
+++ b/src/core/utils/request/storeResponseCookies.ts
@@ -5,11 +5,7 @@ export async function storeResponseCookies(
   request: Request,
   response: Response,
 ): Promise<void> {
-  await Promise.all(
-    // Grab the raw "Set-Cookie" response header provided
-    // in the HeadersInit for this mocked response.
-    getRawSetCookie(response).map(async (responseCookie) => {
-      await cookieStore.setCookie(responseCookie, request.url)
-    }),
-  )
+  for (const responseCookie of getRawSetCookie(response)) {
+    await cookieStore.setCookie(responseCookie, request.url)
+  }
 }

--- a/src/core/utils/request/storeResponseCookies.ts
+++ b/src/core/utils/request/storeResponseCookies.ts
@@ -5,11 +5,11 @@ export async function storeResponseCookies(
   request: Request,
   response: Response,
 ): Promise<void> {
-  // Grab the raw "Set-Cookie" response header provided
-  // in the HeadersInit for this mocked response.
-  const responseCookies = getRawSetCookie(response)
-
-  if (responseCookies) {
-    await cookieStore.setCookie(responseCookies, request.url)
-  }
+  await Promise.all(
+    // Grab the raw "Set-Cookie" response header provided
+    // in the HeadersInit for this mocked response.
+    getRawSetCookie(response).map(async (responseCookie) => {
+      await cookieStore.setCookie(responseCookie, request.url)
+    }),
+  )
 }


### PR DESCRIPTION
- Drop TypeScript 5.0 and 5.1, add 5.9.
- Use `Headers.prototype.getSetCookie()` instead of `headers-polyfill`.
- Correctly handle multiple `set-cookie` response headers now.

> We still rely on `headers-polyfil` for multipart data when parsing headers of individual multipart chunks. 