### PR TITLE
fix: do not clone user-provided responses

### DIFF
--- a/src/core/experimental/frames/http-frame.ts
+++ b/src/core/experimental/frames/http-frame.ts
@@ -251,9 +251,13 @@ export abstract class HttpNetworkFrame extends NetworkFrame<
       return null
     }
 
+    const responseCloneForLogs = resolutionContext?.quiet
+      ? null
+      : response.clone()
+
     await storeResponseCookies(request, response)
 
-    this.respondWith(response.clone())
+    this.respondWith(response)
 
     this.events.emit(
       new RequestEvent('request:end', {
@@ -265,7 +269,7 @@ export abstract class HttpNetworkFrame extends NetworkFrame<
     if (!resolutionContext?.quiet) {
       handler.log({
         request: requestCloneForLogs!,
-        response,
+        response: responseCloneForLogs!,
         parsedResult,
       })
     }


### PR DESCRIPTION
Right now, MSW always clones the user-provided mocked response. That disrupts the response's identity, which is relevant in transient response scenarios like on Cloudflare (e.g. providing custom response init options and preserving them). 

The issue is fundamental: instead of cloning a response for logs and using the original, we are cloning for the usage and using the original for logs. This is against what the rest of the architecture is doing (e.g. request clones are handled correctly). 