### PR TITLE
fix: release HttpNetworkFrame listeners after response event

### DIFF
--- a/src/core/experimental/sources/interceptor-source.test.ts
+++ b/src/core/experimental/sources/interceptor-source.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+import type { HttpNetworkFrame } from '../frames/http-frame'
+import { InterceptorSource } from './interceptor-source'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+it('removes frame event listeners after the response event is emitted', async () => {
+  const source = new InterceptorSource({
+    interceptors: [new FetchInterceptor()],
+  })
+
+  let capturedFrame: HttpNetworkFrame | undefined
+
+  source.on('frame', ({ frame }) => {
+    capturedFrame = frame as unknown as HttpNetworkFrame
+    capturedFrame.respondWith(new Response('ok'))
+  })
+
+  source.enable()
+
+  await fetch('http://localhost/test')
+
+  const removeAllListenersSpy = vi.spyOn(capturedFrame!.events, 'removeAllListeners')
+
+  await new Promise<void>((resolve) => queueMicrotask(resolve))
+
+  expect(removeAllListenersSpy).toHaveBeenCalledOnce()
+
+  source.disable()
+})

--- a/src/core/experimental/sources/interceptor-source.test.ts
+++ b/src/core/experimental/sources/interceptor-source.test.ts
@@ -29,5 +29,6 @@ it('removes frame event listeners after the response event is emitted', async ()
 
   await new Promise<void>((resolve) => queueMicrotask(resolve))
 
+  expect(removeAllListenersSpy).toBeDefined()
   expect(removeAllListenersSpy!).toHaveBeenCalledOnce()
 })

--- a/src/core/experimental/sources/interceptor-source.test.ts
+++ b/src/core/experimental/sources/interceptor-source.test.ts
@@ -3,31 +3,31 @@ import { FetchInterceptor } from '@mswjs/interceptors/fetch'
 import type { HttpNetworkFrame } from '../frames/http-frame'
 import { InterceptorSource } from './interceptor-source'
 
+let source: InterceptorSource
+
 afterEach(() => {
+  source?.disable()
   vi.restoreAllMocks()
 })
 
 it('removes frame event listeners after the response event is emitted', async () => {
-  const source = new InterceptorSource({
+  source = new InterceptorSource({
     interceptors: [new FetchInterceptor()],
   })
 
-  let capturedFrame: HttpNetworkFrame | undefined
+  let removeAllListenersSpy: ReturnType<typeof vi.spyOn> | undefined
 
   source.on('frame', ({ frame }) => {
-    capturedFrame = frame as unknown as HttpNetworkFrame
-    capturedFrame.respondWith(new Response('ok'))
+    const httpFrame = frame as unknown as HttpNetworkFrame
+    removeAllListenersSpy = vi.spyOn(httpFrame.events, 'removeAllListeners')
+    httpFrame.respondWith(new Response('ok'))
   })
 
   source.enable()
 
   await fetch('http://localhost/test')
 
-  const removeAllListenersSpy = vi.spyOn(capturedFrame!.events, 'removeAllListeners')
-
   await new Promise<void>((resolve) => queueMicrotask(resolve))
 
-  expect(removeAllListenersSpy).toHaveBeenCalledOnce()
-
-  source.disable()
+  expect(removeAllListenersSpy!).toHaveBeenCalledOnce()
 })

--- a/src/core/experimental/sources/interceptor-source.ts
+++ b/src/core/experimental/sources/interceptor-source.ts
@@ -97,6 +97,7 @@ export class InterceptorSource extends NetworkSource {
           },
         ),
       )
+      httpFrame.events.removeAllListeners()
     })
   }
 


### PR DESCRIPTION
Closes #2735

Hi! Jumping in with a fix for the per-frame listener retention described in #2735.

**Root cause**

`defineNetwork` attaches a wildcard listener to each `HttpNetworkFrame.events` with `{ signal: listenersController.signal }`. That signal lives for the full network lifetime and only aborts on `disable()`. Because `rettime` registers an `onAbort` closure on that signal for every listener attached, every completed request leaves one retained `Emitter` (and its `LensList`, `WeakMap`, `WeakSet` fields) pinned to the shared signal. After 10k requests that's 10k retained emitters; the heap snapshot in the issue shows deltas that are exact multiples of the request count.

**What this PR does**

One line: `httpFrame.events.removeAllListeners()` inside the existing `queueMicrotask` in `InterceptorSource.#handleResponse`, right after the `ResponseEvent` is emitted.

This triggers `rettime`'s `#listenerAbortCleanups` path, which detaches the `onAbort` closure from the shared signal and lets the frame's emitter be GC'd. Calling it after the emit (but still inside the microtask) means all `response:mocked`/`response:bypass` subscribers receive the event before cleanup. Existing code listening on either event is unaffected.

This fix works at the MSW layer regardless of rettime internals, so it holds across rettime versions.

**Test**

New unit test in `interceptor-source.test.ts`: intercepts a real `fetch()` via `FetchInterceptor`, responds synchronously from the frame listener, then asserts `removeAllListeners()` is called on the frame's `events` emitter after the microtask queue flushes. Fails on the pre-fix code, passes after.

**Out of scope**

The issue also notes a secondary leak for error paths where the interceptor never fires the `response` event. Happy to follow up on that separately if useful.