### PR TITLE
fix(ws): remove all frame listeners on client closure

### DIFF
--- a/src/core/experimental/sources/interceptor-source.ts
+++ b/src/core/experimental/sources/interceptor-source.ts
@@ -163,6 +163,20 @@ class InterceptorHttpNetworkFrame extends HttpNetworkFrame {
 class InterceptorWebSocketNetworkFrame extends WebSocketNetworkFrame {
   constructor(args: { connection: WebSocketConnectionData }) {
     super({ connection: args.connection })
+
+    /**
+     * @note Provide a similar frame listener cleanup as for HTTP.
+     * When the client connection closes, the handler can no longer be used.
+     */
+    args.connection.client.addEventListener(
+      'close',
+      () => {
+        this.events.removeAllListeners()
+      },
+      {
+        once: true,
+      },
+    )
   }
 
   public errorWith(reason?: unknown): void {


### PR DESCRIPTION
Makes sure that WebSocket frames also remove all their listeners on connection closure. 