### PR TITLE
feat: support GraphQL subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,6 +292,8 @@
     "fs-teardown": "^0.3.0",
     "glob": "^13.0.6",
     "graphql": "^16.13.2",
+    "graphql-ws": "^5.16.0",
+    "graphql-yoga": "^5.13.4",
     "jsdom": "^25.0.1",
     "json-bigint": "^1.0.0",
     "knip": "^6.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,12 @@ importers:
       graphql:
         specifier: ^16.13.2
         version: 16.14.2
+      graphql-ws:
+        specifier: ^5.16.0
+        version: 5.16.2(graphql@16.14.2)
+      graphql-yoga:
+        specifier: ^5.13.4
+        version: 5.21.2(graphql@16.14.2)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -433,6 +439,18 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@envelop/core@5.5.1':
+    resolution: {integrity: sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@envelop/instrumentation@1.0.0':
+    resolution: {integrity: sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@envelop/types@5.2.1':
+    resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
+    engines: {node: '>=18.0.0'}
+
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
@@ -599,6 +617,9 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
 
@@ -617,10 +638,52 @@ packages:
   '@fastify/websocket@11.2.0':
     resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
 
+  '@graphql-tools/executor@1.5.5':
+    resolution: {integrity: sha512-JAdn4G+ehthnGdJABS+wO6LxAIcoGPiSRHIz1ECYLtaQGkpFIdqH6BLUbZcToX/W/nmOG0kTFLoepCGkugbsBA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/merge@9.2.0':
+    resolution: {integrity: sha512-kChDH/sOxm3TCICup5NgTiz/aJBk+5GAuC0lfJS8FcRfsqZvlCkNwpsYTGAATBCJMrgZ9+csRugCjS97jPcNMw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/schema@10.0.36':
+    resolution: {integrity: sha512-g8S5aLirZInoi3NojzmBxwsZfVawOE0UBlVWYe8kDAR0FxS0riBDiyW7JnlAKayooHMRAMwGaze4RQU3VTTyig==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@10.11.0':
+    resolution: {integrity: sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@11.2.0':
+    resolution: {integrity: sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-yoga/logger@2.0.1':
+    resolution: {integrity: sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-yoga/subscription@5.0.5':
+    resolution: {integrity: sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-yoga/typed-event-target@3.0.2':
+    resolution: {integrity: sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==}
+    engines: {node: '>=18.0.0'}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1091,6 +1154,9 @@ packages:
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@repeaterjs/repeater@3.1.0':
+    resolution: {integrity: sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==}
 
   '@rolldown/binding-android-arm64@1.1.4':
     resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
@@ -1583,6 +1649,30 @@ packages:
 
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@whatwg-node/disposablestack@0.0.6':
+    resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/events@0.1.2':
+    resolution: {integrity: sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/fetch@0.10.13':
+    resolution: {integrity: sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/node-fetch@0.8.6':
+    resolution: {integrity: sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/promise-helpers@1.3.2':
+    resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
+    engines: {node: '>=16.0.0'}
+
+  '@whatwg-node/server@0.11.0':
+    resolution: {integrity: sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==}
+    engines: {node: '>=18.0.0'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -2177,6 +2267,10 @@ packages:
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
 
+  cross-inspect@1.0.1:
+    resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
+    engines: {node: '>=16.0.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2757,6 +2851,18 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql-ws@5.16.2:
+    resolution: {integrity: sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+
+  graphql-yoga@5.21.2:
+    resolution: {integrity: sha512-IIRF/3xtjj2D6caAWL9177hQ8tV3mWB3hve1GRnz7njPhQ3iY1jFtSp98fNGv0yV9kaPh9kKQ8JWdJZnedVmDw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
 
   graphql@16.14.2:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
@@ -4500,6 +4606,9 @@ packages:
       file-loader:
         optional: true
 
+  urlpattern-polyfill@10.1.0:
+    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -5129,6 +5238,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@envelop/core@5.5.1':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@envelop/types': 5.2.1
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@envelop/instrumentation@1.0.0':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@envelop/types@5.2.1':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
   '@epic-web/invariant@1.0.0': {}
 
   '@epic-web/test-server@0.1.6':
@@ -5227,6 +5353,8 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-uri: 3.1.3
 
+  '@fastify/busboy@3.2.0': {}
+
   '@fastify/error@4.2.0': {}
 
   '@fastify/fast-json-stringify-compiler@5.1.0':
@@ -5253,9 +5381,64 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@graphql-tools/executor@1.5.5(graphql@16.14.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.2.0(graphql@16.14.2)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@repeaterjs/repeater': 3.1.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.14.2
+      tslib: 2.8.1
+
+  '@graphql-tools/merge@9.2.0(graphql@16.14.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.2.0(graphql@16.14.2)
+      graphql: 16.14.2
+      tslib: 2.8.1
+
+  '@graphql-tools/schema@10.0.36(graphql@16.14.2)':
+    dependencies:
+      '@graphql-tools/merge': 9.2.0(graphql@16.14.2)
+      '@graphql-tools/utils': 11.2.0(graphql@16.14.2)
+      graphql: 16.14.2
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@10.11.0(graphql@16.14.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 16.14.2
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@11.2.0(graphql@16.14.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 16.14.2
+      tslib: 2.8.1
+
   '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
     dependencies:
       graphql: 16.14.2
+
+  '@graphql-yoga/logger@2.0.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@graphql-yoga/subscription@5.0.5':
+    dependencies:
+      '@graphql-yoga/typed-event-target': 3.0.2
+      '@repeaterjs/repeater': 3.1.0
+      '@whatwg-node/events': 0.1.2
+      tslib: 2.8.1
+
+  '@graphql-yoga/typed-event-target@3.0.2':
+    dependencies:
+      '@repeaterjs/repeater': 3.1.0
+      tslib: 2.8.1
 
   '@hono/node-server@1.19.14(hono@4.12.28)':
     dependencies:
@@ -5612,6 +5795,8 @@ snapshots:
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
+
+  '@repeaterjs/repeater@3.1.0': {}
 
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
@@ -6127,6 +6312,39 @@ snapshots:
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
+
+  '@whatwg-node/disposablestack@0.0.6':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@whatwg-node/events@0.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@whatwg-node/fetch@0.10.13':
+    dependencies:
+      '@whatwg-node/node-fetch': 0.8.6
+      urlpattern-polyfill: 10.1.0
+
+  '@whatwg-node/node-fetch@0.8.6':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@whatwg-node/promise-helpers@1.3.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@whatwg-node/server@0.11.0':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -6752,6 +6970,10 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  cross-inspect@1.0.1:
+    dependencies:
+      tslib: 2.8.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7497,6 +7719,26 @@ snapshots:
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql-ws@5.16.2(graphql@16.14.2):
+    dependencies:
+      graphql: 16.14.2
+
+  graphql-yoga@5.21.2(graphql@16.14.2):
+    dependencies:
+      '@envelop/core': 5.5.1
+      '@envelop/instrumentation': 1.0.0
+      '@graphql-tools/executor': 1.5.5(graphql@16.14.2)
+      '@graphql-tools/schema': 10.0.36(graphql@16.14.2)
+      '@graphql-tools/utils': 10.11.0(graphql@16.14.2)
+      '@graphql-yoga/logger': 2.0.1
+      '@graphql-yoga/subscription': 5.0.5
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      '@whatwg-node/server': 0.11.0
+      graphql: 16.14.2
+      lru-cache: 10.4.3
+      tslib: 2.8.1
 
   graphql@16.14.2: {}
 
@@ -9368,6 +9610,8 @@ snapshots:
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.108.4(esbuild@0.28.1)
+
+  urlpattern-polyfill@10.1.0: {}
 
   util-deprecate@1.0.2: {}
 

--- a/src/core/experimental/define-network.test.ts
+++ b/src/core/experimental/define-network.test.ts
@@ -1,3 +1,4 @@
+import { HttpHandler, HttpMethods } from '../handlers/HttpHandler'
 import { NetworkSource } from './sources/network-source'
 import { defineNetwork } from './define-network'
 
@@ -120,5 +121,33 @@ describe('disable()', () => {
 
     await network.enable()
     expect(network.disable()).toBeInstanceOf(Promise)
+  })
+
+  it('observes both the handler and the source disposal rejections', async () => {
+    const unhandledRejectionListener = vi.fn()
+    process.on('unhandledRejection', unhandledRejectionListener)
+
+    class RejectingNetworkSource extends NetworkSource {
+      enable = () => {}
+      disable = () => Promise.reject(new Error('Source disposal error'))
+    }
+
+    const handler = new HttpHandler(HttpMethods.GET, '/resource', () => {})
+    handler.dispose = () => Promise.reject(new Error('Handler disposal error'))
+
+    const network = defineNetwork({
+      sources: [new RejectingNetworkSource()],
+      handlers: [handler],
+    })
+
+    network.enable()
+
+    await expect(network.disable()).rejects.toThrow()
+
+    // Give an unobserved rejection a chance to surface.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    process.off('unhandledRejection', unhandledRejectionListener)
+
+    expect(unhandledRejectionListener).not.toHaveBeenCalled()
   })
 })

--- a/src/core/experimental/define-network.test.ts
+++ b/src/core/experimental/define-network.test.ts
@@ -127,27 +127,33 @@ describe('disable()', () => {
     const unhandledRejectionListener = vi.fn()
     process.on('unhandledRejection', unhandledRejectionListener)
 
-    class RejectingNetworkSource extends NetworkSource {
-      enable = () => {}
-      disable = () => Promise.reject(new Error('Source disposal error'))
+    try {
+      class RejectingNetworkSource extends NetworkSource {
+        enable = () => {}
+        disable = () => Promise.reject(new Error('Source disposal error'))
+      }
+
+      const handler = new HttpHandler(HttpMethods.GET, '/resource', () => {})
+      handler.dispose = () =>
+        Promise.reject(new Error('Handler disposal error'))
+
+      const network = defineNetwork({
+        sources: [new RejectingNetworkSource()],
+        handlers: [handler],
+      })
+
+      network.enable()
+
+      await expect(network.disable()).rejects.toThrow()
+
+      // Give an unobserved rejection a chance to surface.
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(unhandledRejectionListener).not.toHaveBeenCalled()
+    } finally {
+      // Detach the listener whether the assertions above pass or not,
+      // so a failure here cannot leak it into the rest of the run.
+      process.off('unhandledRejection', unhandledRejectionListener)
     }
-
-    const handler = new HttpHandler(HttpMethods.GET, '/resource', () => {})
-    handler.dispose = () => Promise.reject(new Error('Handler disposal error'))
-
-    const network = defineNetwork({
-      sources: [new RejectingNetworkSource()],
-      handlers: [handler],
-    })
-
-    network.enable()
-
-    await expect(network.disable()).rejects.toThrow()
-
-    // Give an unobserved rejection a chance to surface.
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    process.off('unhandledRejection', unhandledRejectionListener)
-
-    expect(unhandledRejectionListener).not.toHaveBeenCalled()
   })
 })

--- a/src/core/experimental/define-network.ts
+++ b/src/core/experimental/define-network.ts
@@ -238,7 +238,7 @@ export function defineNetwork<Sources extends Array<NetworkSource<any>>>(
       handlersController.restore()
     },
     listHandlers() {
-      return toReadonlyArray(handlersController.currentHandlers())
+      return toReadonlyArray(handlersController.listHandlers())
     },
   }
 }

--- a/src/core/experimental/define-network.ts
+++ b/src/core/experimental/define-network.ts
@@ -241,9 +241,14 @@ export function defineNetwork<Sources extends Array<NetworkSource<any>>>(
         resolvedOptions.sources.map((source) => source.disable()),
       )
 
+      /**
+       * @note Await both disposals so neither rejection goes unobserved.
+       * Chaining them would leave the source disposal floating whenever
+       * the handlers disposal rejects.
+       */
       return (
         handlersDisposal instanceof Promise
-          ? handlersDisposal.then(() => sourcesDisposal)
+          ? Promise.all([handlersDisposal, sourcesDisposal]).then(() => {})
           : sourcesDisposal
       ) as MaybePromise<ReturnType<Sources[number]['disable']>>
     },

--- a/src/core/experimental/define-network.ts
+++ b/src/core/experimental/define-network.ts
@@ -222,10 +222,29 @@ export function defineNetwork<Sources extends Array<NetworkSource<any>>>(
       )
 
       readyState = NetworkReadyState.DISABLED
+
+      // Let the handlers release the resources they hold before
+      // tearing down the network itself. Handlers may still need the
+      // network while disposing of themselves (e.g. to close the
+      // connections they own).
+      const handlersDisposal = handlersController.dispose()
       disposable.dispose()
 
-      return colorlessPromiseAll(
+      /**
+       * @note Tear down the sources synchronously, never behind the
+       * handlers disposal. `disable()` is not always awaited (e.g.
+       * `server.close()` is synchronous), and a deferred teardown would
+       * race any `enable()` that follows, disabling the sources that the
+       * new session has just enabled.
+       */
+      const sourcesDisposal = colorlessPromiseAll(
         resolvedOptions.sources.map((source) => source.disable()),
+      )
+
+      return (
+        handlersDisposal instanceof Promise
+          ? handlersDisposal.then(() => sourcesDisposal)
+          : sourcesDisposal
       ) as MaybePromise<ReturnType<Sources[number]['disable']>>
     },
     use(...handlers) {

--- a/src/core/experimental/frames/websocket-frame.ts
+++ b/src/core/experimental/frames/websocket-frame.ts
@@ -23,7 +23,45 @@ export interface WebSocketNetworkFrameOptions {
 
 export type WebSocketNetworkFrameEventMap = {
   connection: WebSocketConnectionEvent
+  'graphql:subscription': GraphQLSubscriptionEvent
   unhandledException: UnhandledWebSocketExceptionEvent
+}
+
+export interface GraphQLSubscriptionEventInit {
+  operationName: string
+  query: string
+  variables: Record<string, unknown>
+  request: Request
+}
+
+/**
+ * Emitted when a GraphQL subscription is established over an
+ * intercepted WebSocket connection (i.e. matched by a subscription
+ * handler and resolved).
+ *
+ * @note The event type is declared here, next to the WebSocket frame
+ * event map, so the life-cycle event emitters derived from this map
+ * (e.g. `server.events`) are typed correctly. It carries plain data
+ * only and is emitted exclusively by the `msw/graphql` module —
+ * the core stays free of the `graphql` dependency.
+ */
+export class GraphQLSubscriptionEvent extends TypedEvent<
+  void,
+  void,
+  'graphql:subscription'
+> {
+  public readonly operationName: string
+  public readonly query: string
+  public readonly variables: Record<string, unknown>
+  public readonly request: Request
+
+  constructor(init: GraphQLSubscriptionEventInit) {
+    super('graphql:subscription')
+    this.operationName = init.operationName
+    this.query = init.query
+    this.variables = init.variables
+    this.request = init.request
+  }
 }
 
 class WebSocketConnectionEvent<
@@ -115,6 +153,12 @@ export abstract class WebSocketNetworkFrame extends NetworkFrame<
     for (const handler of handlers) {
       const handlerConnection = await handler.run(connection, {
         baseUrl: resolutionContext?.baseUrl?.toString(),
+        /**
+         * @note Expose an emit-only reference to this frame's events
+         * so the handlers can emit additional events not covered by
+         * the frame (e.g. "graphql:subscription").
+         */
+        events: this.events,
         /**
          * @note Do not emit the "connection" event when running the handler.
          * Use the run only to get the resolved connection object.

--- a/src/core/experimental/handlers-controller.test.ts
+++ b/src/core/experimental/handlers-controller.test.ts
@@ -1,8 +1,61 @@
 import { http } from '../http'
 import { graphql } from '../../graphql'
 import { ws } from '../ws'
-import { getSiblingHandlers } from '../utils/internal/attachSiblingHandlers'
-import { InMemoryHandlersController } from './handlers-controller'
+import {
+  attachSiblingHandlers,
+  getSiblingHandlers,
+} from '../utils/internal/attachSiblingHandlers'
+import {
+  groupHandlersByKind,
+  InMemoryHandlersController,
+} from './handlers-controller'
+
+describe(groupHandlersByKind, () => {
+  it('groups handlers attached as siblings of siblings', () => {
+    const grandchildHandler = http.get('/grandchild', () => {})
+    const childHandler = attachSiblingHandlers(
+      http.get('/child', () => {}),
+      [grandchildHandler],
+    )
+    const ownerHandler = attachSiblingHandlers(
+      http.get('/owner', () => {}),
+      [childHandler],
+    )
+
+    expect(groupHandlersByKind([ownerHandler]).request).toEqual([
+      ownerHandler,
+      childHandler,
+      grandchildHandler,
+    ])
+  })
+
+  it('groups nested siblings of a different kind into their own bucket', () => {
+    const chat = ws.link('*')
+    const wsHandler = chat.addEventListener('connection', () => {})
+    const [upgradeHandler] = getSiblingHandlers(wsHandler)
+    const ownerHandler = attachSiblingHandlers(
+      http.get('/owner', () => {}),
+      [wsHandler],
+    )
+
+    const groups = groupHandlersByKind([ownerHandler])
+
+    expect(groups.websocket).toEqual([wsHandler])
+    expect(groups.request).toEqual([ownerHandler, upgradeHandler])
+  })
+
+  it('does not recurse infinitely given a cyclic sibling graph', () => {
+    const handlerOne = http.get('/one', () => {})
+    const handlerTwo = http.get('/two', () => {})
+    attachSiblingHandlers(handlerOne, [handlerTwo])
+    attachSiblingHandlers(handlerTwo, [handlerOne])
+
+    expect(groupHandlersByKind([handlerOne]).request).toEqual([
+      handlerOne,
+      handlerTwo,
+    ])
+  })
+})
 
 describe('constructor', () => {
   it('places the sibling in its own kind bucket', () => {
@@ -148,6 +201,29 @@ describe(InMemoryHandlersController.prototype.use, () => {
 
     expect(controller.getHandlersByKind('websocket')).toEqual([wsOne, wsTwo])
     expect(controller.getHandlersByKind('request')).toEqual([upgradeHandler])
+  })
+
+  it('dedupes the shared upgrade sibling against already-registered handlers', () => {
+    const chat = ws.link('*')
+    const wsOne = chat.addEventListener('connection', () => {})
+    const [upgradeHandler] = getSiblingHandlers(wsOne)
+    const controller = new InMemoryHandlersController([wsOne])
+
+    const wsTwo = chat.addEventListener('connection', () => {})
+    controller.use([wsTwo])
+
+    expect(controller.getHandlersByKind('websocket')).toEqual([wsTwo, wsOne])
+    expect(controller.getHandlersByKind('request')).toEqual([upgradeHandler])
+  })
+
+  it('moves an already-registered handler to the front when used again', () => {
+    const httpOne = http.get('/one', () => {})
+    const httpTwo = http.get('/two', () => {})
+    const controller = new InMemoryHandlersController([httpOne, httpTwo])
+
+    controller.use([httpTwo])
+
+    expect(controller.getHandlersByKind('request')).toEqual([httpTwo, httpOne])
   })
 })
 

--- a/src/core/experimental/handlers-controller.test.ts
+++ b/src/core/experimental/handlers-controller.test.ts
@@ -308,6 +308,35 @@ describe(InMemoryHandlersController.prototype.reset, () => {
   })
 })
 
+describe(InMemoryHandlersController.prototype.listHandlers, () => {
+  it('lists explicitly registered handlers, hiding their siblings', () => {
+    const httpHandler = http.get('/', () => {})
+    const wsHandler = ws.link('*').addEventListener('connection', () => {})
+
+    const controller = new InMemoryHandlersController([httpHandler, wsHandler])
+
+    expect(controller.listHandlers()).toEqual([httpHandler, wsHandler])
+  })
+
+  it('hides siblings of runtime handlers', () => {
+    const controller = new InMemoryHandlersController([])
+    const wsHandler = ws.link('*').addEventListener('connection', () => {})
+
+    controller.use([wsHandler])
+
+    expect(controller.listHandlers()).toEqual([wsHandler])
+  })
+
+  it('keeps siblings in "currentHandlers()" so the handler lifecycle reaches them', () => {
+    const wsHandler = ws.link('*').addEventListener('connection', () => {})
+    const [upgradeHandler] = getSiblingHandlers(wsHandler)
+
+    const controller = new InMemoryHandlersController([wsHandler])
+
+    expect(controller.currentHandlers()).toEqual([wsHandler, upgradeHandler])
+  })
+})
+
 describe(InMemoryHandlersController.prototype.getHandlersByKind, () => {
   it('returns an empty array given an empty controller', () => {
     const controller = new InMemoryHandlersController([])

--- a/src/core/experimental/handlers-controller.ts
+++ b/src/core/experimental/handlers-controller.ts
@@ -9,12 +9,21 @@ export type HandlersMap = Partial<Record<AnyHandler['kind'], Array<AnyHandler>>>
 
 export function groupHandlersByKind(handlers: Array<AnyHandler>): HandlersMap {
   const groups: HandlersMap = {}
+  const visitedHandlers = new Set<AnyHandler>()
 
-  const pushUnique = (kind: AnyHandler['kind'], handler: AnyHandler) => {
-    const bucket = (groups[kind] ||= [])
+  const visit = (handler: AnyHandler) => {
+    if (visitedHandlers.has(handler)) {
+      return
+    }
 
-    if (!bucket.includes(handler)) {
-      bucket.push(handler)
+    visitedHandlers.add(handler)
+    const bucket = (groups[handler.kind] ||= [])
+    bucket.push(handler)
+
+    // Recurse so siblings of siblings (user-composed handler
+    // graphs) are grouped as well, not silently dropped.
+    for (const sibling of getSiblingHandlers(handler)) {
+      visit(sibling)
     }
   }
 
@@ -22,11 +31,7 @@ export function groupHandlersByKind(handlers: Array<AnyHandler>): HandlersMap {
    * @note `Object.groupBy` is not implemented in Node.js v20.
    */
   for (const handler of handlers) {
-    pushUnique(handler.kind, handler)
-
-    for (const sibling of getSiblingHandlers(handler)) {
-      pushUnique(sibling.kind, sibling)
-    }
+    visit(handler)
   }
 
   return groups
@@ -86,11 +91,19 @@ export abstract class HandlersController {
 
     // Prepend overrides to their respective kind buckets so they take
     // priority over existing handlers while preserving input order.
+    // Drop existing references that reappear in the overrides (e.g. a
+    // shared upgrade sibling from the same link) so a handler is never
+    // registered twice.
     for (const kind in overrides) {
       const overridesForKind = overrides[kind as AnyHandler['kind']]!
       const existingForKind = handlers[kind as AnyHandler['kind']]
       handlers[kind as AnyHandler['kind']] = existingForKind
-        ? [...overridesForKind, ...existingForKind]
+        ? [
+            ...overridesForKind,
+            ...existingForKind.filter((existingHandler) => {
+              return !overridesForKind.includes(existingHandler)
+            }),
+          ]
         : overridesForKind
     }
 

--- a/src/core/experimental/handlers-controller.ts
+++ b/src/core/experimental/handlers-controller.ts
@@ -2,6 +2,7 @@ import { invariant } from 'outvariant'
 import { type RequestHandler } from '../handlers/RequestHandler'
 import { type WebSocketHandler } from '../handlers/WebSocketHandler'
 import { devUtils } from '../utils/internal/devUtils'
+import type { MaybePromise } from '../typeUtils'
 import {
   getSiblingHandlers,
   isSiblingHandler,
@@ -134,9 +135,7 @@ export abstract class HandlersController {
     )
 
     for (const handler of this.currentHandlers()) {
-      if ('reset' in handler) {
-        handler['reset']()
-      }
+      handler.reset()
     }
 
     const { initialHandlers } = this.getState()
@@ -159,9 +158,25 @@ export abstract class HandlersController {
 
   public restore(): void {
     for (const handler of this.currentHandlers()) {
-      if ('restore' in handler) {
-        handler['restore']()
+      handler.restore()
+    }
+  }
+
+  public dispose(): MaybePromise<void> {
+    const pendingDisposals: Array<Promise<void>> = []
+
+    for (const handler of this.currentHandlers()) {
+      const disposal = handler.dispose()
+
+      if (disposal instanceof Promise) {
+        pendingDisposals.push(disposal)
       }
+    }
+
+    // Stay synchronous unless a handler actually disposes of
+    // itself asynchronously.
+    if (pendingDisposals.length > 0) {
+      return Promise.all(pendingDisposals).then(() => {})
     }
   }
 

--- a/src/core/experimental/handlers-controller.ts
+++ b/src/core/experimental/handlers-controller.ts
@@ -2,7 +2,10 @@ import { invariant } from 'outvariant'
 import { type RequestHandler } from '../handlers/RequestHandler'
 import { type WebSocketHandler } from '../handlers/WebSocketHandler'
 import { devUtils } from '../utils/internal/devUtils'
-import { getSiblingHandlers } from '../utils/internal/attachSiblingHandlers'
+import {
+  getSiblingHandlers,
+  isSiblingHandler,
+} from '../utils/internal/attachSiblingHandlers'
 
 export type AnyHandler = RequestHandler | WebSocketHandler
 export type HandlersMap = Partial<Record<AnyHandler['kind'], Array<AnyHandler>>>
@@ -68,6 +71,18 @@ export abstract class HandlersController {
     return Object.values(this.getState().handlers)
       .flat()
       .filter((handler) => handler != null)
+  }
+
+  /**
+   * Return the list of explicitly registered handlers.
+   * Unlike `currentHandlers()`, this excludes sibling handlers,
+   * which are an implementation detail (e.g. the WebSocket upgrade
+   * handler or the GraphQL subscription transport).
+   */
+  public listHandlers(): Array<AnyHandler> {
+    return this.currentHandlers().filter((handler) => {
+      return !isSiblingHandler(handler)
+    })
   }
 
   public getHandlersByKind(kind: AnyHandler['kind']): Array<AnyHandler> {

--- a/src/core/experimental/setup-api.ts
+++ b/src/core/experimental/setup-api.ts
@@ -50,6 +50,6 @@ export abstract class SetupApi<
   }
 
   public listHandlers(): ReadonlyArray<AnyHandler> {
-    return toReadonlyArray(this.handlersController.currentHandlers())
+    return toReadonlyArray(this.handlersController.listHandlers())
   }
 }

--- a/src/core/handlers/Handler.ts
+++ b/src/core/handlers/Handler.ts
@@ -1,0 +1,42 @@
+import type { MaybePromise } from '../typeUtils'
+
+export type HandlerKind = 'request' | 'websocket'
+
+/**
+ * The base class for all the handlers.
+ */
+export abstract class Handler {
+  /**
+   * The kind of the network frame this handler handles.
+   */
+  abstract readonly kind: HandlerKind
+
+  /**
+   * Reset the runtime state this handler accumulated while handling
+   * the network (e.g. generator resolver progress).
+   *
+   * @note This method is invoked automatically when the handlers are
+   * reset (e.g. `server.resetHandlers()`).
+   */
+  public reset(): void {}
+
+  /**
+   * Restore this handler so it can handle the network again after
+   * being exhausted (e.g. via `{ once: true }`).
+   *
+   * @note This method is invoked automatically when the handlers are
+   * restored (e.g. `server.restoreHandlers()`).
+   */
+  public restore(): void {}
+
+  /**
+   * Release the resources held by this handler.
+   *
+   * @note This method is invoked automatically when the network is
+   * disabled (e.g. `server.close()`). Override it in the handlers that
+   * hold onto anything beyond a single frame, like timers, connections,
+   * or event listeners. Returning a promise makes the network await
+   * this handler's disposal before it tears itself down.
+   */
+  public dispose(): MaybePromise<void> {}
+}

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -100,7 +100,7 @@ export type ResponseResolverInfo<
   finalize: ResponseResolverFinalizeFunction
 } & ResolverExtraInfo
 
-type ResponseResolverFinalizeFunction = (
+export type ResponseResolverFinalizeFunction = (
   callback: () => MaybePromise<void>,
 ) => void
 

--- a/src/core/handlers/RequestHandler.ts
+++ b/src/core/handlers/RequestHandler.ts
@@ -1,3 +1,4 @@
+import { Handler } from './Handler'
 import { getCallFrame } from '../utils/internal/getCallFrame'
 import {
   isIterable,
@@ -140,13 +141,13 @@ export abstract class RequestHandler<
   ParsedResult extends Record<string, any> | undefined = any,
   ResolverExtras extends Record<string, unknown> = any,
   HandlerOptions extends RequestHandlerOptions = RequestHandlerOptions,
-> {
+> extends Handler {
   static cache = new WeakMap<
     StrictRequest<DefaultBodyType>,
     StrictRequest<DefaultBodyType>
   >()
 
-  public readonly kind = 'request' as const
+  public readonly kind = 'request'
 
   protected resolver: ResponseResolver<ResolverExtras, any, any>
   private resolverIterator?:
@@ -174,6 +175,8 @@ export abstract class RequestHandler<
   public isUsed: boolean
 
   constructor(args: RequestHandlerArgs<HandlerInfo, HandlerOptions>) {
+    super()
+
     this.resolver = args.resolver
     this.options = args.options
     this.scheduledCleanups = new Map()
@@ -194,7 +197,7 @@ export abstract class RequestHandler<
    * removed from the active handlers list so re-adding it later starts
    * from a clean state.
    */
-  protected reset(): void {
+  public reset(): void {
     this.scheduledCleanups.clear()
 
     const iterator = this.resolverIterator
@@ -212,7 +215,7 @@ export abstract class RequestHandler<
    * exhausted (e.g. via `{ once: true }`). Also clears any accumulated
    * resolution state.
    */
-  protected restore(): void {
+  public restore(): void {
     if (this.options?.once) {
       this.reset()
       this.isUsed = false

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -1,10 +1,16 @@
 import { Emitter } from 'strict-event-emitter'
+import type { Emitter as NetworkFrameEmitter } from 'rettime'
 import { createRequestId, resolveWebSocketUrl } from '@mswjs/interceptors'
 import type {
   WebSocketClientConnectionProtocol,
   WebSocketConnectionData,
   WebSocketServerConnectionProtocol,
 } from '@mswjs/interceptors/WebSocket'
+/**
+ * @note A type-only import to prevent a runtime module cycle
+ * (the frame module imports this handler at runtime).
+ */
+import type { WebSocketNetworkFrameEventMap } from '../experimental/frames/websocket-frame'
 import {
   type Match,
   type Path,
@@ -31,6 +37,14 @@ export interface WebSocketHandlerConnection {
 
 export interface WebSocketResolutionContext {
   baseUrl?: string
+
+  /**
+   * An emit-only reference to the network frame's events.
+   * Allows handlers to emit additional events not covered by the frame
+   * into the network's life-cycle event stream (e.g. `server.events`).
+   */
+  events?: Pick<NetworkFrameEmitter<WebSocketNetworkFrameEventMap>, 'emit'>
+
   [kAutoConnect]?: boolean
 }
 
@@ -217,8 +231,7 @@ export class WebSocketHandler {
 function createStopPropagationListener(handler: WebSocketHandler) {
   return function stopPropagationListener(event: Event) {
     const propagationStoppedAt = Reflect.get(event, 'kPropagationStoppedAt') as
-      | string
-      | undefined
+      string | undefined
 
     if (propagationStoppedAt && handler.id !== propagationStoppedAt) {
       event.stopImmediatePropagation()

--- a/src/core/handlers/WebSocketHandler.ts
+++ b/src/core/handlers/WebSocketHandler.ts
@@ -17,6 +17,7 @@ import {
   type PathParams,
   matchRequestUrl,
 } from '../utils/matching/matchRequestUrl'
+import { Handler } from './Handler'
 import { getCallFrame } from '../utils/internal/getCallFrame'
 import { attachWebSocketLogger } from '../ws/utils/attachWebSocketLogger'
 
@@ -56,14 +57,17 @@ export const kAutoConnect = Symbol('kAutoConnect')
 const kStopPropagationPatched = Symbol('kStopPropagationPatched')
 const KOnStopPropagation = Symbol('KOnStopPropagation')
 
-export class WebSocketHandler {
+export class WebSocketHandler extends Handler {
   public id: string
   public callFrame?: string
-  public kind = 'websocket' as const
+
+  public readonly kind = 'websocket'
 
   protected [kEmitter]: Emitter<WebSocketHandlerEventMap>
 
   constructor(protected readonly url: Path) {
+    super()
+
     this.id = createRequestId()
 
     this[kEmitter] = new Emitter()

--- a/src/core/utils/internal/attachSiblingHandlers.ts
+++ b/src/core/utils/internal/attachSiblingHandlers.ts
@@ -2,6 +2,7 @@ import { invariant } from 'outvariant'
 import type { AnyHandler } from '../../experimental/handlers-controller'
 
 const kSiblingHandlers = Symbol('kSiblingHandlers')
+const kIsSiblingHandler = Symbol('kIsSiblingHandler')
 
 export function attachSiblingHandlers<T extends AnyHandler>(
   owner: T,
@@ -20,9 +21,28 @@ export function attachSiblingHandlers<T extends AnyHandler>(
     configurable: false,
   })
 
+  // Mark the siblings so introspection (e.g. `.listHandlers()`) can tell
+  // explicitly registered handlers from their implementation details.
+  // Shared siblings can be attached to multiple owners, so skip the
+  // already-marked ones.
+  for (const sibling of siblings) {
+    if (!isSiblingHandler(sibling)) {
+      Object.defineProperty(sibling, kIsSiblingHandler, {
+        value: true,
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      })
+    }
+  }
+
   return owner
 }
 
 export function getSiblingHandlers(owner: AnyHandler): Array<AnyHandler> {
   return Reflect.get(owner, kSiblingHandlers) || []
+}
+
+export function isSiblingHandler(handler: AnyHandler): boolean {
+  return Reflect.get(handler, kIsSiblingHandler) === true
 }

--- a/src/core/ws.ts
+++ b/src/core/ws.ts
@@ -89,6 +89,21 @@ export type WebSocketLink = {
 }
 
 /**
+ * Creates a request handler that responds to WebSocket upgrade
+ * requests whose URL matches the given path.
+ *
+ * @internal
+ */
+export function createWebSocketUpgradeHandler(url: Path) {
+  return http.get(({ request }) => {
+    return (
+      request.headers.get('upgrade')?.toLowerCase() === 'websocket' &&
+      matchRequestUrl(new URL(resolveWebSocketUrl(request.url)), url).matches
+    )
+  }, ws.onUpgrade)
+}
+
+/**
  * Intercepts outgoing WebSocket connections to the given URL.
  *
  * @example
@@ -112,12 +127,7 @@ function createWebSocketLinkHandler(url: Path): WebSocketLink {
   // WebSocketHandler returned by this link. `groupHandlersByKind` dedupes
   // by reference, so it lands in the `request` bucket exactly once regardless
   // of which subset of WS handlers the user ends up registering.
-  const upgradeHandler = http.get(({ request }) => {
-    return (
-      request.headers.get('upgrade')?.toLowerCase() === 'websocket' &&
-      matchRequestUrl(new URL(resolveWebSocketUrl(request.url)), url).matches
-    )
-  }, ws.onUpgrade)
+  const upgradeHandler = createWebSocketUpgradeHandler(url)
 
   return {
     get clients() {

--- a/src/graphql/graphql-handler.ts
+++ b/src/graphql/graphql-handler.ts
@@ -184,6 +184,36 @@ export class GraphQLHandler extends RequestHandler<
     return predicate
   }
 
+  /**
+   * Creates a GraphQL handler information object from the given
+   * operation predicate. Normalizes `DocumentNode` and typed document
+   * string predicates to plain operation names.
+   */
+  static parseGraphQLRequestInfo(args: {
+    operationType: GraphQLOperationType
+    predicate: GraphQLPredicate
+    url: Path
+  }): GraphQLHandlerInfo {
+    const operationName = GraphQLHandler.#parseOperationName(
+      args.predicate,
+      args.operationType,
+    )
+
+    const displayOperationName =
+      typeof operationName === 'function' ? '[custom predicate]' : operationName
+
+    const header =
+      args.operationType === 'all'
+        ? `${args.operationType} (origin: ${args.url.toString()})`
+        : `${args.operationType}${displayOperationName ? ` ${displayOperationName}` : ''} (origin: ${args.url.toString()})`
+
+    return {
+      header,
+      operationType: args.operationType,
+      operationName,
+    }
+  }
+
   constructor(
     operationType: GraphQLOperationType,
     predicate: GraphQLPredicate,
@@ -191,28 +221,12 @@ export class GraphQLHandler extends RequestHandler<
     resolver: ResponseResolver<GraphQLResolverExtras<any>, any, any>,
     options?: RequestHandlerOptions,
   ) {
-    const operationName = GraphQLHandler.#parseOperationName(
-      predicate,
-      operationType,
-    )
-
-    const displayOperationName =
-      typeof operationName === 'function' ? '[custom predicate]' : operationName
-
-    const header =
-      operationType === 'all'
-        ? `${operationType} (origin: ${endpoint.toString()})`
-        : `${operationType}${displayOperationName ? ` ${displayOperationName}` : ''} (origin: ${endpoint.toString()})`
-
     super({
-      info: {
-        header,
+      info: GraphQLHandler.parseGraphQLRequestInfo({
         operationType,
-        operationName: GraphQLHandler.#parseOperationName(
-          predicate,
-          operationType,
-        ),
-      },
+        predicate,
+        url: endpoint,
+      }),
       resolver,
       options,
     })
@@ -242,10 +256,8 @@ export class GraphQLHandler extends RequestHandler<
   }
 
   async parse(args: { request: Request }): Promise<GraphQLRequestParsedResult> {
-    /**
-     * If the request doesn't match a specified endpoint, there's no
-     * need to parse it since there's no case where we would handle this
-     */
+    // If the request doesn't match a specified endpoint, there's no
+    // need to parse it since there's no case where we would handle this
     const match = matchRequestUrl(new URL(args.request.url), this.endpoint)
     const cookies = getAllRequestCookies(args.request)
 

--- a/src/graphql/graphql-subscription.test.ts
+++ b/src/graphql/graphql-subscription.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+import { OperationTypeNode, parse } from 'graphql'
+import { getSiblingHandlers } from '#core/utils/internal/attachSiblingHandlers'
+import type { GraphQLHandlerInfo } from './graphql-handler'
+import {
+  createGraphQLSubscriptionHandler,
+  GraphQLSubscriptionTransportHandler,
+} from './graphql-subscription'
+
+const subscription = createGraphQLSubscriptionHandler(
+  'http://localhost:4000/graphql',
+)
+
+describe('info', () => {
+  it('resolves handler info for a string operation name', () => {
+    expect(
+      subscription('OnCommentAdded', () => {}).info,
+    ).toEqual<GraphQLHandlerInfo>({
+      header:
+        'subscription OnCommentAdded (origin: ws://localhost:4000/graphql)',
+      operationName: 'OnCommentAdded',
+      operationType: OperationTypeNode.SUBSCRIPTION,
+    })
+  })
+
+  it('resolves handler info for a RegExp operation name', () => {
+    expect(subscription(/Comment/, () => {}).info).toEqual<GraphQLHandlerInfo>({
+      header: 'subscription /Comment/ (origin: ws://localhost:4000/graphql)',
+      operationName: /Comment/,
+      operationType: OperationTypeNode.SUBSCRIPTION,
+    })
+  })
+
+  it('resolves handler info for a DocumentNode operation name', () => {
+    const node = parse(`
+      subscription OnCommentAdded {
+        comment {
+          id
+        }
+      }
+    `)
+
+    expect(subscription(node, () => {}).info).toEqual<GraphQLHandlerInfo>({
+      header:
+        'subscription OnCommentAdded (origin: ws://localhost:4000/graphql)',
+      operationName: 'OnCommentAdded',
+      operationType: OperationTypeNode.SUBSCRIPTION,
+    })
+  })
+})
+
+describe('predicate', () => {
+  it('returns true for a matching WebSocket connection url', () => {
+    const handler = subscription('OnCommentAdded', () => {})
+    const url = 'ws://localhost:4000/graphql'
+    const parsedResult = handler.parse({ url })
+
+    expect(handler.predicate({ url, parsedResult })).toBe(true)
+  })
+
+  it('returns false for a non-matching WebSocket connection url', () => {
+    const handler = subscription('OnCommentAdded', () => {})
+    const url = 'ws://example.com/chat'
+    const parsedResult = handler.parse({ url })
+
+    expect(handler.predicate({ url, parsedResult })).toBe(false)
+  })
+})
+
+describe('sibling handlers', () => {
+  it('shares the transport and upgrade handlers between subscription handlers', () => {
+    const firstHandler = subscription('OnCommentAdded', () => {})
+    const secondHandler = subscription('OnPostAdded', () => {})
+
+    const firstSiblings = getSiblingHandlers(firstHandler)
+    const secondSiblings = getSiblingHandlers(secondHandler)
+
+    expect(firstSiblings).toHaveLength(2)
+    expect(firstSiblings[0]).toBeInstanceOf(GraphQLSubscriptionTransportHandler)
+
+    // The transport and the upgrade handlers must be shared by reference
+    // so the handlers controller dedupes them across subscription handlers.
+    expect(secondSiblings[0]).toBe(firstSiblings[0])
+    expect(secondSiblings[1]).toBe(firstSiblings[1])
+  })
+})

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -648,7 +648,10 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     let node: ParsedGraphQLQuery
 
     try {
-      node = parseDocumentNode(parse(message.payload.query))
+      node = parseDocumentNode(
+        parse(message.payload.query),
+        message.payload.operationName,
+      )
     } catch (error) {
       devUtils.warn(
         'Failed to intercept a GraphQL subscription to "%s": the subscription query is not a valid GraphQL document.\n\n%s',

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -128,6 +128,13 @@ export interface GraphQLSubscriptionPayload<
   extensions?: Record<string, unknown>
 }
 
+function createInitMessage(payload?: Record<string, unknown>): string {
+  return JSON.stringify({
+    type: 'connection_init',
+    payload,
+  } satisfies GraphQLWebSocketInitMessage)
+}
+
 function createAcknowledgeMessage(): string {
   return JSON.stringify({
     type: 'connection_ack',
@@ -212,6 +219,12 @@ interface GraphQLSubscriptionConnection {
    */
   subscriptions: Map<string, Array<GraphQLSubscriptionCleanup>>
   events?: WebSocketResolutionContext['events']
+  /**
+   * The payload of the client's `connection_init` message (i.e. the
+   * `connectionParams` of the GraphQL client). Kept so it can be
+   * replayed to the original server on passthrough.
+   */
+  connectionParams?: Record<string, unknown>
 }
 
 /**
@@ -604,6 +617,9 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
 
     switch (message.type) {
       case 'connection_init': {
+        // Preserve the initialization payload (e.g. the client's
+        // credentials) so passthrough can replay it to the server.
+        connection.connectionParams = message.payload
         connection.client.send(createAcknowledgeMessage())
         break
       }
@@ -1002,6 +1018,7 @@ export class GraphQLSubscription<
     return new GraphQLPassthroughSubscription({
       server: connection.server,
       message: this.#message,
+      connectionParams: connection.connectionParams,
       onTerminate: () => {
         this.#transport.endSubscription({
           clientId: this.#clientId,
@@ -1029,14 +1046,17 @@ export class GraphQLPassthroughSubscription {
   readonly #emitter: Emitter<GraphQLPassthroughSubscriptionEventMap>
   readonly #abortController: AbortController
   readonly #onTerminate: () => void
+  readonly #connectionParams?: Record<string, unknown>
 
   constructor(args: {
     server: WebSocketServerConnectionProtocol
     message: GraphQLWebSocketSubscribeMessage
+    connectionParams?: Record<string, unknown>
     onTerminate: () => void
   }) {
     this.#server = args.server
     this.#message = args.message
+    this.#connectionParams = args.connectionParams
     this.#onTerminate = args.onTerminate
     this.#emitter = new Emitter()
 
@@ -1051,11 +1071,7 @@ export class GraphQLPassthroughSubscription {
         // Once the WebSocket server connection is established, send the
         // client connection prompt to the server. This lets the server
         // connect and authorize this client.
-        this.#server.send(
-          JSON.stringify({
-            type: 'connection_init',
-          } satisfies GraphQLWebSocketInitMessage),
-        )
+        this.#server.send(createInitMessage(this.#connectionParams))
       },
       { signal: this.#abortController.signal },
     )

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -200,20 +200,17 @@ interface GraphQLSubscriptionSubscriberEntry {
   subscriber: GraphQLSubscriptionSubscriber
 }
 
-/**
- * An active subscription and the cleanups scheduled for it via the
- * `finalize()` function exposed to the subscription resolver.
- */
-interface GraphQLSubscriptionEntry {
-  message: GraphQLWebSocketSubscribeMessage
-  cleanups: Array<() => MaybePromise<void>>
-}
+type GraphQLSubscriptionCleanup = () => MaybePromise<void>
 
 interface GraphQLSubscriptionConnection {
   client: WebSocketClientConnectionProtocol
   server: WebSocketServerConnectionProtocol
   subscribers: Map<WebSocketHandler, GraphQLSubscriptionSubscriberEntry>
-  subscriptions: Map<string, GraphQLSubscriptionEntry>
+  /**
+   * The active subscriptions of this connection, mapped to the cleanups
+   * scheduled for them via the resolver's `finalize()`.
+   */
+  subscriptions: Map<string, Array<GraphQLSubscriptionCleanup>>
   events?: WebSocketResolutionContext['events']
 }
 
@@ -242,18 +239,6 @@ const connections = new Map<string, GraphQLSubscriptionConnection>()
  * matching subscription handler.
  */
 export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
-  /**
-   * The sessions this transport participates in. A subset of the shared
-   * `connections` registry, kept so `reset()` only drops the state that
-   * belongs to this transport.
-   */
-  #connections: Set<GraphQLSubscriptionConnection>
-
-  constructor(url: Path) {
-    super(url)
-    this.#connections = new Set()
-  }
-
   /**
    * Register the given handler as a subscriber to the GraphQL
    * subscriptions on the given WebSocket connection. Subscribers are
@@ -289,19 +274,17 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     // long after the run: whenever the client sends a "subscribe" message.
     if (handlerConnection) {
       const transportConnection = this.#getOrCreateConnection(handlerConnection)
-      transportConnection.events = resolutionContext?.events
+
+      // Never overwrite the events of a session shared with another
+      // transport: only the frame that resolved it provides them.
+      if (resolutionContext?.events) {
+        transportConnection.events = resolutionContext.events
+      }
     }
 
     return handlerConnection
   }
 
-  /**
-   * Schedule a cleanup to run once the given subscription ends.
-   *
-   * @note If the subscription has already ended by the time this is
-   * called, the cleanup runs immediately. The resolver can no longer
-   * affect that subscription, so there is nothing left to wait for.
-   */
   /**
    * End the given subscription without notifying the client. Used when
    * the subscription has already been terminated over the wire (e.g. the
@@ -313,26 +296,39 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }): void {
     const connection = connections.get(args.clientId)
 
-    if (connection != null) {
+    if (connection) {
       this.#endSubscription(connection, args.subscriptionId)
     }
   }
 
+  /**
+   * Schedule a cleanup to run once the given subscription ends.
+   *
+   * @note If the subscription has already ended by the time this is
+   * called, the cleanup runs immediately. The resolver can no longer
+   * affect that subscription, so there is nothing left to wait for.
+   */
   public finalize(args: {
     clientId: string
     subscriptionId: string
-    cleanup: () => MaybePromise<void>
+    cleanup: GraphQLSubscriptionCleanup
   }): void {
-    const subscription = connections
+    const cleanups = connections
       .get(args.clientId)
       ?.subscriptions.get(args.subscriptionId)
 
-    if (subscription == null) {
-      void args.cleanup()
+    if (cleanups) {
+      cleanups.push(args.cleanup)
       return
     }
 
-    subscription.cleanups.push(args.cleanup)
+    this.#exhaustCleanups([args.cleanup])
+  }
+
+  #endAllSubscriptions(connection: GraphQLSubscriptionConnection): void {
+    for (const subscriptionId of connection.subscriptions.keys()) {
+      this.#endSubscription(connection, subscriptionId)
+    }
   }
 
   /**
@@ -340,32 +336,51 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
    *
    * This is the single exit point for every way a subscription can end:
    * completed by the mock, by the client, or by the original server;
-   * terminated with errors; or dropped when the client disconnects.
-   * Ending an already-ended subscription is a no-op, so the cleanups
-   * are guaranteed to run at most once.
+   * terminated with errors; dropped when the client disconnects; or
+   * detached from its resolver when the handlers are reset. Ending an
+   * already-ended subscription is a no-op, so the cleanups are
+   * guaranteed to run at most once.
    */
-  #endAllSubscriptions(connection: GraphQLSubscriptionConnection): void {
-    for (const subscriptionId of Array.from(connection.subscriptions.keys())) {
-      this.#endSubscription(connection, subscriptionId)
-    }
-  }
-
   #endSubscription(
     connection: GraphQLSubscriptionConnection,
     subscriptionId: string,
   ): void {
-    const subscription = connection.subscriptions.get(subscriptionId)
+    const cleanups = connection.subscriptions.get(subscriptionId)
 
-    if (subscription == null) {
+    if (!cleanups) {
       return
     }
 
     connection.subscriptions.delete(subscriptionId)
+    this.#exhaustCleanups(cleanups)
+  }
 
-    // Run the cleanups as LIFO, consistently with `finalize()`
-    // in the request handlers.
-    for (let index = subscription.cleanups.length - 1; index >= 0; index--) {
-      void subscription.cleanups[index]()
+  /**
+   * Run the given cleanups as LIFO, consistently with `finalize()` in
+   * the request handlers. Cleanups are detached from the subscription
+   * life-cycle: nothing awaits them, so this must never reject.
+   */
+  async #exhaustCleanups(
+    cleanups: Array<GraphQLSubscriptionCleanup>,
+  ): Promise<void> {
+    const errors: Array<Error> = []
+
+    for (let index = cleanups.length - 1; index >= 0; index--) {
+      try {
+        await cleanups[index]()
+      } catch (error) {
+        if (error instanceof Error) {
+          errors.push(error)
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      devUtils.error(
+        'Failed to execute the cleanup for a GraphQL subscription to "%s". Please see the original error below.',
+        this.url.toString(),
+        new AggregateError(errors),
+      )
     }
   }
 
@@ -452,19 +467,22 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
    * controller resets the handlers (e.g. `server.resetHandlers()`).
    */
   public reset(): void {
-    for (const connection of this.#connections) {
+    for (const connection of connections.values()) {
+      let ownsConnection = false
+
       for (const [handler, entry] of connection.subscribers) {
         if (entry.transport === this) {
           connection.subscribers.delete(handler)
+          ownsConnection = true
         }
       }
 
       // Resetting the handlers detaches the resolvers from their
       // subscriptions, so run their cleanups instead of dropping them.
-      this.#endAllSubscriptions(connection)
+      if (ownsConnection) {
+        this.#endAllSubscriptions(connection)
+      }
     }
-
-    this.#connections.clear()
   }
 
   /**
@@ -488,7 +506,6 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     const existingConnection = connections.get(client.id)
 
     if (existingConnection) {
-      this.#connections.add(existingConnection)
       return existingConnection
     }
 
@@ -499,7 +516,6 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
       subscriptions: new Map(),
     }
     connections.set(client.id, transportConnection)
-    this.#connections.add(transportConnection)
 
     // Bind the protocol listeners alongside the session that owns them.
     // Creating the session and binding its listeners is a single step, so
@@ -603,7 +619,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
 
     // Register the subscription before dispatching it so the resolver
     // can publish to it synchronously.
-    connection.subscriptions.set(message.id, { message, cleanups: [] })
+    connection.subscriptions.set(message.id, [])
 
     for (const { subscriber } of connection.subscribers.values()) {
       if (subscriber({ node, message })) {

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -176,6 +176,20 @@ function createPongMessage(): string {
   } satisfies GraphQLWebSocketPongMessage)
 }
 
+/**
+ * Construct a request representing the WebSocket upgrade of the given
+ * connection. GraphQL subscriptions have no request of their own, so
+ * this describes the connection they are multiplexed over.
+ */
+function createUpgradeRequest(url: URL): Request {
+  return new Request(url, {
+    headers: {
+      connection: 'upgrade',
+      upgrade: 'websocket',
+    },
+  })
+}
+
 function parseGraphQLWebSocketMessage<MessageType extends { type: string }>(
   data: WebSocketData,
 ): MessageType | undefined {
@@ -758,12 +772,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
         operationName: node.operationName,
         query: message.payload.query,
         variables: { ...message.payload.variables },
-        request: new Request(connection.client.url, {
-          headers: {
-            connection: 'upgrade',
-            upgrade: 'websocket',
-          },
-        }),
+        request: createUpgradeRequest(connection.client.url),
       }),
     )
   }
@@ -792,6 +801,12 @@ export interface GraphQLSubscriptionResolverInfo<
    * Intercepted GraphQL subscription.
    */
   subscription: GraphQLSubscription<Query, Variables>
+
+  /**
+   * The request that established the WebSocket connection this
+   * subscription is multiplexed over.
+   */
+  request: Request
 
   /**
    * Schedule a cleanup to run once this subscription ends and the
@@ -922,6 +937,7 @@ export class GraphQLSubscriptionHandler<
       params: connection.params,
       operationName,
       subscription,
+      request: createUpgradeRequest(connection.client.url),
       finalize: (cleanup) => {
         this.#transport.finalize({
           clientId: connection.client.id,

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -193,14 +193,31 @@ type GraphQLSubscriptionSubscriber = (args: {
   message: GraphQLWebSocketSubscribeMessage
 }) => boolean
 
+interface GraphQLSubscriptionSubscriberEntry {
+  transport: GraphQLSubscriptionTransportHandler
+  subscriber: GraphQLSubscriptionSubscriber
+}
+
 interface GraphQLSubscriptionConnection {
   client: WebSocketClientConnectionProtocol
   server: WebSocketServerConnectionProtocol
-  subscribers: Map<WebSocketHandler, GraphQLSubscriptionSubscriber>
+  subscribers: Map<WebSocketHandler, GraphQLSubscriptionSubscriberEntry>
   subscriptions: Map<string, GraphQLWebSocketSubscribeMessage>
   events?: WebSocketResolutionContext['events']
-  isBound: boolean
 }
+
+/**
+ * The `graphql-transport-ws` sessions of the intercepted WebSocket
+ * connections, keyed by the client id.
+ *
+ * @note This registry is module-level, and not per-transport, on purpose.
+ * Multiple `graphql.link()` calls to the same endpoint create multiple
+ * transports, and all of them must share a single session per connection.
+ * Otherwise, each transport binds its own protocol listeners to the same
+ * client, which makes it receive duplicate `connection_ack`/`pong` frames
+ * and resolves matching subscription handlers more than once.
+ */
+const connections = new Map<string, GraphQLSubscriptionConnection>()
 
 /**
  * A WebSocket handler implementing the `graphql-transport-ws` protocol
@@ -214,11 +231,16 @@ interface GraphQLSubscriptionConnection {
  * matching subscription handler.
  */
 export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
-  #connections: Map<string, GraphQLSubscriptionConnection>
+  /**
+   * The sessions this transport participates in. A subset of the shared
+   * `connections` registry, kept so `reset()` only drops the state that
+   * belongs to this transport.
+   */
+  #connections: Set<GraphQLSubscriptionConnection>
 
   constructor(url: Path) {
     super(url)
-    this.#connections = new Map()
+    this.#connections = new Set()
   }
 
   /**
@@ -233,13 +255,16 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     subscriber: GraphQLSubscriptionSubscriber,
   ): void {
     const transportConnection = this.#getOrCreateConnection(connection)
-    transportConnection.subscribers.set(handler, subscriber)
+    transportConnection.subscribers.set(handler, {
+      transport: this,
+      subscriber,
+    })
   }
 
   public getConnection(
     clientId: string,
   ): GraphQLSubscriptionConnection | undefined {
-    return this.#connections.get(clientId)
+    return connections.get(clientId)
   }
 
   public async run(
@@ -333,11 +358,25 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   /**
-   * Clear the registry of connections and their active subscriptions.
+   * Drop this transport's subscribers and active subscriptions from the
+   * sessions it participates in. The sessions themselves are left intact:
+   * they are shared with the other transports of the same connection and
+   * own the protocol listeners for as long as the client stays connected.
+   *
    * @note This method is invoked automatically when the handlers
    * controller resets the handlers (e.g. `server.resetHandlers()`).
    */
   public reset(): void {
+    for (const connection of this.#connections) {
+      for (const [handler, entry] of connection.subscribers) {
+        if (entry.transport === this) {
+          connection.subscribers.delete(handler)
+        }
+      }
+
+      connection.subscriptions.clear()
+    }
+
     this.#connections.clear()
   }
 
@@ -351,34 +390,18 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   protected [kConnect](connection: WebSocketHandlerConnection): boolean {
-    const transportConnection = this.#getOrCreateConnection(connection)
-
-    // Bind the protocol listeners at most once per connection
-    // (e.g. if this transport gets registered multiple times).
-    if (transportConnection.isBound) {
-      return true
-    }
-
-    transportConnection.isBound = true
-    const { client } = connection
-
-    client.addEventListener('message', (event) => {
-      this.#handleClientMessage(client.id, event.data)
-    })
-
-    client.addEventListener('close', () => {
-      this.#connections.delete(client.id)
-    })
-
+    this.#getOrCreateConnection(connection)
     return true
   }
 
   #getOrCreateConnection(
     connection: WebSocketHandlerConnection,
   ): GraphQLSubscriptionConnection {
-    const existingConnection = this.#connections.get(connection.client.id)
+    const { client } = connection
+    const existingConnection = connections.get(client.id)
 
     if (existingConnection) {
+      this.#connections.add(existingConnection)
       return existingConnection
     }
 
@@ -387,9 +410,21 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
       server: connection.server,
       subscribers: new Map(),
       subscriptions: new Map(),
-      isBound: false,
     }
-    this.#connections.set(connection.client.id, transportConnection)
+    connections.set(client.id, transportConnection)
+    this.#connections.add(transportConnection)
+
+    // Bind the protocol listeners alongside the session that owns them.
+    // Creating the session and binding its listeners is a single step, so
+    // they are guaranteed to be bound exactly once per connection no matter
+    // how many transports end up sharing this session.
+    client.addEventListener('message', (event) => {
+      this.#handleClientMessage(client.id, event.data)
+    })
+
+    client.addEventListener('close', () => {
+      connections.delete(client.id)
+    })
 
     return transportConnection
   }
@@ -399,7 +434,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     subscriptionId: string
     intent: string
   }): GraphQLSubscriptionConnection | undefined {
-    const connection = this.#connections.get(args.clientId)
+    const connection = connections.get(args.clientId)
 
     if (!connection || !connection.subscriptions.has(args.subscriptionId)) {
       devUtils.warn(
@@ -414,7 +449,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   #handleClientMessage(clientId: string, data: WebSocketData): void {
-    const connection = this.#connections.get(clientId)
+    const connection = connections.get(clientId)
 
     if (!connection) {
       return
@@ -480,7 +515,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     // can publish to it synchronously.
     connection.subscriptions.set(message.id, message)
 
-    for (const subscriber of connection.subscribers.values()) {
+    for (const { subscriber } of connection.subscribers.values()) {
       if (subscriber({ node, message })) {
         this.#emitSubscriptionEvent(connection, node, message)
         return

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -225,6 +225,56 @@ interface GraphQLSubscriptionConnection {
    * replayed to the original server on passthrough.
    */
   connectionParams?: Record<string, unknown>
+  /**
+   * Resolves once the original server has acknowledged this connection.
+   * The upstream session is established once per connection, no matter
+   * how many subscriptions pass through it.
+   */
+  upstreamSession?: Promise<void>
+}
+
+/**
+ * Connect to the original server and initialize the `graphql-transport-ws`
+ * session for the given connection, at most once.
+ *
+ * @note The server connection is shared by every subscription of this
+ * client. Initializing it more than once makes a compliant GraphQL server
+ * close it ("Too many initialisation requests").
+ */
+function ensureUpstreamSession(
+  connection: GraphQLSubscriptionConnection,
+): Promise<void> {
+  if (connection.upstreamSession) {
+    return connection.upstreamSession
+  }
+
+  const { server } = connection
+
+  connection.upstreamSession = new Promise<void>((resolve) => {
+    server.addEventListener('message', (event) => {
+      const message =
+        parseGraphQLWebSocketMessage<GraphQLWebSocketServerMessage>(event.data)
+
+      if (message?.type === 'connection_ack') {
+        // Prevent the original acknowledgement from being forwarded to
+        // the client: it has already received a mocked one on connect.
+        event.preventDefault()
+        resolve()
+      }
+    })
+
+    server.addEventListener(
+      'open',
+      () => {
+        server.send(createInitMessage(connection.connectionParams))
+      },
+      { once: true },
+    )
+
+    server.connect()
+  })
+
+  return connection.upstreamSession
 }
 
 /**
@@ -1021,7 +1071,7 @@ export class GraphQLSubscription<
     return new GraphQLPassthroughSubscription({
       server: connection.server,
       message: this.#message,
-      connectionParams: connection.connectionParams,
+      upstreamSession: ensureUpstreamSession(connection),
       onTerminate: () => {
         this.#transport.endSubscription({
           clientId: this.#clientId,
@@ -1049,17 +1099,15 @@ export class GraphQLPassthroughSubscription {
   readonly #emitter: Emitter<GraphQLPassthroughSubscriptionEventMap>
   readonly #abortController: AbortController
   readonly #onTerminate: () => void
-  readonly #connectionParams?: Record<string, unknown>
 
   constructor(args: {
     server: WebSocketServerConnectionProtocol
     message: GraphQLWebSocketSubscribeMessage
-    connectionParams?: Record<string, unknown>
+    upstreamSession: Promise<void>
     onTerminate: () => void
   }) {
     this.#server = args.server
     this.#message = args.message
-    this.#connectionParams = args.connectionParams
     this.#onTerminate = args.onTerminate
     this.#emitter = new Emitter()
 
@@ -1067,17 +1115,13 @@ export class GraphQLPassthroughSubscription {
     // listeners once the subscription is unsubscribed.
     this.#abortController = new AbortController()
 
-    this.#server.connect()
-    this.#server.addEventListener(
-      'open',
-      () => {
-        // Once the WebSocket server connection is established, send the
-        // client connection prompt to the server. This lets the server
-        // connect and authorize this client.
-        this.#server.send(createInitMessage(this.#connectionParams))
-      },
-      { signal: this.#abortController.signal },
-    )
+    // Replay this subscription once the shared upstream session is
+    // established, so the server can authorize this client first.
+    args.upstreamSession.then(() => {
+      if (!this.#abortController.signal.aborted) {
+        this.#server.send(JSON.stringify(this.#message))
+      }
+    })
 
     this.#server.addEventListener(
       'message',
@@ -1093,16 +1137,8 @@ export class GraphQLPassthroughSubscription {
 
         switch (message.type) {
           case 'connection_ack': {
-            // Prevent the original acknowledgement from being forwarded
-            // to the client: the client has already received a mocked
-            // acknowledgement upon connecting.
             event.preventDefault()
             this.#emitter.emit(new TypedEvent('connection_ack'))
-
-            // Once the GraphQL server acknowledges the connection, send
-            // the subscription intent message. This is the same message
-            // as was sent from the GraphQL client.
-            this.#server.send(JSON.stringify(this.#message))
             break
           }
 
@@ -1189,7 +1225,7 @@ export class GraphQLPassthroughSubscription {
 
   /**
    * Unsubscribe from this passthrough GraphQL subscription.
-   * This closes the underlying server connection.
+   * This stops this subscription on the original server.
    *
    * @note Unsubscribing from the original subscription has no
    * effect on the intercepted `subscription` object.
@@ -1201,7 +1237,13 @@ export class GraphQLPassthroughSubscription {
   public unsubscribe(): void {
     this.#abortController.abort()
     this.#emitter.removeAllListeners()
-    this.#server.close()
+
+    /**
+     * @note Complete this subscription instead of closing the server
+     * connection. That connection is shared by every subscription of
+     * this client, and closing it would terminate the unrelated ones.
+     */
+    this.#server.send(createCompleteMessage({ id: this.#message.id }))
   }
 }
 

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -325,10 +325,16 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     this.#exhaustCleanups([args.cleanup])
   }
 
-  #endAllSubscriptions(connection: GraphQLSubscriptionConnection): void {
+  async #endAllSubscriptions(
+    connection: GraphQLSubscriptionConnection,
+  ): Promise<void> {
+    const pendingCleanups: Array<Promise<void>> = []
+
     for (const subscriptionId of connection.subscriptions.keys()) {
-      this.#endSubscription(connection, subscriptionId)
+      pendingCleanups.push(this.#endSubscription(connection, subscriptionId))
     }
+
+    await Promise.all(pendingCleanups)
   }
 
   /**
@@ -344,15 +350,15 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   #endSubscription(
     connection: GraphQLSubscriptionConnection,
     subscriptionId: string,
-  ): void {
+  ): Promise<void> {
     const cleanups = connection.subscriptions.get(subscriptionId)
 
     if (!cleanups) {
-      return
+      return Promise.resolve()
     }
 
     connection.subscriptions.delete(subscriptionId)
-    this.#exhaustCleanups(cleanups)
+    return this.#exhaustCleanups(cleanups)
   }
 
   /**
@@ -482,6 +488,34 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
       if (ownsConnection) {
         this.#endAllSubscriptions(connection)
       }
+    }
+  }
+
+  /**
+   * Forget the sessions of this transport, ending their subscriptions.
+   * @note This method is invoked automatically when the network is
+   * disabled (e.g. `server.close()`).
+   */
+  public dispose(): MaybePromise<void> {
+    const pendingCleanups: Array<Promise<void>> = []
+
+    for (const [clientId, connection] of connections) {
+      for (const [handler, entry] of connection.subscribers) {
+        if (entry.transport === this) {
+          connection.subscribers.delete(handler)
+        }
+      }
+
+      // A session is shared by all the transports of the same endpoint,
+      // so it's only torn down once the last of them is disposed of.
+      if (connection.subscribers.size === 0) {
+        pendingCleanups.push(this.#endAllSubscriptions(connection))
+        connections.delete(clientId)
+      }
+    }
+
+    if (pendingCleanups.length > 0) {
+      return Promise.all(pendingCleanups).then(() => {})
     }
   }
 

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -14,7 +14,9 @@ import {
   WebSocketHandler,
   kConnect,
   type WebSocketHandlerConnection,
+  type WebSocketResolutionContext,
 } from '#core/handlers/WebSocketHandler'
+import { GraphQLSubscriptionEvent } from '#core/experimental/frames/websocket-frame'
 import {
   matchRequestUrl,
   type Path,
@@ -196,6 +198,7 @@ interface GraphQLSubscriptionConnection {
   server: WebSocketServerConnectionProtocol
   subscribers: Map<WebSocketHandler, GraphQLSubscriptionSubscriber>
   subscriptions: Map<string, GraphQLWebSocketSubscribeMessage>
+  events?: WebSocketResolutionContext['events']
   isBound: boolean
 }
 
@@ -237,6 +240,23 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     clientId: string,
   ): GraphQLSubscriptionConnection | undefined {
     return this.#connections.get(clientId)
+  }
+
+  public async run(
+    connection: WebSocketConnectionData,
+    resolutionContext?: WebSocketResolutionContext,
+  ): Promise<WebSocketHandlerConnection | null> {
+    const handlerConnection = await super.run(connection, resolutionContext)
+
+    // Capture the network frame events reference for this connection.
+    // The transport emits life-cycle events (e.g. "graphql:subscription")
+    // long after the run: whenever the client sends a "subscribe" message.
+    if (handlerConnection) {
+      const transportConnection = this.#getOrCreateConnection(handlerConnection)
+      transportConnection.events = resolutionContext?.events
+    }
+
+    return handlerConnection
   }
 
   /**
@@ -462,6 +482,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
 
     for (const subscriber of connection.subscribers.values()) {
       if (subscriber({ node, message })) {
+        this.#emitSubscriptionEvent(connection, node, message)
         return
       }
     }
@@ -470,6 +491,36 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
       'Intercepted a GraphQL subscription "%s" to "%s" that has no matching subscription handler. If you wish to mock this subscription, create a subscription handler for it.',
       node.operationName || '(anonymous)',
       toPublicUrl(connection.client.url),
+    )
+  }
+
+  /**
+   * Emit the "graphql:subscription" life-cycle event on the network.
+   * The event is emitted once the subscription has been established:
+   * matched by a subscription handler and resolved.
+   */
+  #emitSubscriptionEvent(
+    connection: GraphQLSubscriptionConnection,
+    node: ParsedGraphQLQuery,
+    message: GraphQLWebSocketSubscribeMessage,
+  ): void {
+    // Anonymous subscriptions can never match a subscription handler.
+    if (!connection.events || !node.operationName) {
+      return
+    }
+
+    connection.events.emit(
+      new GraphQLSubscriptionEvent({
+        operationName: node.operationName,
+        query: message.payload.query,
+        variables: { ...message.payload.variables },
+        request: new Request(connection.client.url, {
+          headers: {
+            connection: 'upgrade',
+            upgrade: 'websocket',
+          },
+        }),
+      }),
     )
   }
 }

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -1,0 +1,1102 @@
+import { invariant } from 'outvariant'
+import { Emitter, TypedEvent } from 'rettime'
+import { parse, OperationTypeNode, type GraphQLError } from 'graphql'
+import { resolveWebSocketUrl } from '@mswjs/interceptors'
+import type {
+  WebSocketClientConnectionProtocol,
+  WebSocketConnectionData,
+  WebSocketData,
+  WebSocketServerConnectionProtocol,
+} from '@mswjs/interceptors/WebSocket'
+import { http } from '#core/http'
+import { ws } from '#core/ws'
+import {
+  WebSocketHandler,
+  kConnect,
+  type WebSocketHandlerConnection,
+} from '#core/handlers/WebSocketHandler'
+import {
+  matchRequestUrl,
+  type Path,
+  type PathParams,
+} from '#core/utils/matching/matchRequestUrl'
+import { attachSiblingHandlers } from '#core/utils/internal/attachSiblingHandlers'
+import { jsonParse } from '#core/utils/internal/jsonParse'
+import { devUtils } from '#core/utils/internal/devUtils'
+import { getTimestamp } from '#core/utils/logging/getTimestamp'
+import { toPublicUrl } from '#core/utils/request/toPublicUrl'
+import { colors } from '#core/ws/utils/attachWebSocketLogger'
+import {
+  GraphQLHandler,
+  isDocumentNode,
+  type DocumentTypeDecoration,
+  type GraphQLHandlerInfo,
+  type GraphQLHandlerNameSelector,
+  type GraphQLQuery,
+  type GraphQLVariables,
+} from './graphql-handler'
+import {
+  parseDocumentNode,
+  type ParsedGraphQLQuery,
+} from './parse-graphql-request'
+
+/**
+ * Messages of the `graphql-transport-ws` subprotocol.
+ * @see https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverWebSocket.md
+ */
+export interface GraphQLWebSocketInitMessage {
+  type: 'connection_init'
+  payload?: Record<string, unknown>
+}
+
+export interface GraphQLWebSocketSubscribePayload<
+  Variables extends GraphQLVariables = GraphQLVariables,
+> {
+  operationName?: string | null
+  query: string
+  variables?: Variables
+  extensions?: Record<string, unknown>
+}
+
+export interface GraphQLWebSocketSubscribeMessage<
+  Variables extends GraphQLVariables = GraphQLVariables,
+> {
+  type: 'subscribe'
+  id: string
+  payload: GraphQLWebSocketSubscribePayload<Variables>
+}
+
+export interface GraphQLWebSocketCompleteMessage {
+  type: 'complete'
+  id: string
+}
+
+export interface GraphQLWebSocketPingMessage {
+  type: 'ping'
+  payload?: Record<string, unknown>
+}
+
+export interface GraphQLWebSocketPongMessage {
+  type: 'pong'
+  payload?: Record<string, unknown>
+}
+
+export type GraphQLWebSocketClientMessage =
+  | GraphQLWebSocketInitMessage
+  | GraphQLWebSocketSubscribeMessage
+  | GraphQLWebSocketCompleteMessage
+  | GraphQLWebSocketPingMessage
+  | GraphQLWebSocketPongMessage
+
+export interface GraphQLWebSocketAcknowledgeMessage {
+  type: 'connection_ack'
+  payload?: Record<string, unknown>
+}
+
+export interface GraphQLWebSocketNextMessage {
+  type: 'next'
+  id: string
+  payload: GraphQLSubscriptionPayload
+}
+
+export interface GraphQLWebSocketErrorMessage {
+  type: 'error'
+  id: string
+  payload: ReadonlyArray<Partial<GraphQLError>>
+}
+
+export type GraphQLWebSocketServerMessage =
+  | GraphQLWebSocketAcknowledgeMessage
+  | GraphQLWebSocketNextMessage
+  | GraphQLWebSocketErrorMessage
+  | GraphQLWebSocketCompleteMessage
+  | GraphQLWebSocketPingMessage
+  | GraphQLWebSocketPongMessage
+
+/**
+ * A GraphQL execution result published to a subscription.
+ */
+export interface GraphQLSubscriptionPayload<
+  Query extends GraphQLQuery = GraphQLQuery,
+> {
+  data?: Query | null
+  errors?: ReadonlyArray<Partial<GraphQLError>> | null
+  extensions?: Record<string, unknown>
+}
+
+function createAcknowledgeMessage(): string {
+  return JSON.stringify({
+    type: 'connection_ack',
+  } satisfies GraphQLWebSocketAcknowledgeMessage)
+}
+
+function createNextMessage(args: {
+  id: string
+  payload: GraphQLSubscriptionPayload
+}): string {
+  return JSON.stringify({
+    id: args.id,
+    type: 'next',
+    payload: args.payload,
+  } satisfies GraphQLWebSocketNextMessage)
+}
+
+function createErrorMessage(args: {
+  id: string
+  payload: ReadonlyArray<Partial<GraphQLError>>
+}): string {
+  return JSON.stringify({
+    id: args.id,
+    type: 'error',
+    payload: args.payload,
+  } satisfies GraphQLWebSocketErrorMessage)
+}
+
+function createCompleteMessage(args: { id: string }): string {
+  return JSON.stringify({
+    id: args.id,
+    type: 'complete',
+  } satisfies GraphQLWebSocketCompleteMessage)
+}
+
+function createPongMessage(): string {
+  return JSON.stringify({
+    type: 'pong',
+  } satisfies GraphQLWebSocketPongMessage)
+}
+
+function parseGraphQLWebSocketMessage<MessageType extends { type: string }>(
+  data: WebSocketData,
+): MessageType | undefined {
+  if (typeof data !== 'string') {
+    return undefined
+  }
+
+  const message = jsonParse<MessageType>(data)
+
+  if (!message || typeof message.type !== 'string') {
+    return undefined
+  }
+
+  return message
+}
+
+/**
+ * A subscriber provided by a `GraphQLSubscriptionHandler` for a particular
+ * WebSocket connection. Returns true if the handler matched the parsed
+ * subscribe operation and resolved it.
+ */
+type GraphQLSubscriptionSubscriber = (args: {
+  node: ParsedGraphQLQuery
+  message: GraphQLWebSocketSubscribeMessage
+}) => boolean
+
+interface GraphQLSubscriptionConnection {
+  client: WebSocketClientConnectionProtocol
+  server: WebSocketServerConnectionProtocol
+  subscribers: Map<WebSocketHandler, GraphQLSubscriptionSubscriber>
+  subscriptions: Map<string, GraphQLWebSocketSubscribeMessage>
+  isBound: boolean
+}
+
+/**
+ * A WebSocket handler implementing the `graphql-transport-ws` protocol
+ * session for a single GraphQL endpoint. One transport is shared across
+ * all subscription handlers created from the same `graphql.link()` call
+ * (attached to each of them as a sibling handler).
+ *
+ * The transport owns the protocol/session concerns: connection
+ * acknowledgement, keep-alive, the per-connection registry of active
+ * subscriptions, and dispatching parsed `subscribe` operations to the
+ * matching subscription handler.
+ */
+export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
+  #connections: Map<string, GraphQLSubscriptionConnection>
+
+  constructor(url: Path) {
+    super(url)
+    this.#connections = new Map()
+  }
+
+  /**
+   * Registers the given handler as a subscriber to the GraphQL
+   * subscriptions on the given WebSocket connection. Subscribers are
+   * dispatched in registration order, which follows the handlers
+   * resolution order (runtime handlers take precedence).
+   */
+  public subscribe(
+    connection: WebSocketHandlerConnection,
+    handler: WebSocketHandler,
+    subscriber: GraphQLSubscriptionSubscriber,
+  ): void {
+    const transportConnection = this.#getOrCreateConnection(connection)
+    transportConnection.subscribers.set(handler, subscriber)
+  }
+
+  public getConnection(
+    clientId: string,
+  ): GraphQLSubscriptionConnection | undefined {
+    return this.#connections.get(clientId)
+  }
+
+  /**
+   * Sends a `next` message with the given payload to the subscription.
+   */
+  public publish(args: {
+    clientId: string
+    subscriptionId: string
+    payload: GraphQLSubscriptionPayload
+  }): void {
+    const connection = this.#getConnectionForSubscription({
+      clientId: args.clientId,
+      subscriptionId: args.subscriptionId,
+      intent: 'publish to',
+    })
+
+    if (!connection) {
+      return
+    }
+
+    connection.client.send(
+      createNextMessage({
+        id: args.subscriptionId,
+        payload: args.payload,
+      }),
+    )
+  }
+
+  /**
+   * Sends a terminal `error` message to the subscription and
+   * removes it from the registry of active subscriptions.
+   */
+  public error(args: {
+    clientId: string
+    subscriptionId: string
+    errors: ReadonlyArray<Partial<GraphQLError>>
+  }): void {
+    const connection = this.#getConnectionForSubscription({
+      clientId: args.clientId,
+      subscriptionId: args.subscriptionId,
+      intent: 'error',
+    })
+
+    if (!connection) {
+      return
+    }
+
+    connection.client.send(
+      createErrorMessage({
+        id: args.subscriptionId,
+        payload: args.errors,
+      }),
+    )
+    connection.subscriptions.delete(args.subscriptionId)
+  }
+
+  /**
+   * Sends a `complete` message to the subscription and removes it
+   * from the registry of active subscriptions.
+   */
+  public complete(args: { clientId: string; subscriptionId: string }): void {
+    const connection = this.#getConnectionForSubscription({
+      clientId: args.clientId,
+      subscriptionId: args.subscriptionId,
+      intent: 'complete',
+    })
+
+    if (!connection) {
+      return
+    }
+
+    connection.client.send(createCompleteMessage({ id: args.subscriptionId }))
+    connection.subscriptions.delete(args.subscriptionId)
+  }
+
+  /**
+   * Clears the registry of connections and their active subscriptions.
+   * @note This method is invoked automatically when the handlers
+   * controller resets the handlers (e.g. `server.resetHandlers()`).
+   */
+  public reset(): void {
+    this.#connections.clear()
+  }
+
+  /**
+   * @note The transport is the sole owner of logging for GraphQL
+   * subscription connections. It logs parsed `graphql-transport-ws`
+   * frames instead of raw WebSocket messages.
+   */
+  public log(connection: WebSocketConnectionData): () => void {
+    return attachGraphQLSubscriptionLogger(connection)
+  }
+
+  protected [kConnect](connection: WebSocketHandlerConnection): boolean {
+    const transportConnection = this.#getOrCreateConnection(connection)
+
+    // Bind the protocol listeners at most once per connection
+    // (e.g. if this transport gets registered multiple times).
+    if (transportConnection.isBound) {
+      return true
+    }
+
+    transportConnection.isBound = true
+    const { client } = connection
+
+    client.addEventListener('message', (event) => {
+      this.#handleClientMessage(client.id, event.data)
+    })
+
+    client.addEventListener('close', () => {
+      this.#connections.delete(client.id)
+    })
+
+    return true
+  }
+
+  #getOrCreateConnection(
+    connection: WebSocketHandlerConnection,
+  ): GraphQLSubscriptionConnection {
+    const existingConnection = this.#connections.get(connection.client.id)
+
+    if (existingConnection) {
+      return existingConnection
+    }
+
+    const transportConnection: GraphQLSubscriptionConnection = {
+      client: connection.client,
+      server: connection.server,
+      subscribers: new Map(),
+      subscriptions: new Map(),
+      isBound: false,
+    }
+    this.#connections.set(connection.client.id, transportConnection)
+
+    return transportConnection
+  }
+
+  #getConnectionForSubscription(args: {
+    clientId: string
+    subscriptionId: string
+    intent: string
+  }): GraphQLSubscriptionConnection | undefined {
+    const connection = this.#connections.get(args.clientId)
+
+    if (!connection || !connection.subscriptions.has(args.subscriptionId)) {
+      devUtils.warn(
+        'Failed to %s the GraphQL subscription "%s": the subscription is no longer active.',
+        args.intent,
+        args.subscriptionId,
+      )
+      return undefined
+    }
+
+    return connection
+  }
+
+  #handleClientMessage(clientId: string, data: WebSocketData): void {
+    const connection = this.#connections.get(clientId)
+
+    if (!connection) {
+      return
+    }
+
+    const message =
+      parseGraphQLWebSocketMessage<GraphQLWebSocketClientMessage>(data)
+
+    if (!message) {
+      return
+    }
+
+    switch (message.type) {
+      case 'connection_init': {
+        connection.client.send(createAcknowledgeMessage())
+        break
+      }
+
+      case 'ping': {
+        connection.client.send(createPongMessage())
+        break
+      }
+
+      case 'subscribe': {
+        this.#handleSubscribeMessage(connection, message)
+        break
+      }
+
+      case 'complete': {
+        connection.subscriptions.delete(message.id)
+        break
+      }
+    }
+  }
+
+  #handleSubscribeMessage(
+    connection: GraphQLSubscriptionConnection,
+    message: GraphQLWebSocketSubscribeMessage,
+  ): void {
+    let node: ParsedGraphQLQuery
+
+    try {
+      node = parseDocumentNode(parse(message.payload.query))
+    } catch (error) {
+      devUtils.warn(
+        'Failed to intercept a GraphQL subscription to "%s": the subscription query is not a valid GraphQL document.\n\n%s',
+        toPublicUrl(connection.client.url),
+        error,
+      )
+      return
+    }
+
+    if (node.operationType !== OperationTypeNode.SUBSCRIPTION) {
+      devUtils.warn(
+        'Intercepted a GraphQL %s "%s" over WebSocket: only subscription operations are supported over the WebSocket transport.',
+        node.operationType,
+        node.operationName || '(anonymous)',
+      )
+      return
+    }
+
+    // Register the subscription before dispatching it so the resolver
+    // can publish to it synchronously.
+    connection.subscriptions.set(message.id, message)
+
+    for (const subscriber of connection.subscribers.values()) {
+      if (subscriber({ node, message })) {
+        return
+      }
+    }
+
+    devUtils.warn(
+      'Intercepted a GraphQL subscription "%s" to "%s" that has no matching subscription handler. If you wish to mock this subscription, create a subscription handler for it.',
+      node.operationName || '(anonymous)',
+      toPublicUrl(connection.client.url),
+    )
+  }
+}
+
+export type GraphQLSubscriptionName<
+  Query extends GraphQLQuery = GraphQLQuery,
+  Variables extends GraphQLVariables = GraphQLVariables,
+> = GraphQLHandlerNameSelector | DocumentTypeDecoration<Query, Variables>
+
+export interface GraphQLSubscriptionResolverInfo<
+  Query extends GraphQLQuery = GraphQLQuery,
+  Variables extends GraphQLVariables = GraphQLVariables,
+> {
+  /**
+   * Path parameters parsed from the WebSocket connection URL.
+   */
+  params: PathParams
+
+  /**
+   * The name of the intercepted operation.
+   */
+  operationName: string
+
+  /**
+   * Intercepted GraphQL subscription.
+   */
+  subscription: GraphQLSubscription<Query, Variables>
+}
+
+export type GraphQLSubscriptionResolver<
+  Query extends GraphQLQuery = GraphQLQuery,
+  Variables extends GraphQLVariables = GraphQLVariables,
+> = (info: GraphQLSubscriptionResolverInfo<Query, Variables>) => void
+
+export interface GraphQLSubscriptionHandlerOptions {
+  /**
+   * Mark this handler as used after its first match.
+   * Used handlers do not match subsequent subscriptions.
+   */
+  once?: boolean
+}
+
+/**
+ * A WebSocket handler intercepting GraphQL subscriptions by their
+ * operation name. Matching and resolution are delegated to it by the
+ * subscription transport (its sibling handler) so the first matching
+ * handler wins, respecting runtime handler overrides.
+ */
+export class GraphQLSubscriptionHandler<
+  Query extends GraphQLQuery = GraphQLQuery,
+  Variables extends GraphQLVariables = GraphQLVariables,
+> extends WebSocketHandler {
+  public info: GraphQLHandlerInfo
+  public isUsed: boolean
+
+  readonly #operationName: string | RegExp
+  readonly #transport: GraphQLSubscriptionTransportHandler
+  readonly #resolver: GraphQLSubscriptionResolver<Query, Variables>
+  readonly #options: GraphQLSubscriptionHandlerOptions
+
+  constructor(args: {
+    url: Path
+    operationName: GraphQLSubscriptionName<Query, Variables>
+    transport: GraphQLSubscriptionTransportHandler
+    resolver: GraphQLSubscriptionResolver<Query, Variables>
+    options?: GraphQLSubscriptionHandlerOptions
+  }) {
+    super(args.url)
+
+    // Create the same GraphQL handler info as request-based GraphQL
+    // handlers so this handler prints nicely during introspection
+    // (e.g. `server.listHandlers()`). This also normalizes `DocumentNode`
+    // and typed document predicates to plain operation names.
+    this.info = GraphQLHandler.parseGraphQLRequestInfo({
+      operationType: OperationTypeNode.SUBSCRIPTION,
+      predicate: args.operationName,
+      url: args.url,
+    })
+
+    const { operationName } = this.info
+
+    invariant(
+      typeof operationName !== 'function' && !isDocumentNode(operationName),
+      'Failed to create a GraphQL subscription handler: custom predicates are not supported for subscriptions',
+    )
+
+    this.#operationName = operationName
+    this.#transport = args.transport
+    this.#resolver = args.resolver
+    this.#options = args.options || {}
+    this.isUsed = false
+  }
+
+  public reset(): void {
+    this.isUsed = false
+  }
+
+  /**
+   * @note Individual subscription handlers stay silent. The subscription
+   * transport owns the GraphQL-aware logging for the entire connection
+   * (a logger is attached once per matching handler otherwise).
+   */
+  public log(): () => void {
+    return function detachLogger() {}
+  }
+
+  protected [kConnect](connection: WebSocketHandlerConnection): boolean {
+    this.#transport.subscribe(connection, this, (args) => {
+      return this.#handleSubscribe(connection, args)
+    })
+
+    return true
+  }
+
+  #handleSubscribe(
+    connection: WebSocketHandlerConnection,
+    args: {
+      node: ParsedGraphQLQuery
+      message: GraphQLWebSocketSubscribeMessage
+    },
+  ): boolean {
+    if (this.#options.once && this.isUsed) {
+      return false
+    }
+
+    const { operationName } = args.node
+
+    if (!operationName || !this.#matchesOperationName(operationName)) {
+      return false
+    }
+
+    this.isUsed = true
+
+    const subscription = new GraphQLSubscription<Query, Variables>({
+      message: args.message,
+      clientId: connection.client.id,
+      transport: this.#transport,
+    })
+
+    this.#resolver({
+      params: connection.params,
+      operationName,
+      subscription,
+    })
+
+    return true
+  }
+
+  #matchesOperationName(operationName: string): boolean {
+    if (this.#operationName instanceof RegExp) {
+      return this.#operationName.test(operationName)
+    }
+
+    return this.#operationName === operationName
+  }
+}
+
+/**
+ * Representation of the intercepted GraphQL subscription.
+ */
+export class GraphQLSubscription<
+  Query extends GraphQLQuery = GraphQLQuery,
+  Variables extends GraphQLVariables = GraphQLVariables,
+> {
+  public id: string
+  public query: string
+  public variables: Variables
+  public extensions?: Record<string, unknown>
+
+  readonly #message: GraphQLWebSocketSubscribeMessage
+  readonly #clientId: string
+  readonly #transport: GraphQLSubscriptionTransportHandler
+
+  constructor(args: {
+    message: GraphQLWebSocketSubscribeMessage
+    clientId: string
+    transport: GraphQLSubscriptionTransportHandler
+  }) {
+    this.id = args.message.id
+    this.query = args.message.payload.query
+    this.variables = (args.message.payload.variables || {}) as Variables
+    this.extensions = args.message.payload.extensions
+
+    this.#message = args.message
+    this.#clientId = args.clientId
+    this.#transport = args.transport
+  }
+
+  /**
+   * Publish an execution result to the subscribed client.
+   *
+   * @example
+   * subscription.publish({
+   *   data: {
+   *     postAdded: {
+   *       id: 'abc-123'
+   *     }
+   *   }
+   * })
+   */
+  public publish(payload: GraphQLSubscriptionPayload<Query>): void {
+    this.#transport.publish({
+      clientId: this.#clientId,
+      subscriptionId: this.id,
+      payload,
+    })
+  }
+
+  /**
+   * Use the given `Iterable` or `AsyncIterable` as the source
+   * of data for this subscription. Whenever the iterable yields a
+   * value, it gets published to this subscription.
+   *
+   * @example
+   * subscription.from(async function* () {
+   *   yield { text: 'hello world' }
+   * })
+   */
+  public async from(
+    source: Iterable<Query> | AsyncIterable<Query>,
+  ): Promise<void> {
+    for await (const data of source) {
+      this.publish({ data })
+    }
+  }
+
+  /**
+   * Terminate this subscription with the given errors.
+   *
+   * @example
+   * subscription.error([{ message: 'Something went wrong' }])
+   */
+  public error(errors: ReadonlyArray<Partial<GraphQLError>>): void {
+    this.#transport.error({
+      clientId: this.#clientId,
+      subscriptionId: this.id,
+      errors,
+    })
+  }
+
+  /**
+   * Marks this subscription as complete.
+   *
+   * @example
+   * subscription.complete()
+   */
+  public complete(): void {
+    this.#transport.complete({
+      clientId: this.#clientId,
+      subscriptionId: this.id,
+    })
+  }
+
+  /**
+   * Perform this GraphQL subscription as-is.
+   * This establishes a connection to the actual server, replays
+   * the intercepted subscription, and forwards the server payloads
+   * to the GraphQL client. You can intercept, modify, or prevent
+   * any of the original server messages.
+   *
+   * @example
+   * const postAddedSubscription = subscription.passthrough()
+   * postAddedSubscription.addEventListener('next', (event) => {
+   *   event.preventDefault()
+   *   event.data.payload.data.postAdded.id = 'mock-id'
+   *   subscription.publish(event.data.payload)
+   * })
+   */
+  public passthrough(): GraphQLPassthroughSubscription {
+    const connection = this.#transport.getConnection(this.#clientId)
+
+    /**
+     * @note One can only call this method inside the GraphQL subscription
+     * handler. By that point, the WebSocket connection has been established
+     * and intercepted so the connection reference is guaranteed.
+     */
+    invariant(
+      connection,
+      'Failed to passthrough the GraphQL subscription ("%s"): the underlying WebSocket connection is closed',
+      this.query,
+    )
+
+    return new GraphQLPassthroughSubscription({
+      server: connection.server,
+      message: this.#message,
+    })
+  }
+}
+
+export type GraphQLPassthroughSubscriptionEventMap = {
+  connection_ack: TypedEvent
+  next: TypedEvent<GraphQLWebSocketNextMessage>
+  error: TypedEvent<GraphQLWebSocketErrorMessage>
+  complete: TypedEvent<GraphQLWebSocketCompleteMessage>
+}
+
+/**
+ * Representation of a GraphQL subscription to the actual server.
+ * You interface with this object from the client's perspective.
+ */
+export class GraphQLPassthroughSubscription {
+  readonly #server: WebSocketServerConnectionProtocol
+  readonly #message: GraphQLWebSocketSubscribeMessage
+  readonly #emitter: Emitter<GraphQLPassthroughSubscriptionEventMap>
+  readonly #abortController: AbortController
+
+  constructor(args: {
+    server: WebSocketServerConnectionProtocol
+    message: GraphQLWebSocketSubscribeMessage
+  }) {
+    this.#server = args.server
+    this.#message = args.message
+    this.#emitter = new Emitter()
+
+    // An abort controller responsible for removing the server event
+    // listeners once the subscription is unsubscribed.
+    this.#abortController = new AbortController()
+
+    this.#server.connect()
+    this.#server.addEventListener(
+      'open',
+      () => {
+        // Once the WebSocket server connection is established, send the
+        // client connection prompt to the server. This lets the server
+        // connect and authorize this client.
+        this.#server.send(
+          JSON.stringify({
+            type: 'connection_init',
+          } satisfies GraphQLWebSocketInitMessage),
+        )
+      },
+      { signal: this.#abortController.signal },
+    )
+
+    this.#server.addEventListener(
+      'message',
+      (event) => {
+        const message =
+          parseGraphQLWebSocketMessage<GraphQLWebSocketServerMessage>(
+            event.data,
+          )
+
+        if (!message) {
+          return
+        }
+
+        switch (message.type) {
+          case 'connection_ack': {
+            // Prevent the original acknowledgement from being forwarded
+            // to the client: the client has already received a mocked
+            // acknowledgement upon connecting.
+            event.preventDefault()
+            this.#emitter.emit(new TypedEvent('connection_ack'))
+
+            // Once the GraphQL server acknowledges the connection, send
+            // the subscription intent message. This is the same message
+            // as was sent from the GraphQL client.
+            this.#server.send(JSON.stringify(this.#message))
+            break
+          }
+
+          case 'next': {
+            if (message.id !== this.#message.id) {
+              break
+            }
+
+            const nextEvent = new TypedEvent('next', { data: message })
+            this.#emitter.emit(nextEvent)
+
+            if (nextEvent.defaultPrevented) {
+              event.preventDefault()
+            }
+
+            break
+          }
+
+          case 'error': {
+            if (message.id !== this.#message.id) {
+              break
+            }
+
+            const errorEvent = new TypedEvent('error', { data: message })
+            this.#emitter.emit(errorEvent)
+
+            if (errorEvent.defaultPrevented) {
+              event.preventDefault()
+            }
+
+            break
+          }
+
+          case 'complete': {
+            if (message.id !== this.#message.id) {
+              break
+            }
+
+            const completeEvent = new TypedEvent('complete', { data: message })
+            this.#emitter.emit(completeEvent)
+
+            if (completeEvent.defaultPrevented) {
+              event.preventDefault()
+            }
+
+            break
+          }
+        }
+      },
+      { signal: this.#abortController.signal },
+    )
+  }
+
+  /**
+   * Add an event listener to the given GraphQL subscription event.
+   *
+   * @example
+   * const onPostAddedSubscription = subscription.passthrough()
+   * onPostAddedSubscription.addEventListener('next', (event) => {
+   *   console.log(event.data)
+   *   // { id, payload, ... }
+   * })
+   */
+  public addEventListener<
+    EventType extends keyof GraphQLPassthroughSubscriptionEventMap & string,
+  >(
+    event: EventType,
+    listener: Emitter.Listener<
+      Emitter<GraphQLPassthroughSubscriptionEventMap>,
+      EventType
+    >,
+  ): void {
+    this.#emitter.on(event, listener, {
+      signal: this.#abortController.signal,
+    })
+  }
+
+  /**
+   * Unsubscribe from this passthrough GraphQL subscription.
+   * This closes the underlying server connection.
+   *
+   * @note Unsubscribing from the original subscription has no
+   * effect on the intercepted `subscription` object.
+   *
+   * @example
+   * const onPostAddedSubscription = subscription.passthrough()
+   * onPostAddedSubscription.unsubscribe()
+   */
+  public unsubscribe(): void {
+    this.#abortController.abort()
+    this.#emitter.removeAllListeners()
+    this.#server.close()
+  }
+}
+
+function logGraphQLFrame(args: {
+  color: string
+  label: string
+  payload?: unknown
+}): void {
+  const timestamp = getTimestamp({ milliseconds: true })
+
+  if (typeof args.payload === 'undefined') {
+    // eslint-disable-next-line no-console
+    console.log(
+      devUtils.formatMessage(`${timestamp} %c${args.label}%c`),
+      `color:${args.color}`,
+      'color:inherit',
+    )
+    return
+  }
+
+  console.groupCollapsed(
+    devUtils.formatMessage(`${timestamp} %c${args.label}%c`),
+    `color:${args.color}`,
+    'color:inherit',
+  )
+  // eslint-disable-next-line no-console
+  console.log(args.payload)
+  console.groupEnd()
+}
+
+/**
+ * Attach a GraphQL-aware logger to the intercepted WebSocket connection.
+ * Unlike the raw WebSocket logger, this logger prints parsed
+ * `graphql-transport-ws` frames relevant to the subscription.
+ */
+function attachGraphQLSubscriptionLogger(
+  connection: WebSocketConnectionData,
+): () => void {
+  const { client } = connection
+  const abortController = new AbortController()
+
+  logGraphQLFrame({
+    color: colors.system,
+    label: `GraphQL subscription connection ${toPublicUrl(client.url)}`,
+  })
+
+  client.addEventListener(
+    'message',
+    (event) => {
+      const message =
+        parseGraphQLWebSocketMessage<GraphQLWebSocketClientMessage>(event.data)
+
+      if (!message) {
+        return
+      }
+
+      switch (message.type) {
+        case 'subscribe': {
+          logGraphQLFrame({
+            color: colors.outgoing,
+            label: `subscribe (id: ${message.id})`,
+            payload: message.payload,
+          })
+          break
+        }
+
+        case 'complete': {
+          logGraphQLFrame({
+            color: colors.outgoing,
+            label: `complete (id: ${message.id})`,
+          })
+          break
+        }
+      }
+    },
+    { signal: abortController.signal },
+  )
+
+  // Proxy `client.send` to log the frames published to the client
+  // (`client.send` does not dispatch any observable events).
+  const originalClientSend = client.send
+
+  client.send = new Proxy(client.send, {
+    apply: (target, thisArg, args) => {
+      const [data] = args
+      const message =
+        parseGraphQLWebSocketMessage<GraphQLWebSocketServerMessage>(data)
+
+      if (message) {
+        switch (message.type) {
+          case 'next': {
+            logGraphQLFrame({
+              color: colors.mocked,
+              label: `next (id: ${message.id})`,
+              payload: message.payload,
+            })
+            break
+          }
+
+          case 'error': {
+            logGraphQLFrame({
+              color: colors.mocked,
+              label: `error (id: ${message.id})`,
+              payload: message.payload,
+            })
+            break
+          }
+
+          case 'complete': {
+            logGraphQLFrame({
+              color: colors.mocked,
+              label: `complete (id: ${message.id})`,
+            })
+            break
+          }
+        }
+      }
+
+      return Reflect.apply(target, thisArg, args)
+    },
+  })
+
+  return function detachLogger() {
+    abortController.abort()
+    client.send = originalClientSend
+  }
+}
+
+export type GraphQLSubscriptionHandlerFactory = <
+  Query extends GraphQLQuery = GraphQLQuery,
+  Variables extends GraphQLVariables = GraphQLVariables,
+>(
+  operationName: GraphQLSubscriptionName<Query, Variables>,
+  resolver: GraphQLSubscriptionResolver<Query, Variables>,
+  options?: GraphQLSubscriptionHandlerOptions,
+) => GraphQLSubscriptionHandler<Query, Variables>
+
+/**
+ * Create a `subscription()` handler factory bound to the given GraphQL
+ * endpoint. All subscription handlers created by the factory share a single
+ * subscription transport and a single WebSocket upgrade handler, both
+ * attached to each handler as siblings.
+ *
+ * @example
+ * const subscription = createGraphQLSubscriptionHandler('https://api.example.com/graphql')
+ * subscription('OnPostAdded', ({ subscription }) => {
+ *   subscription.publish({ data: { postAdded: { id: 'abc-123' } } })
+ * })
+ */
+export function createGraphQLSubscriptionHandler(
+  url: Path,
+): GraphQLSubscriptionHandlerFactory {
+  const webSocketUrl =
+    typeof url === 'string' ? url.replace(/^http/, 'ws') : url
+
+  const transport = new GraphQLSubscriptionTransportHandler(webSocketUrl)
+
+  // The `upgrade` request handler enables WebSocket interception in Node.js.
+  // The same handler instance is shared between all subscription handlers
+  // of this endpoint (sibling handlers are deduped by reference).
+  const upgradeHandler = http.get(({ request }) => {
+    return (
+      request.headers.get('upgrade')?.toLowerCase() === 'websocket' &&
+      matchRequestUrl(new URL(resolveWebSocketUrl(request.url)), webSocketUrl)
+        .matches
+    )
+  }, ws.onUpgrade)
+
+  return (operationName, resolver, options) => {
+    const handler = new GraphQLSubscriptionHandler({
+      url: webSocketUrl,
+      operationName,
+      transport,
+      resolver,
+      options,
+    })
+
+    return attachSiblingHandlers(handler, [transport, upgradeHandler])
+  }
+}

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -22,6 +22,8 @@ import {
   type Path,
   type PathParams,
 } from '#core/utils/matching/matchRequestUrl'
+import type { ResponseResolverFinalizeFunction } from '#core/handlers/RequestHandler'
+import type { MaybePromise } from '#core/typeUtils'
 import { attachSiblingHandlers } from '#core/utils/internal/attachSiblingHandlers'
 import { jsonParse } from '#core/utils/internal/jsonParse'
 import { devUtils } from '#core/utils/internal/devUtils'
@@ -198,11 +200,20 @@ interface GraphQLSubscriptionSubscriberEntry {
   subscriber: GraphQLSubscriptionSubscriber
 }
 
+/**
+ * An active subscription and the cleanups scheduled for it via the
+ * `finalize()` function exposed to the subscription resolver.
+ */
+interface GraphQLSubscriptionEntry {
+  message: GraphQLWebSocketSubscribeMessage
+  cleanups: Array<() => MaybePromise<void>>
+}
+
 interface GraphQLSubscriptionConnection {
   client: WebSocketClientConnectionProtocol
   server: WebSocketServerConnectionProtocol
   subscribers: Map<WebSocketHandler, GraphQLSubscriptionSubscriberEntry>
-  subscriptions: Map<string, GraphQLWebSocketSubscribeMessage>
+  subscriptions: Map<string, GraphQLSubscriptionEntry>
   events?: WebSocketResolutionContext['events']
 }
 
@@ -285,6 +296,80 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   /**
+   * Schedule a cleanup to run once the given subscription ends.
+   *
+   * @note If the subscription has already ended by the time this is
+   * called, the cleanup runs immediately. The resolver can no longer
+   * affect that subscription, so there is nothing left to wait for.
+   */
+  /**
+   * End the given subscription without notifying the client. Used when
+   * the subscription has already been terminated over the wire (e.g. the
+   * original server completed it and that frame reached the client).
+   */
+  public endSubscription(args: {
+    clientId: string
+    subscriptionId: string
+  }): void {
+    const connection = connections.get(args.clientId)
+
+    if (connection != null) {
+      this.#endSubscription(connection, args.subscriptionId)
+    }
+  }
+
+  public finalize(args: {
+    clientId: string
+    subscriptionId: string
+    cleanup: () => MaybePromise<void>
+  }): void {
+    const subscription = connections
+      .get(args.clientId)
+      ?.subscriptions.get(args.subscriptionId)
+
+    if (subscription == null) {
+      void args.cleanup()
+      return
+    }
+
+    subscription.cleanups.push(args.cleanup)
+  }
+
+  /**
+   * End the given subscription and run the cleanups scheduled for it.
+   *
+   * This is the single exit point for every way a subscription can end:
+   * completed by the mock, by the client, or by the original server;
+   * terminated with errors; or dropped when the client disconnects.
+   * Ending an already-ended subscription is a no-op, so the cleanups
+   * are guaranteed to run at most once.
+   */
+  #endAllSubscriptions(connection: GraphQLSubscriptionConnection): void {
+    for (const subscriptionId of Array.from(connection.subscriptions.keys())) {
+      this.#endSubscription(connection, subscriptionId)
+    }
+  }
+
+  #endSubscription(
+    connection: GraphQLSubscriptionConnection,
+    subscriptionId: string,
+  ): void {
+    const subscription = connection.subscriptions.get(subscriptionId)
+
+    if (subscription == null) {
+      return
+    }
+
+    connection.subscriptions.delete(subscriptionId)
+
+    // Run the cleanups as LIFO, consistently with `finalize()`
+    // in the request handlers.
+    for (let index = subscription.cleanups.length - 1; index >= 0; index--) {
+      void subscription.cleanups[index]()
+    }
+  }
+
+  /**
    * Send a `next` message with the given payload to the subscription.
    */
   public publish(args: {
@@ -335,7 +420,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
         payload: args.errors,
       }),
     )
-    connection.subscriptions.delete(args.subscriptionId)
+    this.#endSubscription(connection, args.subscriptionId)
   }
 
   /**
@@ -354,7 +439,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     }
 
     connection.client.send(createCompleteMessage({ id: args.subscriptionId }))
-    connection.subscriptions.delete(args.subscriptionId)
+    this.#endSubscription(connection, args.subscriptionId)
   }
 
   /**
@@ -374,7 +459,9 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
         }
       }
 
-      connection.subscriptions.clear()
+      // Resetting the handlers detaches the resolvers from their
+      // subscriptions, so run their cleanups instead of dropping them.
+      this.#endAllSubscriptions(connection)
     }
 
     this.#connections.clear()
@@ -423,6 +510,9 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
     })
 
     client.addEventListener('close', () => {
+      // The resolvers can no longer affect any of the subscriptions
+      // on this connection once the client disconnects.
+      this.#endAllSubscriptions(transportConnection)
       connections.delete(client.id)
     })
 
@@ -479,7 +569,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
       }
 
       case 'complete': {
-        connection.subscriptions.delete(message.id)
+        this.#endSubscription(connection, message.id)
         break
       }
     }
@@ -513,7 +603,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
 
     // Register the subscription before dispatching it so the resolver
     // can publish to it synchronously.
-    connection.subscriptions.set(message.id, message)
+    connection.subscriptions.set(message.id, { message, cleanups: [] })
 
     for (const { subscriber } of connection.subscribers.values()) {
       if (subscriber({ node, message })) {
@@ -583,6 +673,20 @@ export interface GraphQLSubscriptionResolverInfo<
    * Intercepted GraphQL subscription.
    */
   subscription: GraphQLSubscription<Query, Variables>
+
+  /**
+   * Schedule a cleanup to run once this subscription ends and the
+   * resolver can no longer affect it: it has been completed (by the mock,
+   * the client, or the original server), terminated with errors, or the
+   * client has disconnected.
+   *
+   * @example
+   * api.subscription('OnCommentAdded', ({ subscription, finalize }) => {
+   *   const interval = setInterval(() => subscription.publish(payload), 1000)
+   *   finalize(() => clearInterval(interval))
+   * })
+   */
+  finalize: ResponseResolverFinalizeFunction
 }
 
 export type GraphQLSubscriptionResolver<
@@ -699,6 +803,13 @@ export class GraphQLSubscriptionHandler<
       params: connection.params,
       operationName,
       subscription,
+      finalize: (cleanup) => {
+        this.#transport.finalize({
+          clientId: connection.client.id,
+          subscriptionId: subscription.id,
+          cleanup,
+        })
+      },
     })
 
     return true
@@ -841,6 +952,12 @@ export class GraphQLSubscription<
     return new GraphQLPassthroughSubscription({
       server: connection.server,
       message: this.#message,
+      onTerminate: () => {
+        this.#transport.endSubscription({
+          clientId: this.#clientId,
+          subscriptionId: this.id,
+        })
+      },
     })
   }
 }
@@ -861,13 +978,16 @@ export class GraphQLPassthroughSubscription {
   readonly #message: GraphQLWebSocketSubscribeMessage
   readonly #emitter: Emitter<GraphQLPassthroughSubscriptionEventMap>
   readonly #abortController: AbortController
+  readonly #onTerminate: () => void
 
   constructor(args: {
     server: WebSocketServerConnectionProtocol
     message: GraphQLWebSocketSubscribeMessage
+    onTerminate: () => void
   }) {
     this.#server = args.server
     this.#message = args.message
+    this.#onTerminate = args.onTerminate
     this.#emitter = new Emitter()
 
     // An abort controller responsible for removing the server event
@@ -942,8 +1062,13 @@ export class GraphQLPassthroughSubscription {
 
             if (errorEvent.defaultPrevented) {
               event.preventDefault()
+              break
             }
 
+            // The original server terminated the subscription and that
+            // frame reaches the client, so the subscription ends here.
+            // A prevented frame means the mock took over instead.
+            this.#onTerminate()
             break
           }
 
@@ -957,8 +1082,10 @@ export class GraphQLPassthroughSubscription {
 
             if (completeEvent.defaultPrevented) {
               event.preventDefault()
+              break
             }
 
+            this.#onTerminate()
             break
           }
         }

--- a/src/graphql/graphql-subscription.ts
+++ b/src/graphql/graphql-subscription.ts
@@ -219,7 +219,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   /**
-   * Registers the given handler as a subscriber to the GraphQL
+   * Register the given handler as a subscriber to the GraphQL
    * subscriptions on the given WebSocket connection. Subscribers are
    * dispatched in registration order, which follows the handlers
    * resolution order (runtime handlers take precedence).
@@ -240,7 +240,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   /**
-   * Sends a `next` message with the given payload to the subscription.
+   * Send a `next` message with the given payload to the subscription.
    */
   public publish(args: {
     clientId: string
@@ -266,7 +266,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   /**
-   * Sends a terminal `error` message to the subscription and
+   * Send a terminal `error` message to the subscription and
    * removes it from the registry of active subscriptions.
    */
   public error(args: {
@@ -294,7 +294,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   /**
-   * Sends a `complete` message to the subscription and removes it
+   * Send a `complete` message to the subscription and removes it
    * from the registry of active subscriptions.
    */
   public complete(args: { clientId: string; subscriptionId: string }): void {
@@ -313,7 +313,7 @@ export class GraphQLSubscriptionTransportHandler extends WebSocketHandler {
   }
 
   /**
-   * Clears the registry of connections and their active subscriptions.
+   * Clear the registry of connections and their active subscriptions.
    * @note This method is invoked automatically when the handlers
    * controller resets the handlers (e.g. `server.resetHandlers()`).
    */

--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -13,6 +13,7 @@ import {
   type GraphQLPredicate,
 } from './graphql-handler'
 import type { Path } from '#core/utils/matching/matchRequestUrl'
+import { attachSiblingHandlers } from '#core/utils/internal/attachSiblingHandlers'
 import {
   createGraphQLSubscriptionHandler,
   type GraphQLSubscriptionHandlerFactory,
@@ -59,9 +60,44 @@ function createScopedGraphQLHandler(
   }
 }
 
-function createGraphQLOperationHandler(url: Path): GraphQLOperationHandler {
+function createGraphQLOperationHandler(
+  url: Path,
+  subscriptionFactory?: GraphQLSubscriptionHandlerFactory,
+): GraphQLOperationHandler {
   return (resolver, options) => {
-    return new GraphQLHandler('all', new RegExp('.*'), url, resolver, options)
+    const handler = new GraphQLHandler(
+      'all',
+      new RegExp('.*'),
+      url,
+      resolver,
+      options,
+    )
+
+    if (!subscriptionFactory) {
+      return handler
+    }
+
+    // Attach a catch-all subscription handler as a sibling so the
+    // operation handler also matches GraphQL subscriptions over WebSocket.
+    // The subscription transport guarantees only actual GraphQL
+    // subscriptions are dispatched to it.
+    const subscriptionCatchAllHandler = subscriptionFactory(
+      new RegExp('.*'),
+      ({ operationName, subscription }) => {
+        /**
+         * @note Subscriptions are resolved imperatively so the resolver
+         * is invoked with a reduced info object (no request to expose),
+         * and its return value is ignored.
+         */
+        resolver({
+          operationName,
+          query: subscription.query,
+          variables: subscription.variables,
+        } as Parameters<typeof resolver>[0])
+      },
+    )
+
+    return attachSiblingHandlers(handler, [subscriptionCatchAllHandler])
   }
 }
 
@@ -125,6 +161,11 @@ export const graphql = {
    *   return HttpResponse.json({ data: { name: 'John' } })
    * })
    *
+   * @note Unlike `graphql.link(url).operation()`, this handler does not
+   * match GraphQL subscriptions: intercepting them requires claiming the
+   * WebSocket connections to a concrete endpoint, and a wildcard would
+   * claim every WebSocket connection on the page.
+   *
    * @see {@link https://mswjs.io/docs/api/graphql#graphqloperationresolver `graphql.operation()` API reference}
    */
   operation: createGraphQLOperationHandler('*'),
@@ -139,14 +180,21 @@ export const graphql = {
    * @see {@link https://mswjs.io/docs/api/graphql#graphqllinkurl `graphql.link()` API reference}
    */
   link(url: Path): GraphQLLinkHandlers {
+    /**
+     * @note Create the subscription handler factory once per link so
+     * the `subscription()` and `operation()` handlers share the same
+     * underlying subscription transport (deduped by reference).
+     */
+    const subscription = createGraphQLSubscriptionHandler(url)
+
     return {
-      operation: createGraphQLOperationHandler(url),
+      operation: createGraphQLOperationHandler(url, subscription),
       query: createScopedGraphQLHandler('query' as OperationTypeNode, url),
       mutation: createScopedGraphQLHandler(
         'mutation' as OperationTypeNode,
         url,
       ),
-      subscription: createGraphQLSubscriptionHandler(url),
+      subscription,
     }
   },
 }

--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -12,6 +12,8 @@ import {
   type GraphQLQuery,
   type GraphQLPredicate,
 } from './graphql-handler'
+import { createRequestId } from '@mswjs/interceptors'
+import { getAllRequestCookies } from '#core/utils/request/getRequestCookies'
 import type { Path } from '#core/utils/matching/matchRequestUrl'
 import { attachSiblingHandlers } from '#core/utils/internal/attachSiblingHandlers'
 import {
@@ -64,7 +66,21 @@ function createGraphQLOperationHandler(
   url: Path,
   subscriptionFactory?: GraphQLSubscriptionHandlerFactory,
 ): GraphQLOperationHandler {
-  return (resolver, options) => {
+  /**
+   * @note An explicitly generic function so the subscription sibling
+   * can be created with the same `Query`/`Variables` types as the
+   * operation resolver, without casting its resolver info.
+   */
+  return <
+    Query extends GraphQLQuery = GraphQLQuery,
+    Variables extends GraphQLVariables = GraphQLVariables,
+  >(
+    resolver: GraphQLResponseResolver<
+      [Query] extends [never] ? GraphQLQuery : Query,
+      Variables
+    >,
+    options?: RequestHandlerOptions,
+  ): GraphQLHandler => {
     const handler = new GraphQLHandler(
       'all',
       new RegExp('.*'),
@@ -81,19 +97,23 @@ function createGraphQLOperationHandler(
     // operation handler also matches GraphQL subscriptions over WebSocket.
     // The subscription transport guarantees only actual GraphQL
     // subscriptions are dispatched to it.
-    const subscriptionCatchAllHandler = subscriptionFactory(
+    const subscriptionCatchAllHandler = subscriptionFactory<Query, Variables>(
       new RegExp('.*'),
-      ({ operationName, subscription }) => {
+      ({ operationName, subscription, request, finalize }) => {
         /**
-         * @note Subscriptions are resolved imperatively so the resolver
-         * is invoked with a reduced info object (no request to expose),
-         * and its return value is ignored.
+         * @note Subscriptions are resolved imperatively, so the return
+         * value of the resolver is ignored. The request describes the
+         * WebSocket connection this subscription is multiplexed over.
          */
         resolver({
           operationName,
           query: subscription.query,
           variables: subscription.variables,
-        } as Parameters<typeof resolver>[0])
+          cookies: getAllRequestCookies(request),
+          request,
+          requestId: createRequestId(),
+          finalize,
+        })
       },
       // Forward the handler options so a one-time operation handler is
       // also consumed by the first subscription it matches.

--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -95,6 +95,9 @@ function createGraphQLOperationHandler(
           variables: subscription.variables,
         } as Parameters<typeof resolver>[0])
       },
+      // Forward the handler options so a one-time operation handler is
+      // also consumed by the first subscription it matches.
+      options,
     )
 
     return attachSiblingHandlers(handler, [subscriptionCatchAllHandler])

--- a/src/graphql/graphql.ts
+++ b/src/graphql/graphql.ts
@@ -13,6 +13,10 @@ import {
   type GraphQLPredicate,
 } from './graphql-handler'
 import type { Path } from '#core/utils/matching/matchRequestUrl'
+import {
+  createGraphQLSubscriptionHandler,
+  type GraphQLSubscriptionHandlerFactory,
+} from './graphql-subscription'
 
 export type GraphQLRequestHandler = <
   Query extends GraphQLQuery = GraphQLQuery,
@@ -65,6 +69,17 @@ export interface GraphQLLinkHandlers {
   query: GraphQLRequestHandler
   mutation: GraphQLRequestHandler
   operation: GraphQLOperationHandler
+  /**
+   * Intercept a GraphQL subscription.
+   *
+   * @example
+   * graphql.subscription('OnPostAdded', ({ subscription }) => {
+   *   subscription.publish({
+   *    data: { postAdded: { id: 'abc-123' } },
+   *   })
+   * })
+   */
+  subscription: GraphQLSubscriptionHandlerFactory
 }
 
 /**
@@ -131,6 +146,7 @@ export const graphql = {
         'mutation' as OperationTypeNode,
         url,
       ),
+      subscription: createGraphQLSubscriptionHandler(url),
     }
   },
 }

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -18,3 +18,18 @@ export {
 } from './graphql-handler'
 
 export type { ParsedGraphQLRequest } from './parse-graphql-request'
+
+export {
+  createGraphQLSubscriptionHandler,
+  GraphQLSubscription,
+  GraphQLSubscriptionHandler,
+  GraphQLSubscriptionTransportHandler,
+  GraphQLPassthroughSubscription,
+  type GraphQLSubscriptionHandlerFactory,
+  type GraphQLSubscriptionHandlerOptions,
+  type GraphQLSubscriptionName,
+  type GraphQLSubscriptionPayload,
+  type GraphQLSubscriptionResolver,
+  type GraphQLSubscriptionResolverInfo,
+  type GraphQLPassthroughSubscriptionEventMap,
+} from './graphql-subscription'

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -23,7 +23,6 @@ export {
   createGraphQLSubscriptionHandler,
   GraphQLSubscription,
   GraphQLSubscriptionHandler,
-  GraphQLSubscriptionTransportHandler,
   GraphQLPassthroughSubscription,
   type GraphQLSubscriptionHandlerFactory,
   type GraphQLSubscriptionHandlerOptions,

--- a/src/graphql/parse-graphql-request.test.ts
+++ b/src/graphql/parse-graphql-request.test.ts
@@ -1,7 +1,9 @@
 import { encodeBuffer } from '@mswjs/interceptors'
-import { OperationTypeNode } from 'graphql'
+import { OperationTypeNode, parse } from 'graphql'
 import {
+  parseDocumentNode,
   parseGraphQLRequest,
+  type ParsedGraphQLQuery,
   type ParsedGraphQLRequest,
 } from './parse-graphql-request'
 
@@ -93,4 +95,43 @@ test('does not read the original request body', async () => {
   // Must not read the original request body because GraphQL parsing
   // is an internal operation that must not lock the body stream.
   expect(request.bodyUsed).toBe(false)
+})
+
+describe('parseDocumentNode', () => {
+  const document = parse(`
+    query GetComments {
+      comments {
+        text
+      }
+    }
+
+    subscription OnCommentAdded {
+      commentAdded {
+        text
+      }
+    }
+  `)
+
+  test('returns the first operation given no operation name', () => {
+    expect(parseDocumentNode(document)).toEqual<ParsedGraphQLQuery>({
+      operationType: OperationTypeNode.QUERY,
+      operationName: 'GetComments',
+    })
+  })
+
+  test('returns the operation matching the given operation name', () => {
+    expect(
+      parseDocumentNode(document, 'OnCommentAdded'),
+    ).toEqual<ParsedGraphQLQuery>({
+      operationType: OperationTypeNode.SUBSCRIPTION,
+      operationName: 'OnCommentAdded',
+    })
+  })
+
+  test('falls back to the first operation given an unknown operation name', () => {
+    expect(parseDocumentNode(document, 'Unknown')).toEqual<ParsedGraphQLQuery>({
+      operationType: OperationTypeNode.QUERY,
+      operationName: 'GetComments',
+    })
+  })
 })

--- a/src/graphql/parse-graphql-request.test.ts
+++ b/src/graphql/parse-graphql-request.test.ts
@@ -128,10 +128,11 @@ describe('parseDocumentNode', () => {
     })
   })
 
-  test('falls back to the first operation given an unknown operation name', () => {
+  test('resolves no operation given an unknown operation name', () => {
     expect(parseDocumentNode(document, 'Unknown')).toEqual<ParsedGraphQLQuery>({
-      operationType: OperationTypeNode.QUERY,
-      operationName: 'GetComments',
+      operationType: undefined,
+      // The requested name is echoed back for diagnostics.
+      operationName: 'Unknown',
     })
   })
 })

--- a/src/graphql/parse-graphql-request.ts
+++ b/src/graphql/parse-graphql-request.ts
@@ -17,7 +17,11 @@ interface GraphQLInput {
 }
 
 export interface ParsedGraphQLQuery {
-  operationType: OperationTypeNode
+  /**
+   * Undefined if the document has no operation matching the
+   * requested operation name.
+   */
+  operationType?: OperationTypeNode
   operationName?: string
 }
 
@@ -41,18 +45,24 @@ export function parseDocumentNode(
   /**
    * @note A document may bundle multiple operations (e.g. the ones
    * emitted by GraphQL Code Generator). Honor the requested operation
-   * name, falling back to the first operation, like a GraphQL server
-   * given a request without an operation name.
+   * name, and resolve nothing if the document has no such operation.
+   * Falling back to the first operation would silently resolve one the
+   * client never asked for.
    */
   const operationDef = operationName
     ? operationDefs.find((definition) => {
         return definition.name?.value === operationName
-      }) || operationDefs[0]
+      })
     : operationDefs[0]
 
   return {
     operationType: operationDef?.operation,
-    operationName: operationDef?.name?.value,
+    /**
+     * @note Echo the requested operation name even when the document
+     * has no such operation. It makes the "unhandled operation" warnings
+     * name the operation the client actually asked for.
+     */
+    operationName: operationDef?.name?.value || operationName || undefined,
   }
 }
 

--- a/src/graphql/parse-graphql-request.ts
+++ b/src/graphql/parse-graphql-request.ts
@@ -29,10 +29,25 @@ export type ParsedGraphQLRequest<
     })
   | undefined
 
-export function parseDocumentNode(node: DocumentNode): ParsedGraphQLQuery {
-  const operationDef = node.definitions.find((definition) => {
+export function parseDocumentNode(
+  node: DocumentNode,
+  operationName?: string | null,
+): ParsedGraphQLQuery {
+  const operationDefs = node.definitions.filter((definition) => {
     return definition.kind === 'OperationDefinition'
-  }) as OperationDefinitionNode
+  }) as Array<OperationDefinitionNode>
+
+  /**
+   * @note A document may bundle multiple operations (e.g. the ones
+   * emitted by GraphQL Code Generator). Honor the requested operation
+   * name, falling back to the first operation, like a GraphQL server
+   * given a request without an operation name.
+   */
+  const operationDef = operationName
+    ? operationDefs.find((definition) => {
+        return definition.name?.value === operationName
+      }) || operationDefs[0]
+    : operationDefs[0]
 
   return {
     operationType: operationDef?.operation,

--- a/src/graphql/parse-graphql-request.ts
+++ b/src/graphql/parse-graphql-request.ts
@@ -13,6 +13,7 @@ import { parseMultipartData } from '#core/utils/internal/parseMultipartData'
 interface GraphQLInput {
   query: string | null
   variables?: GraphQLVariables
+  operationName?: string | null
 }
 
 export interface ParsedGraphQLQuery {
@@ -55,10 +56,13 @@ export function parseDocumentNode(
   }
 }
 
-async function parseQuery(query: string): Promise<ParsedGraphQLQuery | Error> {
+async function parseQuery(
+  query: string,
+  operationName?: string | null,
+): Promise<ParsedGraphQLQuery | Error> {
   try {
     const ast = parse(query)
-    return parseDocumentNode(ast)
+    return parseDocumentNode(ast, operationName)
   } catch (error) {
     return error as Error
   }
@@ -114,6 +118,7 @@ async function getGraphQLInput(request: Request): Promise<GraphQLInput | null> {
       return {
         query,
         variables: jsonParse(variables),
+        operationName: url.searchParams.get('operationName'),
       }
     }
 
@@ -137,9 +142,11 @@ async function getGraphQLInput(request: Request): Promise<GraphQLInput | null> {
 
         const { operations, map, ...files } = responseJson
         const parsedOperations =
-          jsonParse<{ query?: string; variables?: GraphQLVariables }>(
-            operations,
-          ) || {}
+          jsonParse<{
+            query?: string
+            variables?: GraphQLVariables
+            operationName?: string | null
+          }>(operations) || {}
 
         if (!parsedOperations.query) {
           return null
@@ -157,6 +164,7 @@ async function getGraphQLInput(request: Request): Promise<GraphQLInput | null> {
         return {
           query: parsedOperations.query,
           variables,
+          operationName: parsedOperations.operationName,
         }
       }
 
@@ -164,15 +172,17 @@ async function getGraphQLInput(request: Request): Promise<GraphQLInput | null> {
       const requestJson: {
         query: string
         variables?: GraphQLVariables
+        operationName?: string | null
         operations?: any /** @todo Annotate this */
       } = await requestClone.json().catch(() => null)
 
       if (requestJson?.query) {
-        const { query, variables } = requestJson
+        const { query, variables, operationName } = requestJson
 
         return {
           query,
           variables,
+          operationName,
         }
       }
       return null
@@ -196,8 +206,8 @@ export async function parseGraphQLRequest(
     return
   }
 
-  const { query, variables } = input
-  const parsedResult = await parseQuery(query)
+  const { query, variables, operationName } = input
+  const parsedResult = await parseQuery(query, operationName)
 
   if (parsedResult instanceof Error) {
     const requestPublicUrl = toPublicUrl(request.url)

--- a/test/browser/graphql-api/subscription.mocks.ts
+++ b/test/browser/graphql-api/subscription.mocks.ts
@@ -1,0 +1,13 @@
+import { graphql } from 'msw/graphql'
+import { setupWorker } from 'msw/browser'
+import { createClient } from 'graphql-ws'
+
+const worker = setupWorker()
+worker.start()
+
+window.msw = {
+  // @ts-expect-error
+  worker,
+  graphql,
+  createClient,
+}

--- a/test/browser/graphql-api/subscription.test.ts
+++ b/test/browser/graphql-api/subscription.test.ts
@@ -1,0 +1,208 @@
+import type { createClient } from 'graphql-ws'
+import type { graphql } from 'msw/graphql'
+import type { SetupWorker } from 'msw/browser'
+import { gql } from '../../support/graphql'
+import { test, expect } from '../playwright.extend'
+
+declare namespace window {
+  export const msw: {
+    worker: SetupWorker
+    graphql: typeof graphql
+    createClient: typeof createClient
+  }
+}
+
+const SUBSCRIPTION_EXAMPLE = new URL('./subscription.mocks.ts', import.meta.url)
+
+const GRAPHQL_URL = 'ws://localhost:4000/graphql'
+
+test('mocks a GraphQL subscription', async ({ loadExample, page }) => {
+  await loadExample(SUBSCRIPTION_EXAMPLE)
+
+  const messages = await page.evaluate(
+    async ({ url, query }) => {
+      const { worker, graphql, createClient } = window.msw
+
+      worker.use(
+        graphql.link(url).subscription('OnCommentAdded', ({ subscription }) => {
+          subscription.publish({
+            data: { commentAdded: { text: 'Hello world' } },
+          })
+          queueMicrotask(() => {
+            subscription.complete()
+          })
+        }),
+      )
+
+      const client = createClient({ url })
+      const messages: Array<unknown> = []
+
+      for await (const result of client.iterate({ query })) {
+        messages.push(result)
+      }
+
+      await client.dispose()
+      return messages
+    },
+    {
+      url: GRAPHQL_URL,
+      query: gql`
+        subscription OnCommentAdded {
+          commentAdded {
+            text
+          }
+        }
+      `,
+    },
+  )
+
+  expect(messages).toEqual([
+    { data: { commentAdded: { text: 'Hello world' } } },
+  ])
+})
+
+test('publishes multiple payloads to a GraphQL subscription', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(SUBSCRIPTION_EXAMPLE)
+
+  const messages = await page.evaluate(
+    async ({ url, query }) => {
+      const { worker, graphql, createClient } = window.msw
+
+      worker.use(
+        graphql
+          .link(url)
+          .subscription('OnPostAdded', async ({ subscription }) => {
+            // `from()` publishes every value of the iterable but does not
+            // complete the subscription, so complete it once it's exhausted.
+            await subscription.from([
+              { postAdded: { title: 'First' } },
+              { postAdded: { title: 'Second' } },
+            ])
+            subscription.complete()
+          }),
+      )
+
+      const client = createClient({ url })
+      const messages: Array<unknown> = []
+
+      for await (const result of client.iterate({ query })) {
+        messages.push(result)
+      }
+
+      await client.dispose()
+      return messages
+    },
+    {
+      url: GRAPHQL_URL,
+      query: gql`
+        subscription OnPostAdded {
+          postAdded {
+            title
+          }
+        }
+      `,
+    },
+  )
+
+  expect(messages).toEqual([
+    { data: { postAdded: { title: 'First' } } },
+    { data: { postAdded: { title: 'Second' } } },
+  ])
+})
+
+test('terminates a GraphQL subscription with errors', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(SUBSCRIPTION_EXAMPLE)
+
+  const errors = await page.evaluate(
+    async ({ url, query }) => {
+      const { worker, graphql, createClient } = window.msw
+
+      worker.use(
+        graphql
+          .link(url)
+          .subscription('OnCommentRemoved', ({ subscription }) => {
+            queueMicrotask(() => {
+              subscription.error([{ message: 'Something went wrong' }])
+            })
+          }),
+      )
+
+      const client = createClient({ url })
+
+      try {
+        for await (const _ of client.iterate({ query })) {
+          // Intentionally empty: this subscription only errors.
+        }
+        return []
+      } catch (error) {
+        // A subscription terminated with errors rejects the iterator with
+        // the list of GraphQL errors. Map them to plain objects so they
+        // survive the serialization to the test runner.
+        return Array.prototype
+          .concat(error)
+          .map((graphQLError) => ({ message: graphQLError.message }))
+      } finally {
+        await client.dispose()
+      }
+    },
+    {
+      url: GRAPHQL_URL,
+      query: gql`
+        subscription OnCommentRemoved {
+          commentRemoved {
+            id
+          }
+        }
+      `,
+    },
+  )
+
+  expect(errors).toEqual([{ message: 'Something went wrong' }])
+})
+
+test('prints a warning on a subscription without a matching handler', async ({
+  loadExample,
+  spyOnConsole,
+  page,
+}) => {
+  const consoleSpy = spyOnConsole()
+  await loadExample(SUBSCRIPTION_EXAMPLE)
+
+  await page.evaluate(
+    async ({ url, query }) => {
+      const { worker, graphql, createClient } = window.msw
+
+      // A subscription handler for an unrelated operation. It makes MSW
+      // claim this connection without matching the operation below.
+      worker.use(graphql.link(url).subscription('OnCommentAdded', () => {}))
+
+      const client = createClient({ url })
+
+      // This subscription never resolves, so don't await it.
+      client
+        .iterate({ query })
+        .next()
+        .catch(() => {})
+    },
+    {
+      url: GRAPHQL_URL,
+      query: gql`
+        subscription OnUnknownEvent {
+          unknownEvent {
+            id
+          }
+        }
+      `,
+    },
+  )
+
+  await expect
+    .poll(() => consoleSpy.get('warning')?.join('\n'))
+    .toMatch(/Intercepted a GraphQL subscription "OnUnknownEvent"/)
+})

--- a/test/node/graphql-api/events.test.ts
+++ b/test/node/graphql-api/events.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+import { createClient } from 'graphql-ws'
+import { setupServer } from 'msw/node'
+import { graphql } from 'msw/graphql'
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  server.events.removeAllListeners()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it('emits the "graphql:subscription" event when a subscription is established', async () => {
+  const subscriptionListener = vi.fn()
+  server.events.on('graphql:subscription', subscriptionListener)
+
+  const api = graphql.link('https://localhost/graphql')
+  server.use(api.subscription('OnCommentAdded', () => {}))
+
+  const query = `subscription OnCommentAdded { commentAdded { text } }`
+  const client = createClient({
+    url: 'wss://localhost/graphql',
+  })
+  const subscription = client.iterate({
+    query,
+    variables: { postId: 'post-1' },
+  })
+
+  await expect.poll(() => subscriptionListener.mock.calls.length).toBe(1)
+
+  expect(subscriptionListener).toHaveBeenCalledTimes(1)
+
+  const [subscriptionEvent] = subscriptionListener.mock.calls[0]
+  expect(subscriptionEvent).toBeInstanceOf(Event)
+  expect(subscriptionEvent.type).toBe('graphql:subscription')
+  expect(subscriptionEvent.operationName).toBe('OnCommentAdded')
+  expect(subscriptionEvent.query).toBe(query)
+  expect(subscriptionEvent.variables).toEqual({ postId: 'post-1' })
+  expect(subscriptionEvent.request).toBeInstanceOf(Request)
+  expect(subscriptionEvent.request.url).toBe('wss://localhost/graphql')
+  expect(subscriptionEvent.request.headers.get('connection')).toBe('upgrade')
+  expect(subscriptionEvent.request.headers.get('upgrade')).toBe('websocket')
+})

--- a/test/node/graphql-api/events.test.ts
+++ b/test/node/graphql-api/events.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { createClient } from 'graphql-ws'
+import { createClient } from '../../support/graphqlClient'
 import { setupServer } from 'msw/node'
 import { graphql } from 'msw/graphql'
 
@@ -26,7 +26,7 @@ it('emits the "graphql:subscription" event when a subscription is established', 
   server.use(api.subscription('OnCommentAdded', () => {}))
 
   const query = `subscription OnCommentAdded { commentAdded { text } }`
-  const client = createClient({
+  await using client = createClient({
     url: 'wss://localhost/graphql',
   })
   const subscription = client.iterate({

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -6,7 +6,6 @@ import {
   type GraphQLSubscription,
   type GraphQLSubscriptionResolver,
 } from 'msw/graphql'
-import { DeferredPromise } from '@open-draft/deferred-promise'
 import { createTestHttpServer } from '@epic-web/test-server/http'
 import { createWebSocketMiddleware } from '@epic-web/test-server/ws'
 import {
@@ -137,7 +136,7 @@ it('terminates a subscription with errors', async () => {
 })
 
 it('exposes path parameters from the WebSocket link', async () => {
-  const paramsPromise = new DeferredPromise<PathParams>()
+  const paramsPromise = Promise.withResolvers<PathParams>()
   const api = graphql.link('https://localhost/:service')
 
   server.use(
@@ -162,7 +161,7 @@ it('exposes path parameters from the WebSocket link', async () => {
 
   await subscription.next()
 
-  await expect(paramsPromise).resolves.toEqual({
+  await expect(paramsPromise.promise).resolves.toEqual({
     service: 'user-service',
   })
 })
@@ -338,7 +337,7 @@ it('warns when publishing to a subscription after the handlers were reset', asyn
   vi.spyOn(console, 'warn').mockImplementation(() => {})
 
   const api = graphql.link('http://localhost:4000/graphql')
-  const subscriptionPromise = new DeferredPromise<GraphQLSubscription>()
+  const subscriptionPromise = Promise.withResolvers<GraphQLSubscription>()
 
   server.use(
     api.subscription('OnCommentAdded', ({ subscription }) => {
@@ -360,7 +359,7 @@ it('warns when publishing to a subscription after the handlers were reset', asyn
   })
   const pendingNext = subscription.next()
 
-  const interceptedSubscription = await subscriptionPromise
+  const interceptedSubscription = await subscriptionPromise.promise
   server.resetHandlers()
 
   // Publishing to a stale subscription must be a warning no-op
@@ -387,7 +386,7 @@ it('responds to the protocol ping messages', async () => {
     'graphql-transport-ws',
   ])
   const messages: Array<{ type: string }> = []
-  const pongPromise = new DeferredPromise<void>()
+  const pongPromise = Promise.withResolvers<void>()
 
   socket.onopen = () => {
     socket.send(JSON.stringify({ type: 'connection_init' }))
@@ -405,7 +404,7 @@ it('responds to the protocol ping messages', async () => {
     }
   }
 
-  await pongPromise
+  await pongPromise.promise
 
   expect(messages).toEqual([{ type: 'connection_ack' }, { type: 'pong' }])
   socket.close()
@@ -415,7 +414,7 @@ it('subscribes to extraneous pubsubs', async () => {
   const pubsub = createPubSub<{
     commentAdded: [{ commentAdded: { text: string } }]
   }>()
-  const subscriptionEstablishedPromise = new DeferredPromise<void>()
+  const subscriptionEstablishedPromise = Promise.withResolvers<void>()
 
   const api = graphql.link('https://localhost/graphql')
   server.use(
@@ -453,7 +452,7 @@ it('subscribes to extraneous pubsubs', async () => {
   // pubsub. Unlike the client, the pubsub does not replay events published
   // before the subscription became active (the mutation below may otherwise
   // outrace the WebSocket handshake, e.g. on Node.js 24).
-  await subscriptionEstablishedPromise
+  await subscriptionEstablishedPromise.promise
 
   const comment = { text: 'hello world' }
   await fetch('https://localhost/graphql', {

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -26,6 +26,7 @@ beforeAll(() => {
 
 afterEach(() => {
   server.resetHandlers()
+  server.events.removeAllListeners()
   vi.restoreAllMocks()
 })
 
@@ -414,13 +415,18 @@ it('subscribes to extraneous pubsubs', async () => {
   const pubsub = createPubSub<{
     commentAdded: [{ commentAdded: { text: string } }]
   }>()
-  const subscriptionEstablishedPromise = Promise.withResolvers<void>()
+  const subscriptionAddedPromise = Promise.withResolvers<void>()
+
+  server.events.on('graphql:subscription', ({ operationName }) => {
+    if (operationName === 'OnCommentAdded') {
+      subscriptionAddedPromise.resolve()
+    }
+  })
 
   const api = graphql.link('https://localhost/graphql')
   server.use(
     api.subscription('OnCommentAdded', ({ subscription }) => {
       subscription.from(pubsub.subscribe('commentAdded'))
-      subscriptionEstablishedPromise.resolve()
     }),
     api.mutation('AddComment', ({ variables }) => {
       const { comment } = variables
@@ -452,7 +458,7 @@ it('subscribes to extraneous pubsubs', async () => {
   // pubsub. Unlike the client, the pubsub does not replay events published
   // before the subscription became active (the mutation below may otherwise
   // outrace the WebSocket handshake, e.g. on Node.js 24).
-  await subscriptionEstablishedPromise.promise
+  await subscriptionAddedPromise.promise
 
   const comment = { text: 'hello world' }
   await fetch('https://localhost/graphql', {
@@ -480,6 +486,84 @@ it('subscribes to extraneous pubsubs', async () => {
       },
     },
   })
+})
+
+it('emits the "graphql:subscription" life-cycle event when a subscription is established', async () => {
+  const subscriptionEventPromise = Promise.withResolvers<{
+    operationName: string
+    query: string
+    variables: Record<string, unknown>
+    request: Request
+  }>()
+
+  server.events.on('graphql:subscription', (event) => {
+    subscriptionEventPromise.resolve(event)
+  })
+
+  const api = graphql.link('https://localhost/graphql')
+  server.use(api.subscription('OnCommentAdded', () => {}))
+
+  const client = createClient({
+    url: 'wss://localhost/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded($postId: ID!) {
+        commentAdded(postId: $postId) {
+          text
+        }
+      }
+    `,
+    variables: { postId: 'post-1' },
+  })
+  const pendingNext = subscription.next()
+
+  const subscriptionEvent = await subscriptionEventPromise.promise
+
+  expect(subscriptionEvent.operationName).toBe('OnCommentAdded')
+  expect(subscriptionEvent.query).toContain('subscription OnCommentAdded')
+  expect(subscriptionEvent.variables).toEqual({ postId: 'post-1' })
+  expect(subscriptionEvent.request).toBeInstanceOf(Request)
+  expect(subscriptionEvent.request.url).toBe('wss://localhost/graphql')
+  expect(subscriptionEvent.request.headers.get('connection')).toBe('upgrade')
+  expect(subscriptionEvent.request.headers.get('upgrade')).toBe('websocket')
+
+  pendingNext.catch(() => {})
+  await client.dispose()
+})
+
+it('does not emit the "graphql:subscription" life-cycle event for unhandled subscriptions', async () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const subscriptionListener = vi.fn()
+  server.events.on('graphql:subscription', subscriptionListener)
+
+  const api = graphql.link('https://localhost/graphql')
+  server.use(api.subscription('OnCommentAdded', () => {}))
+
+  const client = createClient({
+    url: 'wss://localhost/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnPostAdded {
+        postAdded {
+          id
+        }
+      }
+    `,
+  })
+  const pendingNext = subscription.next()
+
+  // The unhandled subscription warning marks the dispatch completion.
+  await expect
+    .poll(() => vi.mocked(console.warn).mock.calls.flat().join('\n'))
+    .toMatch(/no matching subscription handler/)
+
+  expect(subscriptionListener).not.toHaveBeenCalled()
+
+  pendingNext.catch(() => {})
+  await client.dispose()
 })
 
 it('combines extraneous and default pubsubs', async () => {

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -435,6 +435,98 @@ it('responds to the protocol ping messages', async () => {
   socket.close()
 })
 
+it('acknowledges the connection once when multiple links share the endpoint', async () => {
+  // Two `graphql.link()` calls to the same endpoint create two subscription
+  // transports, both matching this connection. They must share a single
+  // protocol session, otherwise each of them binds its own listeners and
+  // answers every client frame, duplicating the server messages.
+  const firstApi = graphql.link('http://localhost:4000/graphql')
+  const secondApi = graphql.link('http://localhost:4000/graphql')
+
+  server.use(
+    firstApi.subscription('OnCommentAdded', () => {}),
+    secondApi.subscription('OnCommentAdded', () => {}),
+  )
+
+  const socket = new WebSocket('ws://localhost:4000/graphql', [
+    'graphql-transport-ws',
+  ])
+  const messages: Array<{ type: string }> = []
+  const pongPromise = Promise.withResolvers<void>()
+
+  socket.onopen = () => {
+    socket.send(JSON.stringify({ type: 'connection_init' }))
+  }
+  socket.onmessage = (event) => {
+    const message = JSON.parse(String(event.data))
+    messages.push(message)
+
+    if (message.type === 'connection_ack') {
+      socket.send(JSON.stringify({ type: 'ping' }))
+    }
+
+    if (message.type === 'pong') {
+      pongPromise.resolve()
+    }
+  }
+
+  await pongPromise.promise
+
+  // Await a tick past the first "pong" so any duplicate frames the
+  // transports may send for the same client are captured as well.
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(messages).toEqual([{ type: 'connection_ack' }, { type: 'pong' }])
+  socket.close()
+})
+
+it('resolves a subscription once when multiple links share the endpoint', async () => {
+  const firstResolver = vi.fn<GraphQLSubscriptionResolver>(
+    ({ subscription }) => {
+      subscription.publish({
+        data: { commentAdded: { text: 'first' } },
+      })
+    },
+  )
+  const secondResolver = vi.fn<GraphQLSubscriptionResolver>()
+
+  const firstApi = graphql.link('http://localhost:4000/graphql')
+  const secondApi = graphql.link('http://localhost:4000/graphql')
+
+  server.use(
+    firstApi.subscription('OnCommentAdded', firstResolver),
+    secondApi.subscription('OnCommentAdded', secondResolver),
+  )
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: {
+      data: { commentAdded: { text: 'first' } },
+    },
+  })
+
+  // The subscription must be dispatched to the subscribers in the handler
+  // resolution order, and stop at the first one that matches. Sharing the
+  // endpoint between links must not resolve it once per transport.
+  expect(firstResolver).toHaveBeenCalledTimes(1)
+  expect(secondResolver).not.toHaveBeenCalled()
+
+  await client.dispose()
+})
+
 it('subscribes to extraneous pubsubs', async () => {
   const pubsub = createPubSub<{
     commentAdded: [{ commentAdded: { text: string } }]

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -7,7 +7,7 @@ import {
   type GraphQLSubscriptionResolver,
 } from 'msw/graphql'
 import { createPubSub, createSchema } from 'graphql-yoga'
-import { createClient } from 'graphql-ws'
+import { createClient } from '../../support/graphqlClient'
 import { gql } from '../../support/graphql'
 import { createTestGraphQLServer } from '../../support/graphqlServer'
 
@@ -43,7 +43,7 @@ it('intercepts and mocks a GraphQL subscription', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
   })
   const subscription = client.iterate({
@@ -81,7 +81,7 @@ it('marks a subscription as complete', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
   })
   const subscription = client.iterate({
@@ -111,7 +111,7 @@ it('terminates a subscription with errors', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
   })
   const subscription = client.iterate({
@@ -140,7 +140,7 @@ it('exposes path parameters from the WebSocket link', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'wss://localhost/user-service',
   })
   const subscription = client.iterate({
@@ -186,7 +186,7 @@ it('scopes published data to the subscribed client', async () => {
   `
 
   async function collectMessages(name: string): Promise<Array<unknown>> {
-    const client = createClient({ url: 'ws://localhost:4000/graphql' })
+    await using client = createClient({ url: 'ws://localhost:4000/graphql' })
     const messages: Array<unknown> = []
 
     for await (const result of client.iterate({
@@ -222,7 +222,7 @@ it('respects handler overrides for the same operation', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
   })
   const subscription = client.iterate({
@@ -253,7 +253,7 @@ it('matches an outgoing subscription with "graphql.operation()"', async () => {
   const api = graphql.link('https://localhost/graphql')
   server.use(api.operation(operationResolver))
 
-  const client = createClient({
+  await using client = createClient({
     url: 'wss://localhost/graphql',
   })
   client.iterate({
@@ -288,7 +288,7 @@ it('supports one-time subscription handlers', async () => {
 
   server.use(api.subscription('OnCommentAdded', resolver, { once: true }))
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
   })
   const query = gql`
@@ -318,7 +318,6 @@ it('supports one-time subscription handlers', async () => {
   expect(resolver).toHaveBeenCalledTimes(1)
 
   secondNext.catch(() => {})
-  await client.dispose()
 })
 
 it('warns on a subscription without a matching handler', async () => {
@@ -327,7 +326,7 @@ it('warns on a subscription without a matching handler', async () => {
   const api = graphql.link('http://localhost:4000/graphql')
   server.use(api.subscription('OnCommentAdded', () => {}))
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
   })
   const subscription = client.iterate({
@@ -348,7 +347,6 @@ it('warns on a subscription without a matching handler', async () => {
     )
 
   pendingNext.catch(() => {})
-  await client.dispose()
 })
 
 it('warns when publishing to a subscription after the handlers were reset', async () => {
@@ -363,7 +361,7 @@ it('warns when publishing to a subscription after the handlers were reset', asyn
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
   })
   const subscription = client.iterate({
@@ -393,7 +391,6 @@ it('warns when publishing to a subscription after the handlers were reset', asyn
   )
 
   pendingNext.catch(() => {})
-  await client.dispose()
 })
 
 it('responds to the protocol ping messages', async () => {
@@ -491,7 +488,7 @@ it('resolves a subscription once when multiple links share the endpoint', async 
     secondApi.subscription('OnCommentAdded', secondResolver),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
   })
   const subscription = client.iterate({
@@ -516,8 +513,6 @@ it('resolves a subscription once when multiple links share the endpoint', async 
   // endpoint between links must not resolve it once per transport.
   expect(firstResolver).toHaveBeenCalledTimes(1)
   expect(secondResolver).not.toHaveBeenCalled()
-
-  await client.dispose()
 })
 
 it('subscribes to extraneous pubsubs', async () => {
@@ -550,7 +545,7 @@ it('subscribes to extraneous pubsubs', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'wss://localhost/graphql',
   })
   const subscription = client.iterate({
@@ -612,7 +607,7 @@ it('emits the "graphql:subscription" life-cycle event when a subscription is est
   const api = graphql.link('https://localhost/graphql')
   server.use(api.subscription('OnCommentAdded', () => {}))
 
-  const client = createClient({
+  await using client = createClient({
     url: 'wss://localhost/graphql',
   })
   const subscription = client.iterate({
@@ -638,7 +633,6 @@ it('emits the "graphql:subscription" life-cycle event when a subscription is est
   expect(subscriptionEvent.request.headers.get('upgrade')).toBe('websocket')
 
   pendingNext.catch(() => {})
-  await client.dispose()
 })
 
 it('does not emit the "graphql:subscription" life-cycle event for unhandled subscriptions', async () => {
@@ -650,7 +644,7 @@ it('does not emit the "graphql:subscription" life-cycle event for unhandled subs
   const api = graphql.link('https://localhost/graphql')
   server.use(api.subscription('OnCommentAdded', () => {}))
 
-  const client = createClient({
+  await using client = createClient({
     url: 'wss://localhost/graphql',
   })
   const subscription = client.iterate({
@@ -672,7 +666,6 @@ it('does not emit the "graphql:subscription" life-cycle event for unhandled subs
   expect(subscriptionListener).not.toHaveBeenCalled()
 
   pendingNext.catch(() => {})
-  await client.dispose()
 })
 
 it('combines extraneous and default pubsubs', async () => {
@@ -704,7 +697,7 @@ it('combines extraneous and default pubsubs', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'wss://localhost/graphql',
   })
   const subscription = client.iterate({
@@ -794,7 +787,7 @@ it('bypasses a subscription', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: testServer.ws.url().href,
   })
   const subscription = client.iterate({
@@ -871,7 +864,7 @@ it('augments original server subscription payload', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: testServer.ws.url().href,
   })
   const subscription = client.iterate({

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -276,6 +276,37 @@ it('matches an outgoing subscription with "graphql.operation()"', async () => {
     })
 })
 
+it('supports one-time "graphql.operation()" handlers', async () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const operationResolver = vi.fn()
+  const api = graphql.link('http://localhost:4000/graphql')
+  server.use(api.operation(operationResolver, { once: true }))
+
+  await using client = createClient({
+    url: 'ws://localhost:4000/graphql',
+    lazy: false,
+  })
+  const query = gql`
+    subscription OnCommentAdded {
+      commentAdded {
+        text
+      }
+    }
+  `
+
+  client.iterate({ query }).next()
+  await expect.poll(() => operationResolver).toHaveBeenCalledOnce()
+
+  // The second subscription must not match the used handler.
+  client.iterate({ query }).next()
+  await expect
+    .poll(() => vi.mocked(console.warn).mock.calls.flat().join('\n'))
+    .toMatch(/no matching subscription handler/)
+
+  expect(operationResolver).toHaveBeenCalledOnce()
+})
+
 it('supports one-time subscription handlers', async () => {
   vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -6,17 +6,10 @@ import {
   type GraphQLSubscription,
   type GraphQLSubscriptionResolver,
 } from 'msw/graphql'
-import { createTestHttpServer } from '@epic-web/test-server/http'
-import { createWebSocketMiddleware } from '@epic-web/test-server/ws'
-import {
-  createPubSub,
-  createSchema,
-  createYoga,
-  type YogaSchemaDefinition,
-} from 'graphql-yoga'
+import { createPubSub, createSchema } from 'graphql-yoga'
 import { createClient } from 'graphql-ws'
-import { useServer } from 'graphql-ws/lib/use/ws'
 import { gql } from '../../support/graphql'
+import { createTestGraphQLServer } from '../../support/graphqlServer'
 
 const server = setupServer()
 
@@ -762,85 +755,6 @@ it('combines extraneous and default pubsubs', async () => {
     },
   })
 })
-
-async function createTestGraphQLServer(options: {
-  pathname?: string
-  schema: YogaSchemaDefinition<Record<string, unknown>, Record<string, unknown>>
-}) {
-  const pathname = options.pathname || '/graphql'
-
-  const yoga = createYoga({
-    schema: options.schema,
-    graphiql: false,
-  })
-
-  const testServer = await createTestHttpServer({
-    defineRoutes(router) {
-      router.get('/graphql/*', ({ req }) => {
-        return yoga.fetch(req.raw)
-      })
-    },
-  })
-  const wss = createWebSocketMiddleware({
-    server: testServer,
-    pathname: yoga.graphqlEndpoint,
-  })
-
-  const disposeOfServer = useServer(
-    {
-      execute: (args: any) => args.execute(args),
-      subscribe: (args: any) => args.subscribe(args),
-      onSubscribe: async (ctx, params) => {
-        const { schema, execute, subscribe, contextFactory, parse, validate } =
-          yoga.getEnveloped({
-            ...ctx,
-            req: ctx.extra.request,
-            socket: ctx.extra.socket,
-            params,
-          })
-
-        const args = {
-          schema,
-          operationName: params.payload.operationName,
-          document: parse(params.payload.query),
-          variableValues: params.payload.variables,
-          contextValue: await contextFactory(),
-          execute,
-          subscribe,
-        }
-
-        const errors = validate(args.schema, args.document)
-
-        if (errors.length) {
-          return errors
-        }
-
-        return args
-      },
-    },
-    wss.raw,
-  )
-
-  return {
-    async [Symbol.asyncDispose]() {
-      await Promise.all([
-        testServer[Symbol.asyncDispose](),
-        wss[Symbol.asyncDispose](),
-      ])
-      await disposeOfServer.dispose()
-    },
-    http: {
-      url() {
-        return testServer.http.url(pathname)
-      },
-    },
-    ws: {
-      url() {
-        return wss.ws.url()
-      },
-    },
-  }
-}
 
 it('bypasses a subscription', async () => {
   await using testServer = await createTestGraphQLServer({

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -749,6 +749,46 @@ it('combines extraneous and default pubsubs', async () => {
   })
 })
 
+it('selects the operation by name in a multi-operation document', async () => {
+  const api = graphql.link('http://localhost:4000/graphql')
+
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      subscription.publish({
+        data: { commentAdded: { text: 'Hello world' } },
+      })
+    }),
+  )
+
+  await using client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const subscription = client.iterate({
+    // A document bundle where the subscription is not the first operation.
+    query: gql`
+      query GetComments {
+        comments {
+          text
+        }
+      }
+
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+    operationName: 'OnCommentAdded',
+  })
+
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: {
+      data: { commentAdded: { text: 'Hello world' } },
+    },
+  })
+})
+
 it('replays the connection params to the original server', async () => {
   const connectionParamsListener = vi.fn()
 

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -206,9 +206,6 @@ it('scopes published data to the subscribed client', async () => {
     return messages
   }
 
-  // Each client must receive only the data published to its
-  // own subscription (subscription ids are unique per socket,
-  // not across the clients).
   await expect(collectMessages('john')).resolves.toEqual([
     { data: { greeting: 'hello, john' } },
   ])
@@ -245,7 +242,6 @@ it('respects handler overrides for the same operation', async () => {
     `,
   })
 
-  // Must receive the data from the override handler.
   await expect(subscription.next()).resolves.toEqual({
     done: false,
     value: {
@@ -255,8 +251,36 @@ it('respects handler overrides for the same operation', async () => {
     },
   })
 
-  // The initial handler must not be called (first matching handler wins).
   expect(initialResolver).not.toHaveBeenCalled()
+})
+
+it('matches an outgoing subscription with "graphql.operation()"', async () => {
+  const operationResolver = vi.fn()
+
+  const api = graphql.link('https://localhost/graphql')
+  server.use(api.operation(operationResolver))
+
+  const client = createClient({
+    url: 'wss://localhost/graphql',
+  })
+  client.iterate({
+    query: gql`
+      subscription OnCommentAdded($postId: ID!) {
+        commentAdded(postId: $postId) {
+          text
+        }
+      }
+    `,
+    variables: { postId: 'post-1' },
+  })
+
+  await expect
+    .poll(() => operationResolver)
+    .toHaveBeenCalledExactlyOnceWith({
+      operationName: 'OnCommentAdded',
+      query: expect.stringContaining('subscription OnCommentAdded'),
+      variables: { postId: 'post-1' },
+    })
 })
 
 it('supports one-time subscription handlers', async () => {

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -1,0 +1,785 @@
+// @vitest-environment node
+import { HttpResponse, type PathParams } from 'msw'
+import { setupServer } from 'msw/node'
+import {
+  graphql,
+  type GraphQLSubscription,
+  type GraphQLSubscriptionResolver,
+} from 'msw/graphql'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+import { createTestHttpServer } from '@epic-web/test-server/http'
+import { createWebSocketMiddleware } from '@epic-web/test-server/ws'
+import {
+  createPubSub,
+  createSchema,
+  createYoga,
+  type YogaSchemaDefinition,
+} from 'graphql-yoga'
+import { createClient } from 'graphql-ws'
+import { useServer } from 'graphql-ws/lib/use/ws'
+import { gql } from '../../support/graphql'
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  vi.restoreAllMocks()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it('intercepts and mocks a GraphQL subscription', async () => {
+  const api = graphql.link('http://localhost:4000/graphql')
+
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      subscription.publish({
+        data: {
+          commentAdded: {
+            id: '1',
+            text: 'Hello world',
+          },
+        },
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          id
+          text
+        }
+      }
+    `,
+  })
+
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: {
+      data: {
+        commentAdded: {
+          id: '1',
+          text: 'Hello world',
+        },
+      },
+    },
+  })
+})
+
+it('marks a subscription as complete', async () => {
+  const api = graphql.link('http://localhost:4000/graphql')
+
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      queueMicrotask(() => {
+        subscription.complete()
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  await expect(subscription.next()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  })
+})
+
+it('terminates a subscription with errors', async () => {
+  const api = graphql.link('http://localhost:4000/graphql')
+
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      queueMicrotask(() => {
+        subscription.error([{ message: 'Something went wrong' }])
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  await expect(subscription.next()).rejects.toEqual([
+    expect.objectContaining({ message: 'Something went wrong' }),
+  ])
+})
+
+it('exposes path parameters from the WebSocket link', async () => {
+  const paramsPromise = new DeferredPromise<PathParams>()
+  const api = graphql.link('https://localhost/:service')
+
+  server.use(
+    api.subscription('OnCommentAdded', ({ params, subscription }) => {
+      paramsPromise.resolve(params)
+      subscription.complete()
+    }),
+  )
+
+  const client = createClient({
+    url: 'wss://localhost/user-service',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  await subscription.next()
+
+  await expect(paramsPromise).resolves.toEqual({
+    service: 'user-service',
+  })
+})
+
+it('scopes published data to the subscribed client', async () => {
+  const api = graphql.link('http://localhost:4000/graphql')
+
+  server.use(
+    api.subscription<{ greeting: string }, { name: string }>(
+      'OnGreeting',
+      ({ subscription }) => {
+        subscription.publish({
+          data: {
+            greeting: `hello, ${subscription.variables.name}`,
+          },
+        })
+        queueMicrotask(() => {
+          subscription.complete()
+        })
+      },
+    ),
+  )
+
+  const query = gql`
+    subscription OnGreeting($name: String!) {
+      greeting(name: $name)
+    }
+  `
+
+  async function collectMessages(name: string): Promise<Array<unknown>> {
+    const client = createClient({ url: 'ws://localhost:4000/graphql' })
+    const messages: Array<unknown> = []
+
+    for await (const result of client.iterate({
+      query,
+      variables: { name },
+    })) {
+      messages.push(result)
+    }
+
+    return messages
+  }
+
+  // Each client must receive only the data published to its
+  // own subscription (subscription ids are unique per socket,
+  // not across the clients).
+  await expect(collectMessages('john')).resolves.toEqual([
+    { data: { greeting: 'hello, john' } },
+  ])
+  await expect(collectMessages('kate')).resolves.toEqual([
+    { data: { greeting: 'hello, kate' } },
+  ])
+})
+
+it('respects handler overrides for the same operation', async () => {
+  const api = graphql.link('http://localhost:4000/graphql')
+  const initialResolver = vi.fn()
+
+  server.use(api.subscription('OnCommentAdded', initialResolver))
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      subscription.publish({
+        data: {
+          commentAdded: { text: 'override' },
+        },
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  // Must receive the data from the override handler.
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: {
+      data: {
+        commentAdded: { text: 'override' },
+      },
+    },
+  })
+
+  // The initial handler must not be called (first matching handler wins).
+  expect(initialResolver).not.toHaveBeenCalled()
+})
+
+it('supports one-time subscription handlers', async () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const api = graphql.link('http://localhost:4000/graphql')
+  const resolver = vi.fn<GraphQLSubscriptionResolver>(({ subscription }) => {
+    subscription.publish({
+      data: { commentAdded: { text: 'first' } },
+    })
+  })
+
+  server.use(api.subscription('OnCommentAdded', resolver, { once: true }))
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const query = gql`
+    subscription OnCommentAdded {
+      commentAdded {
+        text
+      }
+    }
+  `
+
+  const firstSubscription = client.iterate({ query })
+  await expect(firstSubscription.next()).resolves.toEqual({
+    done: false,
+    value: {
+      data: { commentAdded: { text: 'first' } },
+    },
+  })
+
+  // The second subscription must not match the used handler.
+  const secondSubscription = client.iterate({ query })
+  const secondNext = secondSubscription.next()
+
+  await expect
+    .poll(() => vi.mocked(console.warn).mock.calls.flat().join('\n'))
+    .toMatch(/no matching subscription handler/)
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+
+  secondNext.catch(() => {})
+  await client.dispose()
+})
+
+it('warns on a subscription without a matching handler', async () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const api = graphql.link('http://localhost:4000/graphql')
+  server.use(api.subscription('OnCommentAdded', () => {}))
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnPostAdded {
+        postAdded {
+          id
+        }
+      }
+    `,
+  })
+  const pendingNext = subscription.next()
+
+  await expect
+    .poll(() => vi.mocked(console.warn).mock.calls.flat().join('\n'))
+    .toMatch(
+      /Intercepted a GraphQL subscription "OnPostAdded" to "ws:\/\/localhost:4000\/graphql" that has no matching subscription handler/,
+    )
+
+  pendingNext.catch(() => {})
+  await client.dispose()
+})
+
+it('warns when publishing to a subscription after the handlers were reset', async () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const api = graphql.link('http://localhost:4000/graphql')
+  const subscriptionPromise = new DeferredPromise<GraphQLSubscription>()
+
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      subscriptionPromise.resolve(subscription)
+    }),
+  )
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+  const pendingNext = subscription.next()
+
+  const interceptedSubscription = await subscriptionPromise
+  server.resetHandlers()
+
+  // Publishing to a stale subscription must be a warning no-op
+  // instead of writing to the (possibly unrelated) socket.
+  interceptedSubscription.publish({
+    data: { commentAdded: { text: 'stale' } },
+  })
+
+  expect(console.warn).toHaveBeenCalledWith(
+    expect.stringMatching(
+      /Failed to publish to the GraphQL subscription ".+": the subscription is no longer active/,
+    ),
+  )
+
+  pendingNext.catch(() => {})
+  await client.dispose()
+})
+
+it('responds to the protocol ping messages', async () => {
+  const api = graphql.link('http://localhost:4000/graphql')
+  server.use(api.subscription('OnCommentAdded', () => {}))
+
+  const socket = new WebSocket('ws://localhost:4000/graphql', [
+    'graphql-transport-ws',
+  ])
+  const messages: Array<{ type: string }> = []
+  const pongPromise = new DeferredPromise<void>()
+
+  socket.onopen = () => {
+    socket.send(JSON.stringify({ type: 'connection_init' }))
+  }
+  socket.onmessage = (event) => {
+    const message = JSON.parse(String(event.data))
+    messages.push(message)
+
+    if (message.type === 'connection_ack') {
+      socket.send(JSON.stringify({ type: 'ping' }))
+    }
+
+    if (message.type === 'pong') {
+      pongPromise.resolve()
+    }
+  }
+
+  await pongPromise
+
+  expect(messages).toEqual([{ type: 'connection_ack' }, { type: 'pong' }])
+  socket.close()
+})
+
+it('subscribes to extraneous pubsubs', async () => {
+  const pubsub = createPubSub<{
+    commentAdded: [{ commentAdded: { text: string } }]
+  }>()
+  const subscriptionEstablishedPromise = new DeferredPromise<void>()
+
+  const api = graphql.link('https://localhost/graphql')
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      subscription.from(pubsub.subscribe('commentAdded'))
+      subscriptionEstablishedPromise.resolve()
+    }),
+    api.mutation('AddComment', ({ variables }) => {
+      const { comment } = variables
+
+      pubsub.publish('commentAdded', {
+        commentAdded: comment,
+      })
+
+      return HttpResponse.json({
+        data: { comment },
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: 'wss://localhost/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  // Await the subscription to be established before publishing to the
+  // pubsub. Unlike the client, the pubsub does not replay events published
+  // before the subscription became active (the mutation below may otherwise
+  // outrace the WebSocket handshake, e.g. on Node.js 24).
+  await subscriptionEstablishedPromise
+
+  const comment = { text: 'hello world' }
+  await fetch('https://localhost/graphql', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: gql`
+        mutation AddComment($comment: CommentInput!) {
+          comment {
+            text
+          }
+        }
+      `,
+      variables: { comment },
+    }),
+  })
+
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: {
+      data: {
+        commentAdded: comment,
+      },
+    },
+  })
+})
+
+it('combines extraneous and default pubsubs', async () => {
+  const pubsub = createPubSub<{
+    commentAdded: [{ commentAdded: { text: string } }]
+  }>()
+
+  const api = graphql.link('https://localhost/graphql')
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      subscription.publish({
+        data: {
+          commentAdded: {
+            text: 'manual comment',
+          },
+        },
+      })
+
+      subscription.from(pubsub.subscribe('commentAdded'))
+    }),
+    api.mutation('AddComment', ({ variables }) => {
+      const { comment } = variables
+
+      pubsub.publish('commentAdded', { commentAdded: comment })
+
+      return HttpResponse.json({
+        data: { comment },
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: 'wss://localhost/graphql',
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  // First, must receive the payload from the manual publish.
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: {
+      data: {
+        commentAdded: { text: 'manual comment' },
+      },
+    },
+  })
+
+  const comment = { text: 'comment from mutation' }
+  await fetch('https://localhost/graphql', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: gql`
+        mutation AddComment($comment: CommentInput!) {
+          comment {
+            text
+          }
+        }
+      `,
+      variables: { comment },
+    }),
+  })
+
+  // Then, must receive the publish from the mutation.
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: {
+      data: {
+        commentAdded: comment,
+      },
+    },
+  })
+})
+
+async function createTestGraphQLServer(options: {
+  pathname?: string
+  schema: YogaSchemaDefinition<Record<string, unknown>, Record<string, unknown>>
+}) {
+  const pathname = options.pathname || '/graphql'
+
+  const yoga = createYoga({
+    schema: options.schema,
+    graphiql: false,
+  })
+
+  const testServer = await createTestHttpServer({
+    defineRoutes(router) {
+      router.get('/graphql/*', ({ req }) => {
+        return yoga.fetch(req.raw)
+      })
+    },
+  })
+  const wss = createWebSocketMiddleware({
+    server: testServer,
+    pathname: yoga.graphqlEndpoint,
+  })
+
+  const disposeOfServer = useServer(
+    {
+      execute: (args: any) => args.execute(args),
+      subscribe: (args: any) => args.subscribe(args),
+      onSubscribe: async (ctx, params) => {
+        const { schema, execute, subscribe, contextFactory, parse, validate } =
+          yoga.getEnveloped({
+            ...ctx,
+            req: ctx.extra.request,
+            socket: ctx.extra.socket,
+            params,
+          })
+
+        const args = {
+          schema,
+          operationName: params.payload.operationName,
+          document: parse(params.payload.query),
+          variableValues: params.payload.variables,
+          contextValue: await contextFactory(),
+          execute,
+          subscribe,
+        }
+
+        const errors = validate(args.schema, args.document)
+
+        if (errors.length) {
+          return errors
+        }
+
+        return args
+      },
+    },
+    wss.raw,
+  )
+
+  return {
+    async [Symbol.asyncDispose]() {
+      await Promise.all([
+        testServer[Symbol.asyncDispose](),
+        wss[Symbol.asyncDispose](),
+      ])
+      await disposeOfServer.dispose()
+    },
+    http: {
+      url() {
+        return testServer.http.url(pathname)
+      },
+    },
+    ws: {
+      url() {
+        return wss.ws.url()
+      },
+    },
+  }
+}
+
+it('bypasses a subscription', async () => {
+  await using testServer = await createTestGraphQLServer({
+    schema: createSchema({
+      typeDefs: gql`
+        type Comment {
+          text: String!
+        }
+
+        type Query {
+          comments: [Comment!]!
+        }
+
+        type Subscription {
+          commentAdded: Comment!
+        }
+      `,
+      resolvers: {
+        Subscription: {
+          commentAdded: {
+            async *subscribe() {
+              yield { commentAdded: { text: 'hello world' } }
+            },
+          },
+        },
+      },
+    }),
+  })
+
+  const api = graphql.link(testServer.http.url().href)
+  server.use(
+    api.subscription('OnCommentAdded', async ({ subscription }) => {
+      const onCommentAddedSubscription = subscription.passthrough()
+      onCommentAddedSubscription.addEventListener('next', () => {
+        onCommentAddedSubscription.unsubscribe()
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: testServer.ws.url().href,
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  // Must receive the payload from the original server.
+  await expect(subscription.next()).resolves.toEqual({
+    value: {
+      data: {
+        commentAdded: {
+          text: 'hello world',
+        },
+      },
+    },
+    done: false,
+  })
+})
+
+it('augments original server subscription payload', async () => {
+  await using testServer = await createTestGraphQLServer({
+    schema: createSchema({
+      typeDefs: gql`
+        type Comment {
+          text: String!
+        }
+
+        type Query {
+          comments: [Comment!]!
+        }
+
+        type Subscription {
+          commentAdded: Comment!
+        }
+      `,
+      resolvers: {
+        Subscription: {
+          commentAdded: {
+            async *subscribe() {
+              yield { commentAdded: { text: 'hello world' } }
+            },
+          },
+        },
+      },
+    }),
+  })
+
+  const api = graphql.link(testServer.http.url().href)
+  server.use(
+    api.subscription('OnCommentAdded', async ({ subscription }) => {
+      const onCommentAddedSubscription = subscription.passthrough()
+      onCommentAddedSubscription.addEventListener('next', (event) => {
+        // Prevent the default server-to-client forwarding.
+        event.preventDefault()
+
+        // Publish the modified payload to the client.
+        const { payload } = event.data
+        payload.data = {
+          commentAdded: {
+            text: String(payload.data?.commentAdded?.text).toUpperCase(),
+          },
+        }
+
+        subscription.publish(payload)
+
+        onCommentAddedSubscription.unsubscribe()
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: testServer.ws.url().href,
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  // Must receive the payload from the original server.
+  await expect(subscription.next()).resolves.toEqual({
+    value: {
+      data: {
+        commentAdded: {
+          text: 'HELLO WORLD',
+        },
+      },
+    },
+    done: false,
+  })
+})

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -749,6 +749,70 @@ it('combines extraneous and default pubsubs', async () => {
   })
 })
 
+it('replays the connection params to the original server', async () => {
+  const connectionParamsListener = vi.fn()
+
+  await using testServer = await createTestGraphQLServer({
+    onConnect: connectionParamsListener,
+    schema: createSchema({
+      typeDefs: gql`
+        type Comment {
+          text: String!
+        }
+
+        type Query {
+          comments: [Comment!]!
+        }
+
+        type Subscription {
+          commentAdded: Comment!
+        }
+      `,
+      resolvers: {
+        Subscription: {
+          commentAdded: {
+            async *subscribe() {
+              yield { commentAdded: { text: 'hello world' } }
+            },
+          },
+        },
+      },
+    }),
+  })
+
+  const api = graphql.link(testServer.http.url().href)
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription }) => {
+      subscription.passthrough()
+    }),
+  )
+
+  await using client = createClient({
+    url: testServer.ws.url().href,
+    connectionParams: { authorization: 'Bearer abc-123' },
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: { data: { commentAdded: { text: 'hello world' } } },
+  })
+
+  // The client's `connectionParams` must reach the original server
+  // unchanged, otherwise it cannot authorize this client.
+  expect(connectionParamsListener).toHaveBeenCalledWith({
+    authorization: 'Bearer abc-123',
+  })
+})
+
 it('bypasses a subscription', async () => {
   await using testServer = await createTestGraphQLServer({
     schema: createSchema({

--- a/test/node/graphql-api/graphql-subscription.test.ts
+++ b/test/node/graphql-api/graphql-subscription.test.ts
@@ -269,11 +269,23 @@ it('matches an outgoing subscription with "graphql.operation()"', async () => {
 
   await expect
     .poll(() => operationResolver)
-    .toHaveBeenCalledExactlyOnceWith({
-      operationName: 'OnCommentAdded',
-      query: expect.stringContaining('subscription OnCommentAdded'),
-      variables: { postId: 'post-1' },
-    })
+    .toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        operationName: 'OnCommentAdded',
+        query: expect.stringContaining('subscription OnCommentAdded'),
+        variables: { postId: 'post-1' },
+      }),
+    )
+
+  // The resolver must receive the full resolver contract, not a
+  // reduced object that only looks like one to TypeScript.
+  const [info] = operationResolver.mock.calls[0]
+  expect(info.request).toBeInstanceOf(Request)
+  expect(info.request.url).toBe('wss://localhost/graphql')
+  expect(info.request.headers.get('upgrade')).toBe('websocket')
+  expect(info.requestId).toEqual(expect.any(String))
+  expect(info.cookies).toEqual({})
+  expect(info.finalize).toBeInstanceOf(Function)
 })
 
 it('supports one-time "graphql.operation()" handlers', async () => {

--- a/test/node/graphql-api/multi-operation-document.test.ts
+++ b/test/node/graphql-api/multi-operation-document.test.ts
@@ -117,3 +117,28 @@ it('selects the operation by name for a multipart request', async () => {
   })
   expect(queryResolver).not.toHaveBeenCalled()
 })
+
+it('does not match any handler given an unknown operation name', async () => {
+  const queryResolver = vi.fn()
+  const mutationResolver = vi.fn()
+
+  server.use(
+    graphql.query('GetUser', queryResolver),
+    graphql.mutation('UpdateUser', mutationResolver),
+  )
+
+  const response = await fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: DOCUMENT,
+      operationName: 'Unknown',
+    }),
+  }).catch((error) => error)
+
+  // Resolving the leading operation would mock an operation the
+  // client never asked for.
+  expect(queryResolver).not.toHaveBeenCalled()
+  expect(mutationResolver).not.toHaveBeenCalled()
+  expect(response).toBeInstanceOf(Error)
+})

--- a/test/node/graphql-api/multi-operation-document.test.ts
+++ b/test/node/graphql-api/multi-operation-document.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+import { HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { graphql } from 'msw/graphql'
+import { gql } from '../../support/graphql'
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+/**
+ * A document bundling multiple operations, like the ones emitted
+ * by GraphQL Code Generator.
+ */
+const DOCUMENT = gql`
+  query GetUser {
+    user {
+      id
+    }
+  }
+
+  mutation UpdateUser {
+    updateUser {
+      id
+    }
+  }
+`
+
+it('selects the operation by name for a POST request', async () => {
+  const queryResolver = vi.fn()
+
+  server.use(
+    graphql.query('GetUser', queryResolver),
+    graphql.mutation('UpdateUser', () => {
+      return HttpResponse.json({ data: { updateUser: { id: '1' } } })
+    }),
+  )
+
+  const response = await fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: DOCUMENT,
+      operationName: 'UpdateUser',
+    }),
+  })
+
+  await expect(response.json()).resolves.toEqual({
+    data: { updateUser: { id: '1' } },
+  })
+
+  // The leading "GetUser" query must not intercept a request
+  // that explicitly asks for the "UpdateUser" mutation.
+  expect(queryResolver).not.toHaveBeenCalled()
+})
+
+it('selects the operation by name for a GET request', async () => {
+  const queryResolver = vi.fn()
+
+  server.use(
+    graphql.query('GetUser', queryResolver),
+    graphql.mutation('UpdateUser', () => {
+      return HttpResponse.json({ data: { updateUser: { id: '1' } } })
+    }),
+  )
+
+  const url = new URL('http://localhost/graphql')
+  url.searchParams.set('query', DOCUMENT)
+  url.searchParams.set('operationName', 'UpdateUser')
+
+  const response = await fetch(url)
+
+  await expect(response.json()).resolves.toEqual({
+    data: { updateUser: { id: '1' } },
+  })
+  expect(queryResolver).not.toHaveBeenCalled()
+})
+
+it('selects the operation by name for a multipart request', async () => {
+  const queryResolver = vi.fn()
+
+  server.use(
+    graphql.query('GetUser', queryResolver),
+    graphql.mutation('UpdateUser', () => {
+      return HttpResponse.json({ data: { updateUser: { id: '1' } } })
+    }),
+  )
+
+  const formData = new FormData()
+  formData.set(
+    'operations',
+    JSON.stringify({
+      query: DOCUMENT,
+      operationName: 'UpdateUser',
+      variables: {},
+    }),
+  )
+  formData.set('map', JSON.stringify({}))
+
+  const response = await fetch('http://localhost/graphql', {
+    method: 'POST',
+    body: formData,
+  })
+
+  await expect(response.json()).resolves.toEqual({
+    data: { updateUser: { id: '1' } },
+  })
+  expect(queryResolver).not.toHaveBeenCalled()
+})

--- a/test/node/msw-api/finalize.test.ts
+++ b/test/node/msw-api/finalize.test.ts
@@ -301,6 +301,51 @@ it('runs after a GraphQL query handler returns a response', async () => {
   expect(cleanup).toHaveBeenCalledOnce()
 })
 
+it('reports a failing GraphQL subscription cleanup without an unhandled rejection', async () => {
+  const unhandledRejectionListener = vi.fn()
+  process.on('unhandledRejection', unhandledRejectionListener)
+
+  const secondCleanup = vi.fn()
+
+  const api = graphql.link('http://localhost:4000/graphql')
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription, finalize }) => {
+      finalize(secondCleanup)
+      finalize(async () => {
+        throw new Error('Cleanup error')
+      })
+      queueMicrotask(() => {
+        subscription.complete()
+      })
+    }),
+  )
+
+  await using client = createClient({
+    url: 'ws://localhost:4000/graphql',
+    lazy: false,
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+  await subscription.next()
+
+  await expect
+    .poll(() => vi.mocked(console.error).mock.calls.flat().join('\n'))
+    .toMatch(/Failed to execute the cleanup for a GraphQL subscription/)
+
+  // A failing cleanup must not prevent the remaining cleanups from running.
+  expect(secondCleanup).toHaveBeenCalledOnce()
+
+  process.off('unhandledRejection', unhandledRejectionListener)
+  expect(unhandledRejectionListener).not.toHaveBeenCalled()
+})
+
 it('runs after a GraphQL subscription is completed by the mock', async () => {
   const cleanup = vi.fn()
 

--- a/test/node/msw-api/finalize.test.ts
+++ b/test/node/msw-api/finalize.test.ts
@@ -301,6 +301,67 @@ it('runs after a GraphQL query handler returns a response', async () => {
   expect(cleanup).toHaveBeenCalledOnce()
 })
 
+it('runs after a GraphQL operation handler returns a response', async () => {
+  const cleanup = vi.fn()
+
+  const api = graphql.link('http://localhost/graphql')
+  server.use(
+    api.operation(({ finalize }) => {
+      finalize(cleanup)
+      return HttpResponse.json({ data: { user: { id: '1' } } })
+    }),
+  )
+
+  const response = await fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: `query GetUser { user { id } }`,
+    }),
+  })
+
+  await expect(response.json()).resolves.toEqual({
+    data: { user: { id: '1' } },
+  })
+  expect(cleanup).toHaveBeenCalledOnce()
+})
+
+it('runs after a GraphQL operation subscription is completed', async () => {
+  const cleanup = vi.fn()
+  const resolverCalled = Promise.withResolvers<void>()
+
+  const api = graphql.link('ws://localhost:4000/graphql')
+  server.use(
+    api.operation(({ finalize }) => {
+      finalize(cleanup)
+      resolverCalled.resolve()
+    }),
+  )
+
+  await using client = createClient({
+    url: 'ws://localhost:4000/graphql',
+    lazy: false,
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  subscription.next()
+  await resolverCalled.promise
+  expect(cleanup).not.toHaveBeenCalled()
+
+  // Unsubscribing sends a "complete" frame from the client.
+  await subscription.return?.()
+
+  await expect.poll(() => cleanup).toHaveBeenCalledOnce()
+})
+
 it('reports a failing GraphQL subscription cleanup without an unhandled rejection', async () => {
   const unhandledRejectionListener = vi.fn()
   process.on('unhandledRejection', unhandledRejectionListener)

--- a/test/node/msw-api/finalize.test.ts
+++ b/test/node/msw-api/finalize.test.ts
@@ -486,6 +486,48 @@ it('runs after a GraphQL subscription is completed by the original server', asyn
   await expect.poll(() => cleanup).toHaveBeenCalledOnce()
 })
 
+it('runs after the network is closed while the subscription is open', async () => {
+  const cleanup = vi.fn()
+  const subscriptionEstablished = Promise.withResolvers<void>()
+
+  const api = graphql.link('ws://localhost:4000/graphql')
+  server.use(
+    api.subscription('OnCommentAdded', ({ finalize }) => {
+      finalize(cleanup)
+      subscriptionEstablished.resolve()
+    }),
+  )
+
+  await using client = createClient({
+    url: 'ws://localhost:4000/graphql',
+    lazy: false,
+  })
+  client
+    .iterate({
+      query: gql`
+        subscription OnCommentAdded {
+          commentAdded {
+            text
+          }
+        }
+      `,
+    })
+    .next()
+
+  await subscriptionEstablished.promise
+  expect(cleanup).not.toHaveBeenCalled()
+
+  // Closing the network detaches the resolver from the subscription
+  // while the client is still connected.
+  server.close()
+
+  // Restore the network before asserting so a failure here
+  // cannot leave the network closed for the rest of the suite.
+  server.listen()
+
+  await expect.poll(() => cleanup).toHaveBeenCalledOnce()
+})
+
 it('runs cleanup for parallel requests', async () => {
   const cleanup = vi.fn()
 

--- a/test/node/msw-api/finalize.test.ts
+++ b/test/node/msw-api/finalize.test.ts
@@ -3,7 +3,7 @@ import { setTimeout } from 'node:timers/promises'
 import { http, passthrough, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { graphql } from 'msw/graphql'
-import { createClient } from 'graphql-ws'
+import { createClient } from '../../support/graphqlClient'
 import { createSchema } from 'graphql-yoga'
 import { gql } from '../../support/graphql'
 import { createTestGraphQLServer } from '../../support/graphqlServer'
@@ -314,7 +314,7 @@ it('runs after a GraphQL subscription is completed by the mock', async () => {
     }),
   )
 
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
     lazy: false,
   })
@@ -333,8 +333,6 @@ it('runs after a GraphQL subscription is completed by the mock', async () => {
     value: undefined,
   })
   expect(cleanup).toHaveBeenCalledOnce()
-
-  await client.dispose()
 })
 
 it('runs after a GraphQL subscription is completed by the client', async () => {
@@ -352,7 +350,7 @@ it('runs after a GraphQL subscription is completed by the client', async () => {
   // `lazy: false` keeps the socket open after the subscription ends.
   // Otherwise the client closes it, and the cleanup would run via the
   // disconnect path instead of the client's "complete" frame.
-  const client = createClient({
+  await using client = createClient({
     url: 'ws://localhost:4000/graphql',
     lazy: false,
   })
@@ -376,8 +374,6 @@ it('runs after a GraphQL subscription is completed by the client', async () => {
   await subscription.return?.()
 
   await expect.poll(() => cleanup).toHaveBeenCalledOnce()
-
-  await client.dispose()
 })
 
 it('runs after a GraphQL subscription is completed by the original server', async () => {
@@ -422,7 +418,7 @@ it('runs after a GraphQL subscription is completed by the original server', asyn
 
   // `lazy: false` keeps the socket open once the server completes the
   // subscription, so the cleanup cannot run via the disconnect path.
-  const client = createClient({
+  await using client = createClient({
     url: testServer.ws.url().href,
     lazy: false,
   })
@@ -443,8 +439,6 @@ it('runs after a GraphQL subscription is completed by the original server', asyn
 
   // The cleanup runs once the original server completes the subscription.
   await expect.poll(() => cleanup).toHaveBeenCalledOnce()
-
-  await client.dispose()
 })
 
 it('runs cleanup for parallel requests', async () => {

--- a/test/node/msw-api/finalize.test.ts
+++ b/test/node/msw-api/finalize.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment node
 import { setTimeout } from 'node:timers/promises'
-import { http, passthrough } from 'msw'
+import { http, passthrough, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import { graphql } from 'msw/graphql'
+import { createClient } from 'graphql-ws'
+import { createSchema } from 'graphql-yoga'
+import { gql } from '../../support/graphql'
+import { createTestGraphQLServer } from '../../support/graphqlServer'
 
 const server = setupServer()
 
@@ -270,6 +275,176 @@ it('runs once the returned iterator is exhausted', async () => {
     await expect(response.text()).resolves.toBe('final')
     expect(cleanup).toHaveBeenCalledOnce()
   }
+})
+
+it('runs after a GraphQL query handler returns a response', async () => {
+  const cleanup = vi.fn()
+
+  server.use(
+    graphql.query('GetUser', ({ finalize }) => {
+      finalize(cleanup)
+      return HttpResponse.json({ data: { user: { id: '1' } } })
+    }),
+  )
+
+  const response = await fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: `query GetUser { user { id } }`,
+    }),
+  })
+
+  await expect(response.json()).resolves.toEqual({
+    data: { user: { id: '1' } },
+  })
+  expect(cleanup).toHaveBeenCalledOnce()
+})
+
+it('runs after a GraphQL subscription is completed by the mock', async () => {
+  const cleanup = vi.fn()
+
+  const api = graphql.link('http://localhost:4000/graphql')
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription, finalize }) => {
+      finalize(cleanup)
+      queueMicrotask(() => {
+        subscription.complete()
+      })
+    }),
+  )
+
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+    lazy: false,
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  await expect(subscription.next()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  })
+  expect(cleanup).toHaveBeenCalledOnce()
+
+  await client.dispose()
+})
+
+it('runs after a GraphQL subscription is completed by the client', async () => {
+  const cleanup = vi.fn()
+  const resolverCalled = Promise.withResolvers<void>()
+
+  const api = graphql.link('http://localhost:4000/graphql')
+  server.use(
+    api.subscription('OnCommentAdded', ({ finalize }) => {
+      finalize(cleanup)
+      resolverCalled.resolve()
+    }),
+  )
+
+  // `lazy: false` keeps the socket open after the subscription ends.
+  // Otherwise the client closes it, and the cleanup would run via the
+  // disconnect path instead of the client's "complete" frame.
+  const client = createClient({
+    url: 'ws://localhost:4000/graphql',
+    lazy: false,
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  // Begin the subscription, then await it being established so the
+  // client's "complete" frame cannot outrace the handshake.
+  subscription.next()
+  await resolverCalled.promise
+  expect(cleanup).not.toHaveBeenCalled()
+
+  // Unsubscribing sends a "complete" frame from the client.
+  await subscription.return?.()
+
+  await expect.poll(() => cleanup).toHaveBeenCalledOnce()
+
+  await client.dispose()
+})
+
+it('runs after a GraphQL subscription is completed by the original server', async () => {
+  await using testServer = await createTestGraphQLServer({
+    schema: createSchema({
+      typeDefs: gql`
+        type Comment {
+          text: String!
+        }
+
+        type Query {
+          comments: [Comment!]!
+        }
+
+        type Subscription {
+          commentAdded: Comment!
+        }
+      `,
+      resolvers: {
+        Subscription: {
+          commentAdded: {
+            // The server yields a single value and completes
+            // the subscription right after.
+            async *subscribe() {
+              yield { commentAdded: { text: 'hello world' } }
+            },
+          },
+        },
+      },
+    }),
+  })
+
+  const cleanup = vi.fn()
+
+  const api = graphql.link(testServer.http.url().href)
+  server.use(
+    api.subscription('OnCommentAdded', ({ subscription, finalize }) => {
+      finalize(cleanup)
+      subscription.passthrough()
+    }),
+  )
+
+  // `lazy: false` keeps the socket open once the server completes the
+  // subscription, so the cleanup cannot run via the disconnect path.
+  const client = createClient({
+    url: testServer.ws.url().href,
+    lazy: false,
+  })
+  const subscription = client.iterate({
+    query: gql`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `,
+  })
+
+  await expect(subscription.next()).resolves.toEqual({
+    done: false,
+    value: { data: { commentAdded: { text: 'hello world' } } },
+  })
+
+  // The cleanup runs once the original server completes the subscription.
+  await expect.poll(() => cleanup).toHaveBeenCalledOnce()
+
+  await client.dispose()
 })
 
 it('runs cleanup for parallel requests', async () => {

--- a/test/support/graphqlClient.ts
+++ b/test/support/graphqlClient.ts
@@ -1,0 +1,26 @@
+import {
+  createClient as createGraphQLClient,
+  type Client,
+  type ClientOptions,
+} from 'graphql-ws'
+
+export type DisposableGraphQLClient = Client & AsyncDisposable
+
+/**
+ * Create a GraphQL client that disposes of itself when it goes out
+ * of scope. Prefer it over `createClient()` from "graphql-ws" so the
+ * tests don't have to dispose of their clients explicitly.
+ *
+ * @example
+ * await using client = createClient({ url })
+ * // The client is disposed of once the test is done.
+ */
+export function createClient(options: ClientOptions): DisposableGraphQLClient {
+  const client = createGraphQLClient(options)
+
+  return Object.assign(client, {
+    async [Symbol.asyncDispose](): Promise<void> {
+      await client.dispose()
+    },
+  })
+}

--- a/test/support/graphqlServer.ts
+++ b/test/support/graphqlServer.ts
@@ -20,18 +20,19 @@ export async function createTestGraphQLServer(options: {
   const yoga = createYoga({
     schema: options.schema,
     graphiql: false,
+    graphqlEndpoint: pathname,
   })
 
   const testServer = await createTestHttpServer({
     defineRoutes(router) {
-      router.get('/graphql/*', ({ req }) => {
+      router.get(`${pathname}/*`, ({ req }) => {
         return yoga.fetch(req.raw)
       })
     },
   })
   const wss = createWebSocketMiddleware({
     server: testServer,
-    pathname: yoga.graphqlEndpoint,
+    pathname,
   })
 
   const disposeOfServer = useServer(

--- a/test/support/graphqlServer.ts
+++ b/test/support/graphqlServer.ts
@@ -10,6 +10,10 @@ import { useServer } from 'graphql-ws/lib/use/ws'
 export async function createTestGraphQLServer(options: {
   pathname?: string
   schema: YogaSchemaDefinition<Record<string, unknown>, Record<string, unknown>>
+  /**
+   * Called with the `connectionParams` of every connected client.
+   */
+  onConnect?: (connectionParams?: Record<string, unknown>) => void
 }) {
   const pathname = options.pathname || '/graphql'
 
@@ -32,6 +36,9 @@ export async function createTestGraphQLServer(options: {
 
   const disposeOfServer = useServer(
     {
+      onConnect: (ctx) => {
+        options.onConnect?.(ctx.connectionParams)
+      },
       execute: (args: any) => args.execute(args),
       subscribe: (args: any) => args.subscribe(args),
       onSubscribe: async (ctx, params) => {

--- a/test/support/graphqlServer.ts
+++ b/test/support/graphqlServer.ts
@@ -1,0 +1,87 @@
+import { createTestHttpServer } from '@epic-web/test-server/http'
+import { createWebSocketMiddleware } from '@epic-web/test-server/ws'
+import { createYoga, type YogaSchemaDefinition } from 'graphql-yoga'
+import { useServer } from 'graphql-ws/lib/use/ws'
+
+/**
+ * Create a real GraphQL server that serves queries over HTTP and
+ * subscriptions over WebSocket (`graphql-transport-ws`).
+ */
+export async function createTestGraphQLServer(options: {
+  pathname?: string
+  schema: YogaSchemaDefinition<Record<string, unknown>, Record<string, unknown>>
+}) {
+  const pathname = options.pathname || '/graphql'
+
+  const yoga = createYoga({
+    schema: options.schema,
+    graphiql: false,
+  })
+
+  const testServer = await createTestHttpServer({
+    defineRoutes(router) {
+      router.get('/graphql/*', ({ req }) => {
+        return yoga.fetch(req.raw)
+      })
+    },
+  })
+  const wss = createWebSocketMiddleware({
+    server: testServer,
+    pathname: yoga.graphqlEndpoint,
+  })
+
+  const disposeOfServer = useServer(
+    {
+      execute: (args: any) => args.execute(args),
+      subscribe: (args: any) => args.subscribe(args),
+      onSubscribe: async (ctx, params) => {
+        const { schema, execute, subscribe, contextFactory, parse, validate } =
+          yoga.getEnveloped({
+            ...ctx,
+            req: ctx.extra.request,
+            socket: ctx.extra.socket,
+            params,
+          })
+
+        const args = {
+          schema,
+          operationName: params.payload.operationName,
+          document: parse(params.payload.query),
+          variableValues: params.payload.variables,
+          contextValue: await contextFactory(),
+          execute,
+          subscribe,
+        }
+
+        const errors = validate(args.schema, args.document)
+
+        if (errors.length) {
+          return errors
+        }
+
+        return args
+      },
+    },
+    wss.raw,
+  )
+
+  return {
+    async [Symbol.asyncDispose]() {
+      await Promise.all([
+        testServer[Symbol.asyncDispose](),
+        wss[Symbol.asyncDispose](),
+      ])
+      await disposeOfServer.dispose()
+    },
+    http: {
+      url() {
+        return testServer.http.url(pathname)
+      },
+    },
+    ws: {
+      url() {
+        return wss.ws.url()
+      },
+    },
+  }
+}

--- a/test/typings/graphql.test-d.ts
+++ b/test/typings/graphql.test-d.ts
@@ -1,7 +1,29 @@
 import { it, expectTypeOf } from 'vitest'
 import { parse } from 'graphql'
-import { HttpResponse, passthrough } from 'msw'
-import { graphql } from 'msw/graphql'
+import type {
+  DocumentTypeDecoration,
+  TypedDocumentNode,
+} from '@graphql-typed-document-node/core'
+import { HttpResponse, passthrough, type PathParams } from 'msw'
+import {
+  graphql,
+  type GraphQLPassthroughSubscription,
+  type GraphQLSubscription,
+  type GraphQLSubscriptionPayload,
+} from 'msw/graphql'
+
+/**
+ * The two document flavors emitted by GraphQL Code Generator:
+ * a `TypedDocumentNode` (the "typed-document-node" plugin) and a
+ * `TypedDocumentString` (the "client" preset).
+ */
+declare function createTypedDocumentNode<TResult = any, TVariables = any>(
+  query: string,
+): TypedDocumentNode<TResult, TVariables>
+
+declare function createTypedDocumentString<TResult = any, TVariables = any>(
+  query: string,
+): DocumentTypeDecoration<TResult, TVariables>
 
 it('graphql mutation can be used without variables generic type', () => {
   graphql.mutation('GetUser', () => {
@@ -251,4 +273,223 @@ it('supports a "finalize" function', () => {
       (callback: () => Promise<void> | void) => void
     >()
   })
+})
+
+it('graphql subscription is only available on a link', () => {
+  graphql
+    .link('ws://localhost/graphql')
+    .subscription('OnCommentAdded', () => {})
+
+  // Subscriptions require a concrete endpoint, so they are not
+  // exposed on the root "graphql" namespace.
+  // @ts-expect-error Property "subscription" does not exist.
+  graphql.subscription('OnCommentAdded', () => {})
+})
+
+it('graphql subscription accepts string, RegExp, and DocumentNode names', () => {
+  const api = graphql.link('ws://localhost/graphql')
+
+  api.subscription('OnCommentAdded', () => {})
+  api.subscription(/OnComment/, () => {})
+  api.subscription(
+    parse(`
+      subscription OnCommentAdded {
+        commentAdded {
+          text
+        }
+      }
+    `),
+    () => {},
+  )
+
+  // Unlike queries and mutations, subscriptions do not
+  // support custom predicate functions.
+  api.subscription(
+    // @ts-expect-error A custom predicate is not a valid subscription name.
+    () => true,
+    () => {},
+  )
+})
+
+it('graphql subscription exposes the resolver info', () => {
+  graphql
+    .link('ws://localhost/:service')
+    .subscription('OnCommentAdded', (info) => {
+      expectTypeOf(info.operationName).toEqualTypeOf<string>()
+      expectTypeOf(info.params).toEqualTypeOf<PathParams>()
+      expectTypeOf(info.subscription).toEqualTypeOf<GraphQLSubscription>()
+      expectTypeOf(info.finalize).toEqualTypeOf<
+        (callback: () => Promise<void> | void) => void
+      >()
+    })
+})
+
+it('graphql subscription accepts inline generic variables type', () => {
+  graphql
+    .link('ws://localhost/graphql')
+    .subscription<never, { postId: string }>(
+      'OnCommentAdded',
+      ({ subscription }) => {
+        expectTypeOf(subscription.variables).toEqualTypeOf<{
+          postId: string
+        }>()
+        expectTypeOf(subscription.query).toEqualTypeOf<string>()
+        expectTypeOf(subscription.id).toEqualTypeOf<string>()
+      },
+    )
+})
+
+it("graphql subscription does not accept null as variables' generic type", () => {
+  graphql.link('ws://localhost/graphql').subscription<
+    { key: string },
+    // @ts-expect-error `null` is not a valid variables type.
+    null
+  >('OnCommentAdded', () => {})
+})
+
+it('graphql subscription publishes a payload matching the query type', () => {
+  graphql
+    .link('ws://localhost/graphql')
+    .subscription<{ commentAdded: { text: string } }>(
+      'OnCommentAdded',
+      ({ subscription }) => {
+        subscription.publish({
+          data: { commentAdded: { text: 'hello' } },
+        })
+
+        // Explicit null must be allowed.
+        subscription.publish({ data: null })
+
+        subscription.publish({
+          data: { commentAdded: { text: 'hello' } },
+          extensions: { requestId: 'abc-123' },
+        })
+
+        subscription.publish({
+          // @ts-expect-error Published data doesn't match the query type.
+          data: { commentAdded: { text: 123 } },
+        })
+
+        subscription.publish({
+          // @ts-expect-error Published data doesn't match the query type.
+          data: {},
+        })
+      },
+    )
+})
+
+it('graphql subscription publishes from an iterable of the query type', async () => {
+  graphql
+    .link('ws://localhost/graphql')
+    .subscription<{ commentAdded: { text: string } }>(
+      'OnCommentAdded',
+      async ({ subscription }) => {
+        expectTypeOf(subscription.from).returns.toEqualTypeOf<Promise<void>>()
+
+        await subscription.from([{ commentAdded: { text: 'hello' } }])
+
+        await subscription.from(
+          (async function* () {
+            yield { commentAdded: { text: 'hello' } }
+          })(),
+        )
+
+        // @ts-expect-error Published data doesn't match the query type.
+        await subscription.from([{ commentAdded: { text: 123 } }])
+      },
+    )
+})
+
+it('graphql subscription terminates with errors and completes', () => {
+  graphql
+    .link('ws://localhost/graphql')
+    .subscription('OnCommentAdded', ({ subscription }) => {
+      subscription.error([{ message: 'Something went wrong' }])
+
+      // Partial "GraphQLError" objects are allowed.
+      subscription.error([{ message: 'Oops', path: ['commentAdded'] }])
+
+      // @ts-expect-error Errors must be a list.
+      subscription.error({ message: 'Something went wrong' })
+
+      expectTypeOf(subscription.complete).toEqualTypeOf<() => void>()
+    })
+})
+
+it('graphql subscription infers types from a TypedDocumentNode', () => {
+  graphql
+    .link('ws://localhost/graphql')
+    .subscription(
+      createTypedDocumentNode<
+        { commentAdded: { text: string } },
+        { postId: string }
+      >(''),
+      ({ subscription }) => {
+        expectTypeOf(subscription.variables).toEqualTypeOf<{ postId: string }>()
+
+        subscription.publish({
+          data: { commentAdded: { text: 'hello' } },
+        })
+
+        subscription.publish({
+          // @ts-expect-error Published data doesn't match the document type.
+          data: { commentAdded: { text: 123 } },
+        })
+      },
+    )
+})
+
+it('graphql subscription infers types from a TypedDocumentString', () => {
+  graphql
+    .link('ws://localhost/graphql')
+    .subscription(
+      createTypedDocumentString<
+        { commentAdded: { text: string } },
+        { postId: string }
+      >(''),
+      ({ subscription }) => {
+        expectTypeOf(subscription.variables).toEqualTypeOf<{ postId: string }>()
+
+        subscription.publish({
+          data: { commentAdded: { text: 'hello' } },
+        })
+
+        subscription.publish({
+          // @ts-expect-error Published data doesn't match the document type.
+          data: { commentAdded: { text: 123 } },
+        })
+      },
+    )
+})
+
+it('graphql subscription accepts handler options', () => {
+  const api = graphql.link('ws://localhost/graphql')
+
+  api.subscription('OnCommentAdded', () => {}, { once: true })
+
+  // @ts-expect-error Unknown handler option.
+  api.subscription('OnCommentAdded', () => {}, { unknownOption: true })
+})
+
+it('graphql subscription supports passthrough', () => {
+  graphql
+    .link('ws://localhost/graphql')
+    .subscription('OnCommentAdded', ({ subscription }) => {
+      const original = subscription.passthrough()
+      expectTypeOf(original).toEqualTypeOf<GraphQLPassthroughSubscription>()
+
+      original.addEventListener('next', (event) => {
+        expectTypeOf(event.data.type).toEqualTypeOf<'next'>()
+        expectTypeOf(event.data.id).toEqualTypeOf<string>()
+        expectTypeOf(
+          event.data.payload,
+        ).toEqualTypeOf<GraphQLSubscriptionPayload>()
+      })
+      original.addEventListener('complete', () => {})
+      original.addEventListener('error', () => {})
+      original.addEventListener('connection_ack', () => {})
+
+      // @ts-expect-error Unknown passthrough subscription event.
+      original.addEventListener('unknown', () => {})
+    })
 })


### PR DESCRIPTION
- Related to #285 
- Closes https://github.com/mswjs/msw/pull/2357

## API

```ts
import { graphql } from 'msw/graphql'

const api = graphql.link('https://api.example.com/graphql')

api.subscription('OnCommendAdded', ({ subscription }) => {
  subscription.publish({
    data: {
      commendAdded: {
        text: 'hello world'
      }
    }
  })
})
```

## Changes

- Adds `graphql.subscription()`.
- Adds base `Handler` for common methods like `reset()`.
- Adds `dispose()` common handler method to react to when `network.disable()` is called.

## Roadmap

- [x] Implement the `graphql.subscription()` API.
- [x] Fix the missing handler duduplication issue in `HandlersController`.
- [x] Ensure that `graphql.operation()` also captures subscriptions.
- [x] Ensure `finalize()` fires when the subscription is complete.
- [x] Support typed GraphQL subscriptions (infer types from GQL Code Typegen).
- [x] Add browser tests.
- [x] Add type tests.
- [x] Bug: Multiple `connection` events fire for a single subscription. Must have to do with the transport layering. 
- [x] Check the `Variables` type argument presence on `graphql.subscription()`.