### PR TITLE
fix(cookieStore): do not crash request handling when localStorage quota is exceeded

### DIFF
--- a/src/core/utils/cookieStore.test.ts
+++ b/src/core/utils/cookieStore.test.ts
@@ -29,6 +29,7 @@ afterAll(() => {
 afterEach(() => {
   vi.restoreAllMocks()
   localStorage.clear()
+  cookieStore.reset()
 })
 
 it('does not crash request handling when localStorage quota is exceeded', async () => {
@@ -49,7 +50,9 @@ it('does not crash request handling when localStorage quota is exceeded', async 
 
   // The cookie must remain available in-memory for the current session.
   expect(
-    cookieStore.getCookies(url).map((cookie) => `${cookie.key}=${cookie.value}`),
+    cookieStore
+      .getCookies(url)
+      .map((cookie) => `${cookie.key}=${cookie.value}`),
   ).toEqual(['name=value'])
 
   // A warning must be emitted so the failure is not silent.
@@ -57,9 +60,7 @@ it('does not crash request handling when localStorage quota is exceeded', async 
 })
 
 it('persists cookies to localStorage when the quota is available', async () => {
-  await expect(
-    cookieStore.setCookie('token=abc', url),
-  ).resolves.toBeUndefined()
+  await expect(cookieStore.setCookie('token=abc', url)).resolves.toBeUndefined()
 
   expect(localStorage.getItem('__msw-cookie-store__')).toContain('token')
 })

--- a/src/core/utils/cookieStore.test.ts
+++ b/src/core/utils/cookieStore.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+import { afterAll, afterEach, beforeAll, expect, it, vi } from 'vitest'
+import { cookieStore } from './cookieStore'
+
+const url = 'https://example.com'
+
+function createFakeLocalStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key, value) => void store.set(key, String(value)),
+    removeItem: (key) => void store.delete(key),
+    clear: () => store.clear(),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+  }
+}
+
+beforeAll(() => {
+  Reflect.set(globalThis, 'localStorage', createFakeLocalStorage())
+})
+
+afterAll(() => {
+  Reflect.deleteProperty(globalThis, 'localStorage')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+it('does not crash request handling when localStorage quota is exceeded', async () => {
+  const quotaError = new DOMException(
+    'The quota has been exceeded.',
+    'QuotaExceededError',
+  )
+  vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+    throw quotaError
+  })
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  // Persisting the cookie fails because the storage quota is exceeded,
+  // but that must not throw and crash the request handling pipeline.
+  await expect(
+    cookieStore.setCookie('name=value', url),
+  ).resolves.toBeUndefined()
+
+  // The cookie must remain available in-memory for the current session.
+  expect(
+    cookieStore.getCookies(url).map((cookie) => `${cookie.key}=${cookie.value}`),
+  ).toEqual(['name=value'])
+
+  // A warning must be emitted so the failure is not silent.
+  expect(warnSpy).toHaveBeenCalledTimes(1)
+})
+
+it('persists cookies to localStorage when the quota is available', async () => {
+  await expect(
+    cookieStore.setCookie('token=abc', url),
+  ).resolves.toBeUndefined()
+
+  expect(localStorage.getItem('__msw-cookie-store__')).toContain('token')
+})

--- a/src/core/utils/cookieStore.ts
+++ b/src/core/utils/cookieStore.ts
@@ -88,7 +88,18 @@ class CookieStore {
       }
     }
 
-    localStorage.setItem(this.#storageKey, JSON.stringify(data))
+    try {
+      localStorage.setItem(this.#storageKey, JSON.stringify(data))
+    } catch (error) {
+      // Persisting cookies to `localStorage` can fail (e.g. with a
+      // `QuotaExceededError` when the storage is full). Treat persistence as
+      // best-effort: the cookies remain available in-memory for the current
+      // session, and the failure must not crash the request handling pipeline.
+      console.warn(
+        '[MSW] Failed to persist cookies to "localStorage". Cookies will still work for the current session but will not survive a page reload. This is likely because the storage quota has been exceeded.',
+        error,
+      )
+    }
   }
 }
 

--- a/src/core/utils/cookieStore.ts
+++ b/src/core/utils/cookieStore.ts
@@ -31,6 +31,12 @@ class CookieStore {
     return this.#jar.getCookiesSync(url)
   }
 
+  public reset(): void {
+    this.#memoryStore = new MemoryCookieStore()
+    this.#memoryStore.idx = this.getCookieStoreIndex()
+    this.#jar = new CookieJar(this.#memoryStore)
+  }
+
   public async setCookie(cookieName: string, url: string): Promise<void> {
     await this.#jar.setCookie(cookieName, url)
     this.persist()


### PR DESCRIPTION
## Problem

`CookieStore.persist()` called `localStorage.setItem()` without a try/catch. When the storage quota is exceeded (common in long-running test suites or CI), the thrown `QuotaExceededError` propagated up through `setCookie()` → `storeResponseCookies()` → `handleRequest()`, crashing the entire request handling pipeline for all subsequent requests.

## Fix

Persistence is now best-effort: the `localStorage.setItem()` call is wrapped in a try/catch. Cookies remain available in-memory for the current session, and a warning is logged instead of throwing, so a failed write can no longer crash request handling.

```diff
-    localStorage.setItem(this.#storageKey, JSON.stringify(data))
+    try {
+      localStorage.setItem(this.#storageKey, JSON.stringify(data))
+    } catch (error) {
+      console.warn(
+        '[MSW] Failed to persist cookies to "localStorage" ...',
+        error,
+      )
+    }
```

## Testing

Added tests in `src/core/utils/cookieStore.test.ts` covering the quota-exceeded scenario: persistence failures are caught, a warning is logged, and cookies remain usable in-memory without crashing the request pipeline.

Closes #2750
